### PR TITLE
types: use HexBytes instead of hex strings in a few API fields

### DIFF
--- a/benchmark/api_benchmark_test.go
+++ b/benchmark/api_benchmark_test.go
@@ -14,6 +14,7 @@ import (
 	"go.vocdoni.io/dvote/types"
 
 	"go.vocdoni.io/dvote/test/testcommon"
+	"go.vocdoni.io/dvote/test/testcommon/testutil"
 )
 
 // The init function and flags are shared with the other benchmark files.
@@ -103,7 +104,7 @@ func censusBench(b *testing.B, cl *client.Client) {
 
 	// getSize
 	log.Infof("[%d] get size", rint)
-	req.RootHash = ""
+	req.RootHash = nil
 	resp = doRequest("getSize", nil)
 	if got := *resp.Size; int64(*censusSize) != got {
 		b.Fatalf("expected size %v, got %v", *censusSize, got)
@@ -124,7 +125,7 @@ func censusBench(b *testing.B, cl *client.Client) {
 
 	// GenProof valid
 	log.Infof("[%d] generating proofs", rint)
-	req.RootHash = ""
+	req.RootHash = nil
 	var siblings []string
 
 	for _, cl := range claims {
@@ -139,14 +140,14 @@ func censusBench(b *testing.B, cl *client.Client) {
 	// CheckProof valid
 	log.Infof("[%d] checking proofs", rint)
 	for i, s := range siblings {
-		req.ProofData = s
+		req.ProofData = testutil.Hex2byte(b, s)
 		req.ClaimData = claims[i]
 		resp = doRequest("checkProof", nil)
 		if resp.ValidProof != nil && !*resp.ValidProof {
 			b.Fatalf("proof is invalid but it should be valid")
 		}
 	}
-	req.ProofData = ""
+	req.ProofData = nil
 
 	// publish
 	log.Infof("[%d] publish census", rint)

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -147,7 +147,7 @@ func vtest(host, oraclePrivKey, electionType string, entityKey *ethereum.SignKey
 	var censusKeys []*ethereum.SignKeys
 	var proofs [][]byte
 	var err error
-	censusRoot := ""
+	var censusRoot []byte
 	censusURI := ""
 
 	oracleKey := ethereum.NewSignKeys()
@@ -164,7 +164,7 @@ func vtest(host, oraclePrivKey, electionType string, entityKey *ethereum.SignKey
 			log.Fatal(err)
 		}
 	} else {
-		log.Infof("loaded cache census %s with size %d", censusRoot, len(censusKeys))
+		log.Infof("loaded cache census %x with size %d", censusRoot, len(censusKeys))
 		if len(censusKeys) > electionSize {
 			log.Infof("truncating census from %d to %d", len(censusKeys), electionSize)
 			censusKeys = censusKeys[:electionSize]
@@ -190,9 +190,9 @@ func vtest(host, oraclePrivKey, electionType string, entityKey *ethereum.SignKey
 	defer mainClient.Conn.Close(websocket.StatusNormalClosure, "")
 
 	// Create process
-	pid := client.RandomHex(32)
+	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
-	start, err := mainClient.CreateProcess(oracleKey, entityKey.AddressString(), censusRoot, censusURI, pid, electionType, procDuration)
+	start, err := mainClient.CreateProcess(oracleKey, entityKey.Address().Bytes(), censusRoot, censusURI, pid, electionType, procDuration)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -277,7 +277,7 @@ func vtest(host, oraclePrivKey, electionType string, entityKey *ethereum.SignKey
 		gw, cl := gw, cl
 		go func() {
 			defer wg.Done()
-			if votingTimes[gw], err = cl.TestSendVotes(pid, entityKey.AddressString(), censusRoot, start, gwSigners, gwProofs, encrypted, doubleVote, &proofsReadyWG); err != nil {
+			if votingTimes[gw], err = cl.TestSendVotes(pid, entityKey.Address().Bytes(), censusRoot, start, gwSigners, gwProofs, encrypted, doubleVote, &proofsReadyWG); err != nil {
 				log.Fatalf("[%s] %s", cl.Addr, err)
 			}
 			log.Infof("gateway %d %s has ended its job", gw, cl.Addr)

--- a/types/api.go
+++ b/types/api.go
@@ -24,19 +24,19 @@ type MetaRequest struct {
 	ClaimsData [][]byte `json:"claimsData,omitempty"`
 	Content    string   `json:"content,omitempty"`
 	Digested   bool     `json:"digested,omitempty"`
-	EntityId   string   `json:"entityId,omitempty"`
+	EntityId   HexBytes `json:"entityId,omitempty"`
 	From       int64    `json:"from,omitempty"`
-	FromID     string   `json:"fromId,omitempty"`
+	FromID     HexBytes `json:"fromId,omitempty"`
 	ListSize   int64    `json:"listSize,omitempty"`
 	Method     string   `json:"method"`
 	Name       string   `json:"name,omitempty"`
-	Nullifier  string   `json:"nullifier,omitempty"`
+	Nullifier  HexBytes `json:"nullifier,omitempty"`
 	Payload    []byte   `json:"payload,omitempty"`
-	ProcessID  string   `json:"processId,omitempty"`
-	ProofData  string   `json:"proofData,omitempty"`
+	ProcessID  HexBytes `json:"processId,omitempty"`
+	ProofData  HexBytes `json:"proofData,omitempty"`
 	PubKeys    []string `json:"pubKeys,omitempty"`
-	RootHash   string   `json:"rootHash,omitempty"`
-	Signature  string   `json:"signature,omitempty"`
+	RootHash   HexBytes `json:"rootHash,omitempty"`
+	Signature  HexBytes `json:"signature,omitempty"`
 	Timestamp  int32    `json:"timestamp"`
 	Type       string   `json:"type,omitempty"`
 	URI        string   `json:"uri,omitempty"`
@@ -111,7 +111,7 @@ type MetaResponse struct {
 	Nullifiers           *[]string  `json:"nullifiers,omitempty"`
 	Ok                   bool       `json:"ok"`
 	Paused               *bool      `json:"paused,omitempty"`
-	Payload              string     `json:"payload,omitempty"`
+	Payload              string     `json:"payload,omitempty"` // TODO: sometimes hex, sometimes base64?
 	ProcessIDs           []string   `json:"processIds,omitempty"`
 	ProcessList          []string   `json:"processList,omitempty"`
 	Registered           *bool      `json:"registered,omitempty"`

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// HexBytes is a []byte which encodes as hexadecimal in json, as opposed to the
+// base64 default.
+type HexBytes []byte
+
+func (b HexBytes) MarshalJSON() ([]byte, error) {
+	enc := make([]byte, hex.EncodedLen(len(b))+2)
+	enc[0] = '"'
+	hex.Encode(enc[1:], b)
+	enc[len(enc)-1] = '"'
+	return enc, nil
+}
+
+func (b *HexBytes) UnmarshalJSON(data []byte) error {
+	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+		return fmt.Errorf("invalid JSON string: %q", data)
+	}
+	decLen := hex.DecodedLen(len(data) - 2)
+	if cap(*b) < decLen {
+		*b = make([]byte, decLen)
+	}
+	if _, err := hex.Decode(*b, data[1:len(data)-1]); err != nil {
+		return err
+	}
+	return nil
+}

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -1,0 +1,23 @@
+package types
+
+import "testing"
+
+func TestHexBytes(t *testing.T) {
+	input := HexBytes("hello world")
+
+	encoded, err := input.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `"68656c6c6f20776f726c64"`; string(encoded) != want {
+		t.Fatalf("MarshalJSON got %q, exp %q", encoded, want)
+	}
+
+	var decoded HexBytes
+	if err := decoded.UnmarshalJSON(encoded); err != nil {
+		t.Fatal(err)
+	}
+	if string(decoded) != string(input) {
+		t.Fatalf("UnmarshalJSON got %q, exp %q", decoded, input)
+	}
+}

--- a/types/vochain.go
+++ b/types/vochain.go
@@ -8,7 +8,6 @@ import (
 	// dependencies which are too heavy for our low-level "types" package.
 	// libs/bytes is okay, because it only pulls in std deps.
 
-	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/vocdoni/dvote-protobuf/build/go/models"
 )
 
@@ -84,7 +83,7 @@ type GenesisDoc struct {
 	ChainID         string             `json:"chain_id"`
 	ConsensusParams *ConsensusParams   `json:"consensus_params,omitempty"`
 	Validators      []GenesisValidator `json:"validators,omitempty"`
-	AppHash         tmbytes.HexBytes   `json:"app_hash"`
+	AppHash         HexBytes           `json:"app_hash"`
 	AppState        json.RawMessage    `json:"app_state,omitempty"`
 }
 
@@ -112,7 +111,7 @@ type ValidatorParams struct {
 }
 
 type GenesisValidator struct {
-	Address tmbytes.HexBytes `json:"address"`
+	Address HexBytes         `json:"address"`
 	PubKey  TendermintPubKey `json:"pub_key"`
 	Power   string           `json:"power"`
 	Name    string           `json:"name"`

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -136,7 +136,7 @@ func NewGenesis(cfg *config.VochainCfg, chainID string, consensusParams *types.C
 			return []byte{}, err
 		}
 		appState.Validators[idx] = types.GenesisValidator{
-			Address: val.GetAddress(),
+			Address: val.GetAddress().Bytes(),
 			PubKey:  types.TendermintPubKey{Value: pubk.Bytes(), Type: "tendermint/PubKeyEd25519"},
 			Power:   "10",
 			Name:    strconv.Itoa(rand.Int()),

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -2,7 +2,6 @@ package scrutinizer
 
 import (
 	"bytes"
-	"encoding/hex"
 	"fmt"
 	"sync/atomic"
 
@@ -48,46 +47,30 @@ func (s *Scrutinizer) ProcessList(entityID []byte, fromID []byte, max int64) ([]
 }
 
 // ProcessListWithResults returns the list of process ID with already computed results
-func (s *Scrutinizer) ProcessListWithResults(max int64, fromID string) ([]string, error) {
-	from, err := hex.DecodeString(fromID)
-	if err != nil {
-		return nil, err
-	}
+func (s *Scrutinizer) ProcessListWithResults(max int64, fromID []byte) []string {
 	process := []string{}
-	for _, p := range s.List(max, from, []byte{types.ScrutinizerResultsPrefix}) {
+	for _, p := range s.List(max, fromID, []byte{types.ScrutinizerResultsPrefix}) {
 		process = append(process, fmt.Sprintf("%x", p))
 	}
-	return process, nil
+	return process
 }
 
 // ProcessListWithLiveResults returns the list of process ID which have live results (not encrypted)
-func (s *Scrutinizer) ProcessListWithLiveResults(max int64, fromID string) ([]string, error) {
-	from, err := hex.DecodeString(fromID)
-	if err != nil {
-		return nil, err
-	}
+func (s *Scrutinizer) ProcessListWithLiveResults(max int64, fromID []byte) []string {
 	process := []string{}
-	for _, p := range s.List(max, from, []byte{types.ScrutinizerLiveProcessPrefix}) {
+	for _, p := range s.List(max, fromID, []byte{types.ScrutinizerLiveProcessPrefix}) {
 		process = append(process, fmt.Sprintf("%x", p))
 	}
-	return process, nil
+	return process
 }
 
 // EntityList returns the list of entities indexed by the scrutinizer
-func (s *Scrutinizer) EntityList(max int64, fromID string) ([]string, error) {
-	var err error
-	var from []byte
-	if len(fromID) > 0 {
-		from, err = hex.DecodeString(util.TrimHex(fromID))
-		if err != nil {
-			return nil, err
-		}
-	}
+func (s *Scrutinizer) EntityList(max int64, fromID []byte) []string {
 	entities := []string{}
-	for _, e := range s.List(max, from, []byte{types.ScrutinizerEntityPrefix}) {
+	for _, e := range s.List(max, fromID, []byte{types.ScrutinizerEntityPrefix}) {
 		entities = append(entities, fmt.Sprintf("%x", e))
 	}
-	return entities, nil
+	return entities
 }
 
 // EntityCount return the number of entities indexed by the scrutinizer

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -9,6 +9,7 @@ import (
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/nacl"
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
@@ -42,10 +43,8 @@ func testEntityList(t *testing.T, entityCount int) {
 	}
 	var list []string
 	for len(entities) <= entityCount {
-		list, err = sc.EntityList(10, last)
-		if err != nil {
-			t.Fatal(err)
-		}
+		lastBytes := testutil.Hex2byte(t, last)
+		list = sc.EntityList(10, lastBytes)
 		if len(list) < 1 {
 			t.Log("list is empty")
 			break


### PR DESCRIPTION
This means the json marshal/unmarshal steps will automatically do the
hex encoding/decoding, and we can simply use the []byte data directly.

Removes over 100 lines of boilerplate thanks to the above. More "hex
string" fields remain in the API structs, but they are left alone for
now to keep this refactor smaller.

Note that this should be an entirely backwards compatible change, since
the encoded JSON messages should look exactly the same. Replacing REST
with gRPC is still planned for the future, but this is a clear win we
can get today. Plus, our actual business logic gets clearer.