### PR TITLE
types: turn signatures to HexBytes

### DIFF
--- a/benchmark/vochain_benchmark_test.go
+++ b/benchmark/vochain_benchmark_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -123,13 +122,9 @@ func BenchmarkVochain(b *testing.B) {
 	}
 
 	vtx := models.Tx{}
-	signHex, err := dvoteServer.Signer.Sign(txBytes)
+	vtx.Signature, err = dvoteServer.Signer.Sign(txBytes)
 	if err != nil {
 		b.Fatalf("cannot sign oracle tx: %s", err)
-	}
-	vtx.Signature, err = hex.DecodeString(signHex)
-	if err != nil {
-		b.Fatalf("cannot decode signature")
 	}
 	req.Payload, err = proto.Marshal(&vtx)
 	if err != nil {
@@ -229,11 +224,10 @@ func vochainBench(b *testing.B, cl *client.Client, s *ethereum.SignKeys, poseido
 		b.Fatal(err)
 	}
 
-	signHex, err := s.Sign(req.Payload)
+	req.Signature, err = s.Sign(req.Payload)
 	if err != nil {
 		b.Fatal(err)
 	}
-	req.Signature = testutil.Hex2byte(b, signHex)
 
 	// sending submitEnvelope request
 	log.Info("vote payload: %s", tx.String())

--- a/census/auth.go
+++ b/census/auth.go
@@ -1,12 +1,14 @@
 package census
 
 import (
+	"encoding/hex"
 	"errors"
 	"time"
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/dvote/util"
 )
 
 // CheckAuth check if a census request message is authorized
@@ -49,9 +51,13 @@ func (m *Manager) CheckAuth(reqOuter *types.RequestMessage, reqInner *types.Meta
 			return nil
 		}
 		valid := false
-		for _, n := range ns.Keys {
+		for _, keyHex := range ns.Keys {
 			var err error
-			valid, err = ethereum.Verify(reqOuter.MetaRequest, reqOuter.Signature, n)
+			key, err := hex.DecodeString(util.TrimHex(keyHex))
+			if err != nil {
+				return err
+			}
+			valid, err = ethereum.Verify(reqOuter.MetaRequest, reqOuter.Signature, key)
 			if err != nil {
 				log.Warnf("verification error (%s)", err)
 				valid = false

--- a/chain/ethevents/handlers.go
+++ b/chain/ethevents/handlers.go
@@ -2,7 +2,6 @@ package ethevents
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -90,13 +89,9 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal new process tx: %w", err)
 		}
-		signature, err := e.Signer.Sign(processTxBytes)
+		vtx.Signature, err = e.Signer.Sign(processTxBytes)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
-		}
-		vtx.Signature, err = hex.DecodeString(signature)
-		if err != nil {
-			return fmt.Errorf("cannot decode signature: %w", err)
 		}
 		vtx.Payload = &models.Tx_NewProcess{NewProcess: processTx}
 		txb, err := proto.Marshal(&vtx)
@@ -133,13 +128,9 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal setProcess tx: %w", err)
 		}
-		signature, err := e.Signer.Sign(setStatusTxBytes)
+		vtx.Signature, err = e.Signer.Sign(setStatusTxBytes)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
-		}
-		vtx.Signature, err = hex.DecodeString(signature)
-		if err != nil {
-			return fmt.Errorf("cannot decode signature: %w", err)
 		}
 		vtx.Payload = &models.Tx_SetProcess{SetProcess: setProcessTx}
 		tx, err := proto.Marshal(&vtx)

--- a/client/api.go
+++ b/client/api.go
@@ -293,12 +293,7 @@ func (c *Client) TestSendVotes(pid, eid, root []byte, startBlock uint32, signers
 			return 0, err
 		}
 		vtx := models.Tx{Payload: &models.Tx_Vote{Vote: v}}
-		signHex := ""
-		if signHex, err = s.Sign(txBytes); err != nil {
-			return 0, err
-		}
-		vtx.Signature, err = hex.DecodeString(signHex)
-		if err != nil {
+		if vtx.Signature, err = s.Sign(txBytes); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(&vtx); err != nil {
@@ -410,12 +405,7 @@ func (c *Client) CreateProcess(oracle *ethereum.SignKeys, entityID, mkroot []byt
 		return 0, err
 	}
 	vtx := models.Tx{Payload: &models.Tx_NewProcess{NewProcess: p}}
-	signHex := ""
-	if signHex, err = oracle.Sign(txBytes); err != nil {
-		return 0, err
-	}
-	vtx.Signature, err = hex.DecodeString(signHex)
-	if err != nil {
+	if vtx.Signature, err = oracle.Sign(txBytes); err != nil {
 		return 0, err
 	}
 	if req.Payload, err = proto.Marshal(&vtx); err != nil {
@@ -445,12 +435,7 @@ func (c *Client) CancelProcess(oracle *ethereum.SignKeys, pid []byte) error {
 		return err
 	}
 	vtx := models.Tx{Payload: &models.Tx_CancelProcess{CancelProcess: p}}
-	signHex := ""
-	if signHex, err = oracle.Sign(txBytes); err != nil {
-		return err
-	}
-	vtx.Signature, err = hex.DecodeString(signHex)
-	if err != nil {
+	if vtx.Signature, err = oracle.Sign(txBytes); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(&vtx); err != nil {

--- a/client/connection.go
+++ b/client/connection.go
@@ -42,7 +42,7 @@ func (c *Client) Request(req types.MetaRequest, signer *ethereum.SignKeys) (*typ
 	if err != nil {
 		return nil, fmt.Errorf("%s: %v", method, err)
 	}
-	var signature string
+	var signature []byte
 	if signer != nil {
 		signature, err = signer.Sign(reqInner)
 		if err != nil {
@@ -80,7 +80,7 @@ func (c *Client) Request(req types.MetaRequest, signer *ethereum.SignKeys) (*typ
 	if respOuter.ID != reqOuter.ID {
 		return nil, fmt.Errorf("%s: %v", method, "request ID doesn'tb match")
 	}
-	if respOuter.Signature == "" {
+	if len(respOuter.Signature) == 0 {
 		return nil, fmt.Errorf("%s: empty signature in response: %s", method, message)
 	}
 	var respInner types.MetaResponse

--- a/crypto/ethereum/ethereum_test.go
+++ b/crypto/ethereum/ethereum_test.go
@@ -1,7 +1,10 @@
 package ethereum
 
 import (
+	"bytes"
 	"testing"
+
+	"go.vocdoni.io/dvote/test/testcommon/testutil"
 )
 
 func TestSignature(t *testing.T) {
@@ -38,7 +41,7 @@ func TestSignature(t *testing.T) {
 
 	t.Log("Testing compatibility with standard Ethereum signing libraries")
 	hardcodedPriv := "fad9c8855b740a0b7ed4c221dbad0f33a83a49cad6b3fe8d5817ac83d38b6a19"
-	hardcodedSignature := "a0d0ebc374d2a4d6357eaca3da2f5f3ff547c3560008206bc234f9032a866ace6279ffb4093fb39c8bbc39021f6a5c36ef0e813c8c94f325a53f4f395a5c82de01"
+	hardcodedSignature := testutil.Hex2byte(t, "a0d0ebc374d2a4d6357eaca3da2f5f3ff547c3560008206bc234f9032a866ace6279ffb4093fb39c8bbc39021f6a5c36ef0e813c8c94f325a53f4f395a5c82de01")
 	s3 := NewSignKeys()
 	if err := s3.AddHexKey(hardcodedPriv); err != nil {
 		t.Fatal(err)
@@ -52,7 +55,7 @@ func TestSignature(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("Signature: %s", signature)
-	if signature != hardcodedSignature {
+	if !bytes.Equal(signature, hardcodedSignature) {
 		t.Fatalf("Hardcoded signature %s do not match", hardcodedSignature)
 	}
 }

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -2,7 +2,6 @@ package testcommon
 
 import (
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -130,12 +129,11 @@ func SignAndPrepareTx(vtx *models.Tx) error {
 	if err != nil {
 		return err
 	}
-	hexsign, err := signer.Sign(txb)
+	vtx.Signature, err = signer.Sign(txb)
 	if err != nil {
 		return err
 	}
-	vtx.Signature, err = hex.DecodeString(hexsign)
-	return err
+	return nil
 }
 
 func NewVochainStateWithOracles(tb testing.TB) *vochain.State {

--- a/types/api.go
+++ b/types/api.go
@@ -11,8 +11,8 @@ import (
 type RequestMessage struct {
 	MetaRequest json.RawMessage `json:"request"`
 
-	ID        string `json:"id"`
-	Signature string `json:"signature"`
+	ID        string   `json:"id"`
+	Signature HexBytes `json:"signature"`
 }
 
 // MetaRequest contains all of the possible request fields.
@@ -81,8 +81,8 @@ func (r MetaRequest) String() string {
 type ResponseMessage struct {
 	MetaResponse json.RawMessage `json:"response"`
 
-	ID        string `json:"id"`
-	Signature string `json:"signature"`
+	ID        string   `json:"id"`
+	Signature HexBytes `json:"signature"`
 }
 
 // MetaResponse contains all of the possible request fields.

--- a/types/vochain.go
+++ b/types/vochain.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"encoding/json"
-	"go.vocdoni.io/proto/build/go/models"
 	"time"
+
+	"go.vocdoni.io/proto/build/go/models"
 )
 
 // ________________________ STATE ________________________

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -100,13 +100,8 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication, nvoters int) (voter
 		if err != nil {
 			b.Fatal(err)
 		}
-		signHex := ""
-		if signHex, err = s.Sign(txBytes); err != nil {
-			b.Fatal(err)
-		}
 		vtx := models.Tx{}
-		vtx.Signature, err = hex.DecodeString(signHex)
-		if err != nil {
+		if vtx.Signature, err = s.Sign(txBytes); err != nil {
 			b.Fatal(err)
 		}
 		vtx.Payload = &models.Tx_Vote{Vote: tx}

--- a/vochain/app_test.go
+++ b/vochain/app_test.go
@@ -10,7 +10,6 @@ import (
 	tree "go.vocdoni.io/dvote/censustree/gravitontree"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/snarks"
-	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -69,7 +68,6 @@ func TestCheckTX(t *testing.T) {
 
 	var vtx models.Tx
 	var proof []byte
-	var hexsignature string
 	vp := []byte("[1,2,3,4]")
 	for i, s := range keys {
 		proof, err = tr.GenProof([]byte(claims[i]), nil)
@@ -86,11 +84,10 @@ func TestCheckTX(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if hexsignature, err = s.Sign(txBytes); err != nil {
+		if vtx.Signature, err = s.Sign(txBytes); err != nil {
 			t.Fatal(err)
 		}
 		vtx.Payload = &models.Tx_Vote{Vote: tx}
-		vtx.Signature = testutil.Hex2byte(t, hexsignature)
 
 		if cktx.Tx, err = proto.Marshal(&vtx); err != nil {
 			t.Fatal(err)
@@ -263,7 +260,6 @@ func testSetProcess(t *testing.T, pid []byte, oracle *ethereum.SignKeys, app *Ba
 	var cktxresp abcitypes.ResponseCheckTx
 	var detxresp abcitypes.ResponseDeliverTx
 	var vtx models.Tx
-	var hexsignature string
 
 	tx := &models.SetProcessTx{
 		Txtype:    models.TxType_SET_PROCESS_STATUS,
@@ -276,11 +272,10 @@ func testSetProcess(t *testing.T, pid []byte, oracle *ethereum.SignKeys, app *Ba
 		t.Fatal(err)
 	}
 
-	if hexsignature, err = oracle.Sign(txBytes); err != nil {
+	if vtx.Signature, err = oracle.Sign(txBytes); err != nil {
 		t.Fatal(err)
 	}
 	vtx.Payload = &models.Tx_SetProcess{SetProcess: tx}
-	vtx.Signature = testutil.Hex2byte(t, hexsignature)
 
 	if cktx.Tx, err = proto.Marshal(&vtx); err != nil {
 		t.Fatal(err)

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -61,12 +61,12 @@ func checkMerkleProof(proof *models.Proof, censusOrigin models.CensusOrigin, cen
 }
 
 // VerifySignatureAgainstOracles verifies that a signature match with one of the oracles
-func verifySignatureAgainstOracles(oracles []ethcommon.Address, message []byte, signHex string) (bool, ethcommon.Address, error) {
+func verifySignatureAgainstOracles(oracles []ethcommon.Address, message, signature []byte) (bool, ethcommon.Address, error) {
 	signKeys := ethereum.NewSignKeys()
 	for _, oracle := range oracles {
 		signKeys.AddAuthKey(oracle)
 	}
-	return signKeys.VerifySender(message, signHex)
+	return signKeys.VerifySender(message, signature)
 }
 
 // GenerateNullifier generates the nullifier of a vote (hash(address+processId))

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -1,7 +1,6 @@
 package keykeeper
 
 import (
-	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -490,15 +489,9 @@ func (k *KeyKeeper) signAndSendTx(tx *models.AdminTx) error {
 		return err
 	}
 	vtx := models.Tx{Payload: &models.Tx_Admin{Admin: tx}}
-	var signHex string
-	if signHex, err = k.signer.Sign(txBytes); err != nil {
+	if vtx.Signature, err = k.signer.Sign(txBytes); err != nil {
 		return err
 	}
-	signature, err := hex.DecodeString(signHex)
-	if err != nil {
-		return err
-	}
-	vtx.Signature = signature
 	vtxBytes, err := proto.Marshal(&vtx)
 	if err != nil {
 		return err

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -207,7 +207,7 @@ func NewProcessTxCheck(vtx *models.Tx, state *State) (*models.Process, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal new process transaction")
 	}
-	authorized, addr, err := verifySignatureAgainstOracles(oracles, signedBytes, fmt.Sprintf("%x", vtx.Signature))
+	authorized, addr, err := verifySignatureAgainstOracles(oracles, signedBytes, vtx.Signature)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func CancelProcessTxCheck(vtx *models.Tx, state *State) error { // LEGACY
 	if err != nil {
 		return fmt.Errorf("cannot marshal new process transaction")
 	}
-	authorized, addr, err := verifySignatureAgainstOracles(oracles, signedBytes, fmt.Sprintf("%x", vtx.Signature))
+	authorized, addr, err := verifySignatureAgainstOracles(oracles, signedBytes, vtx.Signature)
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func SetProcessTxCheck(vtx *models.Tx, state *State) error {
 	if err != nil {
 		return fmt.Errorf("cannot marshal new process transaction")
 	}
-	authorized, addr, err := verifySignatureAgainstOracles(oracles, signedBytes, fmt.Sprintf("%x", vtx.Signature))
+	authorized, addr, err := verifySignatureAgainstOracles(oracles, signedBytes, vtx.Signature)
 	if err != nil {
 		return err
 	}

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -110,12 +110,10 @@ func testSendVotes(t *testing.T, s testStorageProof, pid []byte, vp []byte, app 
 	if !found {
 		t.Fatalf("signer for address %s not found", s.Address)
 	}
-	hexsignature := ""
-	if hexsignature, err = signer.Sign(txBytes); err != nil {
+	if vtx.Signature, err = signer.Sign(txBytes); err != nil {
 		t.Fatal(err)
 	}
 	vtx.Payload = &models.Tx_Vote{Vote: tx}
-	vtx.Signature = testutil.Hex2byte(t, hexsignature)
 
 	if cktx.Tx, err = proto.Marshal(&vtx); err != nil {
 		t.Fatal(err)

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -186,7 +186,7 @@ func VoteTxCheck(vtx *models.Tx, state *State, txID [32]byte, forCommit bool) (*
 				if err != nil {
 					return nil, fmt.Errorf("cannot marshal vote transaction: %w", err)
 				}
-				pubk, err := ethereum.PubKeyFromSignature(signedBytes, fmt.Sprintf("%x", vtx.Signature))
+				pubk, err := ethereum.PubKeyFromSignature(signedBytes, vtx.Signature)
 				if err != nil {
 					return nil, fmt.Errorf("cannot extract public key from signature: (%w)", err)
 				}
@@ -266,7 +266,7 @@ func AdminTxCheck(vtx *models.Tx, state *State) error {
 		return fmt.Errorf("cannot marshal new process transaction")
 	}
 
-	if authorized, addr, err := verifySignatureAgainstOracles(oracles, signedBytes, fmt.Sprintf("%x", vtx.Signature)); err != nil {
+	if authorized, addr, err := verifySignatureAgainstOracles(oracles, signedBytes, vtx.Signature); err != nil {
 		return err
 	} else if !authorized {
 		return fmt.Errorf("unauthorized to perform an adminTx, address: %s", addr.Hex())


### PR DESCRIPTION
Makes code more intuitive, and removes over fifty lines of boilerplate.

Also changed the code that directly interacted with signatures. For
example, crypto/ethereum's Go APIs no longer use hex-encoded string
parameters for signatures.