### PR TITLE
types: convert Content to []byte, Root/Siblings to HexBytes

### DIFF
--- a/benchmark/api_benchmark_test.go
+++ b/benchmark/api_benchmark_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"encoding/base64"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -14,7 +13,6 @@ import (
 	"go.vocdoni.io/dvote/types"
 
 	"go.vocdoni.io/dvote/test/testcommon"
-	"go.vocdoni.io/dvote/test/testcommon/testutil"
 )
 
 // The init function and flags are shared with the other benchmark files.
@@ -126,7 +124,7 @@ func censusBench(b *testing.B, cl *client.Client) {
 	// GenProof valid
 	log.Infof("[%d] generating proofs", rint)
 	req.RootHash = nil
-	var siblings []string
+	var siblings [][]byte
 
 	for _, cl := range claims {
 		req.ClaimData = cl
@@ -139,8 +137,8 @@ func censusBench(b *testing.B, cl *client.Client) {
 
 	// CheckProof valid
 	log.Infof("[%d] checking proofs", rint)
-	for i, s := range siblings {
-		req.ProofData = testutil.Hex2byte(b, s)
+	for i, sibl := range siblings {
+		req.ProofData = sibl
 		req.ClaimData = claims[i]
 		resp = doRequest("checkProof", nil)
 		if resp.ValidProof != nil && !*resp.ValidProof {
@@ -168,8 +166,7 @@ func censusBench(b *testing.B, cl *client.Client) {
 	var uris []string
 	for i := 0; i < 100; i++ {
 		req.Name = fmt.Sprintf("%d_%d", rint, i)
-		req.Content = base64.StdEncoding.EncodeToString([]byte(
-			fmt.Sprintf("%d0123456789abcdef0123456789abc%d", rint, i)))
+		req.Content = []byte(fmt.Sprintf("%d0123456789abcdef0123456789abc%d", rint, i))
 		resp = doRequest("addFile", nil)
 		if len(resp.URI) < 1 {
 			b.Fatalf("%s wrong URI received", req.Method)

--- a/benchmark/vochain_benchmark_test.go
+++ b/benchmark/vochain_benchmark_test.go
@@ -91,7 +91,7 @@ func BenchmarkVochain(b *testing.B) {
 	// get census root
 	log.Infof("get root")
 	resp = doRequest("getRoot", nil)
-	mkRoot := testutil.Hex2byte(b, resp.Root)
+	mkRoot := resp.Root
 	if len(mkRoot) < 1 {
 		b.Fatalf("got invalid root")
 	}
@@ -195,7 +195,8 @@ func vochainBench(b *testing.B, cl *client.Client, s *ethereum.SignKeys, poseido
 	req.RootHash = mkRoot
 	req.ClaimData = poseidon
 	resp := doRequest("genProof", nil)
-	if len(resp.Siblings) == 0 {
+	siblings := resp.Siblings
+	if len(siblings) == 0 {
 		b.Fatalf("proof not generated while it should be generated correctly")
 	}
 
@@ -210,7 +211,6 @@ func vochainBench(b *testing.B, cl *client.Client, s *ethereum.SignKeys, poseido
 		b.Fatalf("cannot marshal vote: %s", err)
 	}
 	// Generate VoteEnvelope package
-	siblings := testutil.Hex2byte(b, resp.Siblings)
 	tx := models.VoteEnvelope{
 		Nonce:       util.RandomBytes(32),
 		ProcessId:   processID,

--- a/test/census_test.go
+++ b/test/census_test.go
@@ -45,7 +45,6 @@ import (
 	"go.vocdoni.io/dvote/types"
 
 	"go.vocdoni.io/dvote/test/testcommon"
-	"go.vocdoni.io/dvote/test/testcommon/testutil"
 )
 
 var censusSize = flag.Int("censusSize", 100, "number of claims to add in the census")
@@ -125,7 +124,7 @@ func TestCensus(t *testing.T) {
 
 	// getRoot
 	resp = doRequest("getRoot", nil)
-	root := testutil.Hex2byte(t, resp.Root)
+	root := resp.Root
 	if len(root) < 1 {
 		t.Fatalf("got invalid root")
 	}
@@ -181,7 +180,7 @@ func TestCensus(t *testing.T) {
 	req.RootHash = nil
 	req.ClaimData = claims[1]
 	resp = doRequest("genProof", nil)
-	siblings := testutil.Hex2byte(t, resp.Siblings)
+	siblings := resp.Siblings
 	if len(siblings) == 0 {
 		t.Fatalf("proof not generated while it should be generated correctly")
 	}
@@ -215,7 +214,7 @@ func TestCensus(t *testing.T) {
 
 	// getRoot
 	resp = doRequest("getRoot", nil)
-	root = testutil.Hex2byte(t, resp.Root)
+	root = resp.Root
 	if len(root) < 1 {
 		t.Fatalf("got invalid root")
 	}
@@ -226,7 +225,7 @@ func TestCensus(t *testing.T) {
 	if !resp.Ok {
 		t.Fatalf("%s failed", req.Method)
 	}
-	if hex.EncodeToString(root) != resp.Root {
+	if !bytes.Equal(root, resp.Root) {
 		t.Fatalf("got invalid root from published census")
 	}
 
@@ -247,7 +246,7 @@ func TestCensus(t *testing.T) {
 
 	// getRoot
 	resp = doRequest("getRoot", nil)
-	if hex.EncodeToString(root) != resp.Root {
+	if !bytes.Equal(root, resp.Root) {
 		t.Fatalf("root is different after importing! %s != %s", root, resp.Root)
 	}
 

--- a/types/api.go
+++ b/types/api.go
@@ -22,7 +22,7 @@ type MetaRequest struct {
 	CensusURI  string   `json:"censusUri,omitempty"`
 	ClaimData  []byte   `json:"claimData,omitempty"`
 	ClaimsData [][]byte `json:"claimsData,omitempty"`
-	Content    string   `json:"content,omitempty"`
+	Content    []byte   `json:"content,omitempty"`
 	Digested   bool     `json:"digested,omitempty"`
 	EntityId   HexBytes `json:"entityId,omitempty"`
 	From       int64    `json:"from,omitempty"`
@@ -96,7 +96,7 @@ type MetaResponse struct {
 	CensusList           []string   `json:"censusList,omitempty"`
 	ClaimsData           [][]byte   `json:"claimsData,omitempty"`
 	CommitmentKeys       []Key      `json:"commitmentKeys,omitempty"`
-	Content              string     `json:"content,omitempty"`
+	Content              []byte     `json:"content,omitempty"`
 	EncryptionPrivKeys   []Key      `json:"encryptionPrivKeys,omitempty"`
 	EncryptionPublicKeys []Key      `json:"encryptionPubKeys,omitempty"`
 	EntityID             string     `json:"entityId,omitempty"`
@@ -111,15 +111,15 @@ type MetaResponse struct {
 	Nullifiers           *[]string  `json:"nullifiers,omitempty"`
 	Ok                   bool       `json:"ok"`
 	Paused               *bool      `json:"paused,omitempty"`
-	Payload              string     `json:"payload,omitempty"` // TODO: sometimes hex, sometimes base64?
+	Payload              string     `json:"payload,omitempty"` // TODO(mvdan): sometimes hex, sometimes base64?
 	ProcessIDs           []string   `json:"processIds,omitempty"`
 	ProcessList          []string   `json:"processList,omitempty"`
 	Registered           *bool      `json:"registered,omitempty"`
 	Request              string     `json:"request"`
 	Results              [][]uint32 `json:"results,omitempty"`
 	RevealKeys           []Key      `json:"revealKeys,omitempty"`
-	Root                 string     `json:"root,omitempty"`
-	Siblings             string     `json:"siblings,omitempty"`
+	Root                 HexBytes   `json:"root,omitempty"`
+	Siblings             HexBytes   `json:"siblings,omitempty"`
 	Size                 *int64     `json:"size,omitempty"`
 	State                string     `json:"state,omitempty"`
 	Timestamp            int32      `json:"timestamp"`


### PR DESCRIPTION
Content was a base64-encoded string. Since encoding/json already encodes
[]byte as base64 inside JSON strings, we can get that for free by just
using []byte.

The Root and Siblings fields are just hashes, and we were manually
encoding them as hexadecimal strings. Use HexBytes for that.