### PR TITLE
types: allow 0x prefixes when decoding HexBytes

### DIFF
--- a/types/encoding.go
+++ b/types/encoding.go
@@ -21,11 +21,18 @@ func (b *HexBytes) UnmarshalJSON(data []byte) error {
 	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 		return fmt.Errorf("invalid JSON string: %q", data)
 	}
-	decLen := hex.DecodedLen(len(data) - 2)
+	data = data[1 : len(data)-1]
+
+	// Strip a leading "0x" prefix, for backwards compatibility.
+	if len(data) >= 2 && data[0] == '0' && (data[1] == 'x' || data[1] == 'X') {
+		data = data[2:]
+	}
+
+	decLen := hex.DecodedLen(len(data))
 	if cap(*b) < decLen {
 		*b = make([]byte, decLen)
 	}
-	if _, err := hex.Decode(*b, data[1:len(data)-1]); err != nil {
+	if _, err := hex.Decode(*b, data); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This is for backwards compatibility with some fields which regularly
used 0x prefixes, like EntityId. Should fix breakages encountered by
frontends.