### PR TITLE
.github: skip compose-test on forks too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   go-tests:
     runs-on: self-hosted
-    if:  github.repository == 'vocdoni/go-dvote'
+    if: github.repository == 'vocdoni/go-dvote'
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -33,6 +33,7 @@ jobs:
 
   compose-test:
     runs-on: self-hosted
+    if: github.repository == 'vocdoni/go-dvote'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
A recent commit skipped go-tests on forks since those can't run jobs on
our significantly faster runner. Do the same for compose-test, which
still fails on forks, causing confusion.