### PR TITLE
remove some now unnecessary helper funcs

### DIFF
--- a/test/testcommon/testutil/util.go
+++ b/test/testcommon/testutil/util.go
@@ -19,24 +19,6 @@ func Hex2byte(tb testing.TB, s string) []byte {
 	return b
 }
 
-func Hex2byte32(tb testing.TB, s string) [32]byte {
-	b, err := hex.DecodeString(util.TrimHex(s))
-	if err != nil {
-		if tb == nil {
-			panic(err)
-		}
-		tb.Fatal(err)
-	}
-	var b32 [32]byte
-	copy(b32[:], b)
-	return b32
-}
-
-func Hex2byte32ptr(tb testing.TB, s string) *[32]byte {
-	b := Hex2byte32(tb, s)
-	return &b
-}
-
 func B642byte(tb testing.TB, s string) []byte {
 	b, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {

--- a/test/vochain_test.go
+++ b/test/vochain_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"go.vocdoni.io/dvote/test/testcommon"
-	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -27,13 +26,13 @@ func TestCreateProcess(t *testing.T) {
 	}
 
 	// add process
-	_, err = vochain.AddTx(&vtx, s, testutil.Hex2byte32(t, util.RandomHex(32)), true)
+	_, err = vochain.AddTx(&vtx, s, util.Random32(), true)
 	if err != nil {
 		t.Errorf("cannot create process: %s", err)
 	}
 
 	// cannot add same process
-	if _, err = vochain.AddTx(&vtx, s, testutil.Hex2byte32(t, util.RandomHex(32)), true); err == nil {
+	if _, err = vochain.AddTx(&vtx, s, util.Random32(), true); err == nil {
 		t.Errorf("same process added: %s", err)
 	}
 
@@ -41,7 +40,7 @@ func TestCreateProcess(t *testing.T) {
 	vtx.Signature[12] = byte(0xFF)
 	vtx.Signature[14] = byte(0xFF)
 	vtx.Signature[16] = byte(0xFF)
-	if _, err = vochain.AddTx(&vtx, s, testutil.Hex2byte32(t, util.RandomHex(32)), true); err == nil {
+	if _, err = vochain.AddTx(&vtx, s, util.Random32(), true); err == nil {
 		t.Errorf("process added by non oracle: %s", err)
 	}
 }

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -1,34 +1,11 @@
 package util
 
 import (
-	"encoding/hex"
 	"fmt"
 	"io"
 	"math/rand"
-	"regexp"
-	"strconv"
 	"time"
 )
-
-var validHexRegex = regexp.MustCompile("^([0-9a-fA-F])+$")
-
-// IsHex checks if the given string contains only valid hex symbols
-func IsHex(str string) bool { return validHexRegex.MatchString(str) }
-
-// IsHexEncodedStringWithLength checks if the given string contains only valid hex symbols and have the desired length
-func IsHexEncodedStringWithLength(str string, length int) bool {
-	str = TrimHex(str)
-	return hex.DecodedLen(len(str)) == length && IsHex(str)
-}
-
-func Hex2int64(s string) int64 {
-	// base 16 for hexadecimal
-	result, err := strconv.ParseUint(TrimHex(s), 16, 64)
-	if err != nil {
-		panic(err)
-	}
-	return int64(result)
-}
 
 func TrimHex(s string) string {
 	if len(s) >= 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X') {
@@ -42,6 +19,14 @@ var randReader = rand.New(rand.NewSource(time.Now().UnixNano()))
 func RandomBytes(n int) []byte {
 	bytes := make([]byte, n)
 	if _, err := io.ReadFull(randReader, bytes); err != nil {
+		panic(err)
+	}
+	return bytes
+}
+
+func Random32() [32]byte {
+	var bytes [32]byte
+	if _, err := io.ReadFull(randReader, bytes[:]); err != nil {
 		panic(err)
 	}
 	return bytes


### PR DESCRIPTION
The IsHex funcs are no longer necessary, because the API endpoints
already receive hex-decoded bytes.

The testutil funcs to convert hex strings to [32]byte can be replaced by
a single Random32 util func, which is simpler to use too.