### PR TITLE
Avoid ethereum lookup on results processing

### DIFF
--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -85,7 +85,7 @@ func censusGenerate(host string, signer *ethereum.SignKeys, size int, filepath s
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("census created and published\nRoot: %s\nURI: %s", root, uri)
+	log.Infof("census created and published\nRoot: %x\nURI: %s", root, uri)
 	proofs, err := cl.GetProofBatch(keys, root, false)
 	if err != nil {
 		log.Fatal(err)
@@ -197,7 +197,7 @@ func vtest(host, oraclePrivKey, electionType string, entityKey *ethereum.SignKey
 		log.Fatal(err)
 	}
 
-	log.Infof("created process with ID: %s", pid)
+	log.Infof("created process with ID: %x", pid)
 	encrypted := false
 	switch electionType {
 	case "encrypted-poll":

--- a/vochain/scrutinizer/vote.go
+++ b/vochain/scrutinizer/vote.go
@@ -123,10 +123,13 @@ func (s *Scrutinizer) ComputeResult(processID []byte) error {
 		}
 	}
 
-	for _, l := range s.eventListeners {
-		pv.EntityId = p.EntityId
-		pv.ProcessId = p.ProcessId
-		l.OnComputeResults(pv)
+	// add results if process is not live or isLive and status is ended
+	if !isLive || (isLive && p.Status == models.ProcessStatus_ENDED) {
+		for _, l := range s.eventListeners {
+			pv.EntityId = p.EntityId
+			pv.ProcessId = p.ProcessId
+			l.OnComputeResults(pv)
+		}
 	}
 
 	result, err := proto.Marshal(pv)

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -319,7 +319,7 @@ func AdminTxCheck(vtx *models.Tx, state *State) error {
 				return fmt.Errorf("cannot add process keys in a canceled process")
 			}
 			if len(process.EncryptionPublicKeys[*tx.KeyIndex])+len(process.CommitmentKeys[*tx.KeyIndex]) > 0 {
-				return fmt.Errorf("keys for process %s already revealed", tx.ProcessId)
+				return fmt.Errorf("keys for process %x already revealed", tx.ProcessId)
 			}
 			// check included keys and keyindex are valid
 			if err := checkAddProcessKeys(tx, process); err != nil {
@@ -335,7 +335,7 @@ func AdminTxCheck(vtx *models.Tx, state *State) error {
 				return fmt.Errorf("cannot reveal keys before the process is finished")
 			}
 			if len(process.EncryptionPrivateKeys[*tx.KeyIndex])+len(process.RevealKeys[*tx.KeyIndex]) > 0 {
-				return fmt.Errorf("keys for process %s already revealed", tx.ProcessId)
+				return fmt.Errorf("keys for process %x already revealed", tx.ProcessId)
 			}
 			// check the keys are valid
 			if err := checkRevealProcessKeys(tx, process); err != nil {


### PR DESCRIPTION
Avoid sending results tx's on each commit when live processes.

Also fixed some prints.