### PR TITLE
remove unnecessary type conversions

### DIFF
--- a/benchmark/api_benchmark_test.go
+++ b/benchmark/api_benchmark_test.go
@@ -97,7 +97,7 @@ func censusBench(b *testing.B, cl *client.Client) {
 		req.ClaimsData = iclaims
 		doRequest("addClaimBulk", signer)
 		i++
-		log.Infof("census creation progress: %d%%", int((i*100*100)/(*censusSize)))
+		log.Infof("census creation progress: %d%%", (i*100*100)/(*censusSize))
 	}
 
 	// getSize

--- a/benchmark/vochain_benchmark_test.go
+++ b/benchmark/vochain_benchmark_test.go
@@ -108,7 +108,7 @@ func BenchmarkVochain(b *testing.B) {
 		BlockCount:   numberOfBlocks,
 		ProcessId:    processID,
 		ProcessType:  types.PollVote,
-		StartBlock:   uint32(*resp.Height + 1),
+		StartBlock:   *resp.Height + 1,
 	}
 	process := &models.NewProcessTx{
 		Txtype:  models.TxType_NEW_PROCESS,

--- a/chain/ethevents/events.go
+++ b/chain/ethevents/events.go
@@ -130,9 +130,8 @@ func NewEthEvents(contractsAddresses []common.Address, signer *ethereum.SignKeys
 		VochainApp:       vocapp,
 		EventProcessor: &EventProcessor{
 			Events:                make(chan ethtypes.Log),
-			EventProcessThreshold: time.Duration(60 * time.Second),
+			EventProcessThreshold: 60 * time.Second,
 			eventQueue:            make(map[string]*logEvent),
-			eventProcessorRunning: false,
 		},
 	}
 
@@ -154,13 +153,14 @@ func (ev *EthereumEvents) OnComputeResults(results *models.ProcessResult) {
 		log.Errorf("error fetching process %x from the Vochain: %s", results.ProcessId, err)
 		return
 	}
-	if models.ProcessStatus(vocProcessData.Status) == models.ProcessStatus_RESULTS {
+	switch vocProcessData.Status {
+	case models.ProcessStatus_RESULTS:
 		// check vochain process results
 		if len(vocProcessData.Results.Votes) > 0 {
 			log.Infof("process %x results already added on the Vochain, skipping", results.ProcessId)
 			return
 		}
-	} else if models.ProcessStatus(vocProcessData.Status) != models.ProcessStatus_ENDED {
+	case models.ProcessStatus_ENDED:
 		log.Infof("invalid process %x status %s for setting the results, skipping", results.ProcessId, vocProcessData.Status)
 		return
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -216,7 +216,7 @@ func (c *Client) GetProofBatch(signers []*ethereum.SignKeys, root []byte, tolera
 		}
 		proofs = append(proofs, proof)
 		if (i+1)%100 == 0 {
-			log.Infof("proof generation progress for %s: %d%%", c.Addr, int(((i+1)*100)/(len(signers))))
+			log.Infof("proof generation progress for %s: %d%%", c.Addr, ((i+1)*100)/(len(signers)))
 		}
 	}
 	return proofs, nil
@@ -310,7 +310,7 @@ func (c *Client) TestSendVotes(pid, eid, root []byte, startBlock uint32, signers
 		}
 		nullifiers = append(nullifiers, resp.Payload)
 		if (i+1)%100 == 0 {
-			log.Infof("voting progress for %s: %d%%", c.Addr, int(((i+1)*100)/(len(signers))))
+			log.Infof("voting progress for %s: %d%%", c.Addr, ((i+1)*100)/(len(signers)))
 		}
 
 		//Try double voting (should fail)
@@ -383,7 +383,7 @@ func (c *Client) CreateProcess(oracle *ethereum.SignKeys, entityID, mkroot []byt
 		BlockCount:   uint32(duration),
 		ProcessId:    pid,
 		ProcessType:  ptype,
-		StartBlock:   uint32(block + 4),
+		StartBlock:   block + 4,
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: ptype == "encrypted-poll"},
 		Mode:         &models.ProcessMode{AutoStart: true, Interruptible: true},
 		Status:       models.ProcessStatus_READY,
@@ -556,7 +556,7 @@ func (c *Client) CreateCensus(signer *ethereum.SignKeys, censusSigners []*ethere
 			return nil, "", fmt.Errorf("%s failed: %s", req.Method, resp.Message)
 		}
 		i++
-		log.Infof("census creation progress: %d%%", int((i*100*100)/(censusSize)))
+		log.Infof("census creation progress: %d%%", (i*100*100)/(censusSize))
 	}
 
 	// getSize

--- a/cmd/ipfsSync/ipfsSync.go
+++ b/cmd/ipfsSync/ipfsSync.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -65,7 +64,7 @@ func main() {
 			}
 		} else {
 			log.Info("loaded saved node private key")
-			if err := sk.AddHexKey(fmt.Sprintf("%s", pk)); err != nil {
+			if err := sk.AddHexKey(string(pk)); err != nil {
 				log.Fatal(err)
 			}
 			_, privKey = sk.HexString()

--- a/net/websocket.go
+++ b/net/websocket.go
@@ -2,7 +2,6 @@ package net
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -153,7 +152,7 @@ func somaxconn() int {
 	if err != nil {
 		return syscall.SOMAXCONN
 	}
-	n, err := strconv.Atoi(strings.Trim(fmt.Sprintf("%s", content), "\n"))
+	n, err := strconv.Atoi(strings.Trim(string(content), "\n"))
 	if err != nil {
 		return syscall.SOMAXCONN
 	}

--- a/subpub/subpub.go
+++ b/subpub/subpub.go
@@ -116,7 +116,7 @@ func (ps *SubPub) Start(ctx context.Context) {
 		c.PSK = ps.GroupKey[:32]
 	}
 	c.ListenAddrs = []multiaddr.Multiaddr{sourceMultiAddr}
-	c.ConnManager = connmanager.NewConnManager(int(ps.MaxDHTpeers/2), ps.MaxDHTpeers, time.Second*10)
+	c.ConnManager = connmanager.NewConnManager(ps.MaxDHTpeers/2, ps.MaxDHTpeers, time.Second*10)
 
 	log.Debugf("libp2p config: %+v", c)
 	// Note that we don't use ctx here, since we stop via the Close method.

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -380,7 +380,7 @@ func (k *KeyKeeper) checkRevealProcess(height int64) {
 		return
 	}
 	for _, p := range pids.GetPids() {
-		process, err := k.vochain.State.Process([]byte(p), false)
+		process, err := k.vochain.State.Process(p, false)
 		if err != nil {
 			log.Errorf("cannot get process from state: (%s)", err)
 			continue

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -46,7 +46,7 @@ func (v *State) CancelProcess(pid []byte) error { // LEGACY
 		return fmt.Errorf("cannot marshal updated process bytes: %w", err)
 	}
 	v.Lock()
-	err = v.Store.Tree(ProcessTree).Add([]byte(pid), updatedProcessBytes)
+	err = v.Store.Tree(ProcessTree).Add(pid, updatedProcessBytes)
 	v.Unlock()
 	if err != nil {
 		return err

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -24,7 +24,7 @@ const (
 	AppTree                 = "app"
 	ProcessTree             = "process"
 	VoteTree                = "vote"
-	voteCachePurgeThreshold = time.Duration(time.Minute * 10)
+	voteCachePurgeThreshold = time.Minute * 10
 )
 
 var (


### PR DESCRIPTION
Found by unconvert. Also two unnecessary uses of Sprintf found by a
newer staticcheck.