### PR TITLE
fix up a few of my TODOs

### DIFF
--- a/test/vochain_test.go
+++ b/test/vochain_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestCreateProcess(t *testing.T) {
-	// TODO(mvdan): re-enable once
-	// https://go.vocdoni.io/dvote/-/issues/172 is fixed.
+	// TODO(mvdan): re-enable once tests are hermetic
 	// t.Parallel()
 
 	s := testcommon.NewVochainStateWithOracles(t)

--- a/types/api.go
+++ b/types/api.go
@@ -116,7 +116,7 @@ type MetaResponse struct {
 	Nullifiers           *[]string  `json:"nullifiers,omitempty"`
 	Ok                   bool       `json:"ok"`
 	Paused               *bool      `json:"paused,omitempty"`
-	Payload              string     `json:"payload,omitempty"` // TODO(mvdan): sometimes hex, sometimes base64?
+	Payload              string     `json:"payload,omitempty"` // TODO: sometimes hex, sometimes base64 - consolidate with protobuf
 	ProcessIDs           []string   `json:"processIds,omitempty"`
 	ProcessList          []string   `json:"processList,omitempty"`
 	Registered           *bool      `json:"registered,omitempty"`


### PR DESCRIPTION
The go-ethereum method to stop a node is no longer racy, so use it
again.

A TODO had a link to a gitlab issue, so just remove it as it's not
really necessary.

We also agreed to leave Payload as it is, and clean it up as part of a
v2 protobuf API.

While at it, switch eth_test.go to quicktest, and simplify
NewMockEthereum.