### PR TITLE
add go linter to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
+        $(go env GOPATH)/bin/golangci-lint run --timeout=5m -c .golangci.yml
+
     - name: Go test
       run: |
         # we run vet in another step
@@ -30,10 +35,12 @@ jobs:
         go vet ./...
         curl -L https://github.com/dominikh/go-tools/releases/download/2020.2.1/staticcheck_linux_amd64.tar.gz | tar -xzf -
         ./staticcheck/staticcheck ./...
+ 
     - name: Install goveralls
       env:
         GO111MODULE: off
       run: go get github.com/mattn/goveralls
+
     - name: Send coverage to coverall.io
       env:
         COVERALLS_TOKEN: ${{ secrets.github_token }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+issues:
+        max-same-issues: 0
+        exclude-use-default: false
+linters:
+        enable:
+        - whitespace
+        - gosec
+        - gci
+        - misspell
+        - gomnd
+        - gofmt
+        - goimports
+        - lll
+        - golint
+linters-settings:
+        lll:
+                line-length: 100


### PR DESCRIPTION
A lot of work to do in order to have the go-CI happy. However I do see it as a nice improvement (fix all errors reported and keep it enabled from now on).

So I let this PR open so anyone can just push fixes on the code time to time until everything is ready to merge: @vdo @jordipainan @mvdan please feel free if you found some sparse time :)

Instructions for installing the linter locally:

```
git checkout feature/add_go_linter
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
golangci-lint run --timeout=5m -c .golangci.yml
```
You can create as many commits as needed, we'll squash it on the merge.

Signed-off-by: p4u <pau@dabax.net>