### PR TITLE
Clean workspace before compose test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,9 @@ on: [push, pull_request]
 jobs:
   go-tests:
     runs-on: self-hosted
-    container: golang:1.15
+    container: 
+      image: golang:1.15
+      options: --user 1000
     if: github.repository == 'vocdoni/vocdoni-node'
     defaults:
       run:
@@ -38,7 +40,6 @@ jobs:
 
   compose-test:
     runs-on: self-hosted
-    # container: docker/compose:1.28.2
     if: github.repository == 'vocdoni/vocdoni-node'
     steps:
       - name: Check out the repo


### PR DESCRIPTION
This needs to be applied because the `go-tests` job, running in parallel, leaves behind some files owned by root, and they conflict with the actions being run afterwards