### PR TITLE
api: add namespace arg on getProcessList

### DIFF
--- a/chain/contractWrappers.go
+++ b/chain/contractWrappers.go
@@ -87,7 +87,6 @@ func NewVotingHandle(contractsAddress []common.Address, dialEndpoint string) (*V
 
 // NewProcessTxArgs gets the info of a created process on the processes contract and creates a NewProcessTx instance
 func (ph *VotingHandle) NewProcessTxArgs(ctx context.Context, pid [types.ProcessIDsize]byte, namespace uint16) (*models.NewProcessTx, error) {
-	// TODO: @jordipainan What to do with namespace?
 	// get process info from the processes contract
 	processMeta, err := ph.VotingProcess.Get(&ethbind.CallOpts{Context: ctx}, pid)
 	if err != nil {

--- a/router/voteCallbacks.go
+++ b/router/voteCallbacks.go
@@ -170,7 +170,7 @@ func (r *Router) getProcessList(request routerRequest) {
 	if max > MaxListIterations || max <= 0 {
 		max = MaxListIterations
 	}
-	processList, err := r.Scrutinizer.ProcessList(request.EntityId, request.FromID, max)
+	processList, err := r.Scrutinizer.ProcessList(request.EntityId, request.FromID, max, request.Namespace)
 	if err != nil {
 		r.sendError(request, fmt.Sprintf("cannot get entity process list: (%s)", err))
 		return

--- a/types/api.go
+++ b/types/api.go
@@ -33,6 +33,7 @@ type MetaRequest struct {
 	ListSize     int64      `json:"listSize,omitempty"`
 	Method       string     `json:"method"`
 	Name         string     `json:"name,omitempty"`
+	Namespace    *uint32    `json:"namespace,omitempty"`
 	Nullifier    HexBytes   `json:"nullifier,omitempty"`
 	Payload      []byte     `json:"payload,omitempty"`
 	ProcessID    HexBytes   `json:"processId,omitempty"`

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -337,7 +337,7 @@ func NewProcessTxCheck(vtx *models.Tx, state *State) (*models.Process, error) {
 	return tx.Process, nil
 }
 
-// SetProcessTxCheck is an abstraction of ABCI checkTx for canceling an existing process
+// SetProcessTxCheck is an abstraction of ABCI checkTx for updating an existing process
 func SetProcessTxCheck(vtx *models.Tx, state *State) error {
 	tx := vtx.GetSetProcess()
 	// check signature available


### PR DESCRIPTION
- The namespace of a processes contract can be passed
  as an argument to the getProcessList request.
  This allows to fetch only the processes that are registred
  on a specific namespace and not all the processes of the vochain
  for a given entity.
- The 0 value is valid and represents the namespace 0.
- Is possible to obtain all the processes of all namespaces
  just by not passing the namespace argument on the request at all.