### PR TITLE
ethevents: subscription on reconect fails

### DIFF
--- a/chain/ethevents/events.go
+++ b/chain/ethevents/events.go
@@ -353,7 +353,8 @@ func (ev *EthereumEvents) SubscribeEthereumEventLogs(ctx context.Context, fromBl
 	for {
 		select {
 		case err := <-sub.Err():
-			log.Errorf("ethereum events subscription error on channel: %s", err)
+			// TODO: @jordipainan do not fatal here, handle error on event subscription channel
+			log.Fatalf("ethereum events subscription error on channel: %s", err)
 		case event := <-logs:
 			ev.EventProcessor.Events <- event
 		}


### PR DESCRIPTION
When the ethevents service is running and the
web3 conection is lost, the ethevents service
tries to reconect to the web3 endpoint.
For some reason (unknown atm) the ethereum
logs subscription fails on reconect.

As a temporary workaround let's fatal on
subscription failure and rely on docker restart
always policy. This will restart the vocdoni-node
from scratch and lost events will be also processed.

This PR just affects the nodes running the
ethevents service (Oracles).

Future work solution: Restart all the subscription
service freeing all the resources and recreating from
scratch without halting the node. This would be done
using an error channel on SubscribeEthereumEventLogs(...)
method.

(cherry picked from commit f0435c86169c2488297ea3d096a299116db6cef2)