### PR TITLE
add Status on processList query and make entityID optional

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -251,19 +251,17 @@ func (r *Router) EnableVoteAPI(vocapp *vochain.BaseApplication, vocInfo *vochain
 	r.registerPublic("getEnvelopeStatus", r.getEnvelopeStatus)
 	r.registerPublic("getEnvelope", r.getEnvelope)
 	r.registerPublic("getEnvelopeHeight", r.getEnvelopeHeight)
-	r.registerPublic("getProcessList", r.getProcessList)
 	r.registerPublic("getEnvelopeList", r.getEnvelopeList)
 	r.registerPublic("getBlockHeight", r.getBlockHeight)
 	r.registerPublic("getProcessKeys", r.getProcessKeys)
 	r.registerPublic("getBlockStatus", r.getBlockStatus)
-	r.registerPublic("getProcessCount", r.getProcessCount)
 	if r.Scrutinizer != nil {
 		r.APIs = append(r.APIs, "results")
+		r.registerPublic("getProcessList", r.getProcessList)
+		r.registerPublic("getProcessCount", r.getProcessCount)
 		r.registerPublic("getResults", r.getResults)
-		r.registerPublic("getProcListResults", r.getProcListResults)
-		r.registerPublic("getProcListLiveResults", r.getProcListLiveResults)
 		r.registerPublic("getEntities", r.getEntities)
-		r.registerPublic("getScrutinizerEntityCount", r.getScrutinizerEntityCount)
+		r.registerPublic("getEntityCount", r.getEntityCount)
 	}
 }
 

--- a/router/voteCallbacks.go
+++ b/router/voteCallbacks.go
@@ -157,6 +157,7 @@ func (r *Router) getProcessList(request routerRequest) {
 	processList, err := r.Scrutinizer.ProcessList(
 		request.EntityId,
 		request.Namespace,
+		request.Status,
 		request.From,
 		max)
 	if err != nil {

--- a/router/voteCallbacks.go
+++ b/router/voteCallbacks.go
@@ -158,17 +158,18 @@ func (r *Router) getProcessList(request routerRequest) {
 		request.EntityId,
 		request.Namespace,
 		request.Status,
+		request.WithResults,
 		request.From,
 		max)
 	if err != nil {
-		r.sendError(request, fmt.Sprintf("cannot get entity process list: (%s)", err))
+		r.sendError(request, fmt.Sprintf("cannot get process list: (%s)", err))
 		return
 	}
 	for _, p := range processList {
 		response.ProcessList = append(response.ProcessList, fmt.Sprintf("%x", p))
 	}
 	if len(response.ProcessList) == 0 {
-		response.Message = "entity does not exist or has not yet created a process"
+		response.Message = "no processes found for the query"
 		request.Send(r.buildReply(request, &response))
 		return
 	}
@@ -181,12 +182,12 @@ func (r *Router) getProcessList(request routerRequest) {
 func (r *Router) getProcessCount(request routerRequest) {
 	var response types.MetaResponse
 	response.Size = new(int64)
-	count := r.vocapp.State.CountProcesses(true)
+	count := r.Scrutinizer.ProcessCount()
 	*response.Size = count
 	request.Send(r.buildReply(request, &response))
 }
 
-func (r *Router) getScrutinizerEntityCount(request routerRequest) {
+func (r *Router) getEntityCount(request routerRequest) {
 	var response types.MetaResponse
 	response.Size = new(int64)
 	*response.Size = r.Scrutinizer.EntityCount()
@@ -311,26 +312,6 @@ func (r *Router) getResults(request routerRequest) {
 	response.Height = new(uint32)
 	*response.Height = votes
 
-	request.Send(r.buildReply(request, &response))
-}
-
-// finished processes
-func (r *Router) getProcListResults(request routerRequest) {
-	var response types.MetaResponse
-	if request.ListSize > MaxListSize || request.ListSize <= 0 {
-		request.ListSize = MaxListSize
-	}
-	response.ProcessIDs = r.Scrutinizer.ProcessListWithResults(request.ListSize, request.From)
-	request.Send(r.buildReply(request, &response))
-}
-
-// live processes
-func (r *Router) getProcListLiveResults(request routerRequest) {
-	var response types.MetaResponse
-	if request.ListSize > MaxListSize || request.ListSize <= 0 {
-		request.ListSize = MaxListSize
-	}
-	response.ProcessIDs = r.Scrutinizer.ProcessListWithLiveResults(request.ListSize, request.From)
 	request.Send(r.buildReply(request, &response))
 }
 

--- a/types/api.go
+++ b/types/api.go
@@ -44,6 +44,7 @@ type MetaRequest struct {
 	Timestamp    int32      `json:"timestamp"`
 	Type         string     `json:"type,omitempty"`
 	URI          string     `json:"uri,omitempty"`
+	WithResults  bool       `json:"withResults,omitempty"`
 }
 
 func (r MetaRequest) String() string {

--- a/types/api.go
+++ b/types/api.go
@@ -40,6 +40,7 @@ type MetaRequest struct {
 	PubKeys      []string   `json:"pubKeys,omitempty"`
 	RootHash     HexBytes   `json:"rootHash,omitempty"`
 	Signature    HexBytes   `json:"signature,omitempty"`
+	Status       string     `json:"status,omitempty"`
 	Timestamp    int32      `json:"timestamp"`
 	Type         string     `json:"type,omitempty"`
 	URI          string     `json:"uri,omitempty"`

--- a/vochain/scrutinizer/db.go
+++ b/vochain/scrutinizer/db.go
@@ -1,6 +1,9 @@
 package scrutinizer
 
 import (
+	"fmt"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/timshannon/badgerhold/v3"
@@ -8,16 +11,16 @@ import (
 )
 
 type Process struct {
-	ID            []byte `badgerhold:"key"`
-	EntityID      []byte `badgerhold:"index"`
+	ID            []byte `badgerholdKey:"ID"`
+	EntityID      []byte `badgerholdIndex:"EntityID"`
 	StartBlock    uint32
-	EndBlock      uint32 `badgerhold:"index"`
-	ResultsHeight uint32 `badgerhold:"index"`
+	EndBlock      uint32 `badgerholdIndex:"EndBlock"`
+	Rheight       uint32 `badgerholdIndex:"Rheight"`
 	CensusRoot    []byte
 	CensusURI     string
 	CensusOrigin  int32
-	Status        int32  `badgerhold:"index"`
-	Namespace     uint32 `badgerhold:"index"`
+	Status        int32  `badgerholdIndex:"Status"`
+	Namespace     uint32 `badgerholdIndex:"Namespace"`
 	Envelope      *models.EnvelopeType
 	Mode          *models.ProcessMode
 	VoteOpts      *models.ProcessVoteOptions
@@ -29,13 +32,42 @@ type Process struct {
 	FinalResults  bool
 }
 
+func (p Process) String() string {
+	v := reflect.ValueOf(p)
+	t := v.Type()
+	var b strings.Builder
+	b.WriteString("{")
+	for i := 0; i < t.NumField(); i++ {
+		fv := v.Field(i)
+		if fv.IsZero() {
+			// omit zero values
+			continue
+		}
+		if b.Len() > 1 {
+			b.WriteString(" ")
+		}
+		ft := t.Field(i)
+		b.WriteString(ft.Name)
+		b.WriteString(":")
+		if ft.Type.Kind() == reflect.Slice && ft.Type.Elem().Kind() == reflect.Uint8 {
+			// print []byte as hexadecimal
+			fmt.Fprintf(&b, "%x", fv.Bytes())
+		} else {
+			fv = reflect.Indirect(fv) // print *T as T
+			fmt.Fprintf(&b, "%v", fv.Interface())
+		}
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
 type Entity struct {
-	ID           []byte `badgerhold:"key"`
+	ID           []byte `badgerholdKey:"ID"`
 	CreationTime time.Time
 }
 
 type Results struct {
-	ProcessID  []byte `badgerhold:"key"`
+	ProcessID  []byte `badgerholdKey:"ProcessID"`
 	Votes      []*models.QuestionResult
 	Signatures [][]byte
 }

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -124,7 +124,7 @@ func testProcessList(t *testing.T, procsCount int) {
 	last := 0
 	var list [][]byte
 	for len(procs) < procsCount {
-		list, err = sc.ProcessList(eidTest, 0, "", last, 10)
+		list, err = sc.ProcessList(eidTest, 0, "", false, last, 10)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -191,25 +191,25 @@ func TestProcessListWithNamespaceAndStatus(t *testing.T) {
 	}
 
 	// Get the process list for namespace 123
-	list, err := sc.ProcessList(eid20, 123, "", 0, 100)
+	list, err := sc.ProcessList(eid20, 123, "", false, 0, 100)
 	qt.Assert(t, err, qt.IsNil)
 	// Check there are exactly 10
 	qt.Assert(t, len(list), qt.CmpEquals(), 10)
 
 	// Get the process list for all namespaces
-	list, err = sc.ProcessList(nil, 0, "", 0, 100)
+	list, err = sc.ProcessList(nil, 0, "", false, 0, 100)
 	qt.Assert(t, err, qt.IsNil)
 	// Check there are exactly 10 + 10
 	qt.Assert(t, len(list), qt.CmpEquals(), 20)
 
 	// Get the process list for namespace 10
-	list, err = sc.ProcessList(nil, 10, "", 0, 100)
+	list, err = sc.ProcessList(nil, 10, "", false, 0, 100)
 	qt.Assert(t, err, qt.IsNil)
 	// Check there is exactly 1
 	qt.Assert(t, len(list), qt.CmpEquals(), 1)
 
 	// Get the process list for namespace 10
-	list, err = sc.ProcessList(nil, 0, "READY", 0, 100)
+	list, err = sc.ProcessList(nil, 0, "READY", false, 0, 100)
 	qt.Assert(t, err, qt.IsNil)
 	// Check there is exactly 1
 	qt.Assert(t, len(list), qt.CmpEquals(), 10)


### PR DESCRIPTION
1. scrutinizer.ProcessList() now supports also status
Status = READY | ENDED | CANCELED | PAUSED | RESULTS
2. EntityID is optional so if empty, all processes will be returned
3. Add tests for these queries

Signed-off-by: p4u <pau@dabax.net>