### PR TITLE
chain: add entityResolver domains on spec

### DIFF
--- a/chain/blockchains.go
+++ b/chain/blockchains.go
@@ -16,8 +16,8 @@ type Specs struct {
 	BootNodes       []string // List of Bootnodes for this network
 	StartingBlock   int64    // Where to start looking for events
 	ENSregistryAddr string
-	// ENSdomains are ordered as [processes, namespaces, erc20tokenproofs, genesis, results]
-	ENSdomains [5]string // domains for each contract
+	// ENSdomains are ordered as [processes, namespaces, erc20tokenproofs, genesis, results, entityResolver]
+	ENSdomains [6]string // domains for each contract
 }
 
 var AvailableChains = []string{"mainnet", "goerli", "xdai", "xdaistage"}
@@ -46,12 +46,13 @@ var mainnet = Specs{
 	ENSregistryAddr: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
 	BootNodes:       ethparams.MainnetBootnodes,
 	StartingBlock:   10230300, //2020 jun 09 10:00h
-	ENSdomains: [5]string{
+	ENSdomains: [6]string{
 		types.ProcessesDomain,
 		types.NamespacesDomain,
 		types.ERC20ProofsDomain,
 		types.GenesisDomain,
 		types.ResultsDomain,
+		types.EntityResolverDomain,
 	},
 }
 
@@ -61,12 +62,13 @@ var xdai = Specs{
 	ENSregistryAddr: "0x00cEBf9E1E81D3CC17fbA0a49306EBA77a8F26cD",
 	BootNodes:       nil,
 	StartingBlock:   14531875, //2021 Feb 13 21:58h
-	ENSdomains: [5]string{
+	ENSdomains: [6]string{
 		types.ProcessesDomain,
 		types.NamespacesDomain,
 		types.ERC20ProofsDomain,
 		types.GenesisDomain,
 		types.ResultsDomain,
+		types.EntityResolverDomain,
 	},
 }
 
@@ -76,12 +78,13 @@ var xdaistage = Specs{
 	ENSregistryAddr: "0x00cEBf9E1E81D3CC17fbA0a49306EBA77a8F26cD",
 	BootNodes:       nil,
 	StartingBlock:   14531875, //2021 Feb 13 21:58h
-	ENSdomains: [5]string{
+	ENSdomains: [6]string{
 		types.ProcessesStageDomain,
 		types.NamespacesStageDomain,
 		types.ERC20ProofsStageDomain,
 		types.GenesisStageDomain,
 		types.ResultsStageDomain,
+		types.EntityResolverStageDomain,
 	},
 }
 
@@ -92,12 +95,13 @@ var goerlistage = Specs{
 	StartingBlock:   goerli.StartingBlock,
 	ENSregistryAddr: goerli.ENSregistryAddr,
 	BootNodes:       ethparams.GoerliBootnodes,
-	ENSdomains: [5]string{
+	ENSdomains: [6]string{
 		types.ProcessesStageDomain,
 		types.NamespacesStageDomain,
 		types.ERC20ProofsStageDomain,
 		types.GenesisStageDomain,
 		types.ResultsStageDomain,
+		types.EntityResolverStageDomain,
 	},
 	GenesisHash: goerli.GenesisHash,
 	GenesisB64:  goerli.GenesisB64,
@@ -110,12 +114,13 @@ var goerli = Specs{
 	StartingBlock:   3000000,
 	ENSregistryAddr: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
 	BootNodes:       ethparams.GoerliBootnodes,
-	ENSdomains: [5]string{
+	ENSdomains: [6]string{
 		types.ProcessesDevelopmentDomain,
 		types.NamespacesDevelopmentDomain,
 		types.ERC20ProofsDevelopmentDomain,
 		types.GenesisDevelopmentDomain,
 		types.ResultsDevelopmentDomain,
+		types.EntityResolverDevelopmentDomain,
 	},
 	GenesisHash: "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a",
 	GenesisB64: `ewogICJjb25maWciOnsKICAgICJjaGFpbklkIjo1LAogICAgImhvbWVzdGVhZEJsb2NrIjowLAog

--- a/chain/contractWrappers.go
+++ b/chain/contractWrappers.go
@@ -46,10 +46,7 @@ type Genesis struct {
 	Oracles    []common.Address
 }
 
-// NewVotingHandle initializes the Processes, Namespace and TokenStorageProof contracts creating a transactor using the ethereum client
-// contractsAddress[0] -> Processes contract
-// contractsAddress[1] -> Namespace contract
-// contractsAddress[2] -> TokenStorageProof contract
+// NewVotingHandle initializes contracts creating a transactor using the ethereum client
 func NewVotingHandle(contractsAddress []common.Address, dialEndpoint string) (*VotingHandle, error) {
 	var err error
 	ph := new(VotingHandle)

--- a/chain/ethevents/events.go
+++ b/chain/ethevents/events.go
@@ -100,8 +100,7 @@ type EventProcessor struct {
 }
 
 // NewEthEvents creates a new Ethereum events handler
-// contractsAddresses: [0] -> Processes contract, [1] -> Namespace contract, [2] -> TokenStorageProof contract
-// 					   [3] -> Genesis contract, [4] -> Results contract
+// contractsAddresses: [0] -> Processes contract, [1] -> Namespace contract, [2] -> TokenStorageProof contract [3] -> Genesis contract, [4] -> Results contract
 func NewEthEvents(contractsAddresses []common.Address,
 	signer *ethereum.SignKeys,
 	w3Endpoint string,


### PR DESCRIPTION
The entity resolver domains are not used on ethereum events logic and they were never exposed on the specs. A month ago or so we changed how contracts addresses were resolved internally and I added a new arg `entityResolverDomain` on EntityResolverMetadaURL() function for adapting later on the Notification service on the manager-backend.
During this adaptation yesterday I realized that the entity resolver domains depending on the environment are not exposed to the outside and that is something very wrong for anyone that wants to use the pkg chain as an external library (like the notif service).

This PR adds the entity resolver domains to the blockchains spec.