### PR TITLE
extend scrutinizer/indexer API

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -258,8 +258,10 @@ func (r *Router) EnableVoteAPI(vocapp *vochain.BaseApplication, vocInfo *vochain
 	if r.Scrutinizer != nil {
 		r.APIs = append(r.APIs, "results")
 		r.registerPublic("getProcessList", r.getProcessList)
+		r.registerPublic("getProcessInfo", r.getProcessInfo)
 		r.registerPublic("getProcessCount", r.getProcessCount)
 		r.registerPublic("getResults", r.getResults)
+		r.registerPublic("getResultsWeight", r.getResultsWeight)
 		r.registerPublic("getEntityList", r.getEntityList)
 		r.registerPublic("getEntityCount", r.getEntityCount)
 	}

--- a/router/voteCallbacks.go
+++ b/router/voteCallbacks.go
@@ -179,6 +179,17 @@ func (r *Router) getProcessList(request routerRequest) {
 	request.Send(r.buildReply(request, &response))
 }
 
+func (r *Router) getProcessInfo(request routerRequest) {
+	var response types.MetaResponse
+	var err error
+	response.ProcessInfo, err = r.Scrutinizer.ProcessInfo(request.ProcessID)
+	if err != nil {
+		r.sendError(request, fmt.Sprintf("cannot get process info: %v", err))
+		return
+	}
+	request.Send(r.buildReply(request, &response))
+}
+
 func (r *Router) getProcessCount(request routerRequest) {
 	var response types.MetaResponse
 	response.Size = new(int64)
@@ -254,6 +265,17 @@ func (r *Router) getEnvelopeList(request routerRequest) {
 		strnull = append(strnull, fmt.Sprintf("%x", n))
 	}
 	response.Nullifiers = &strnull
+	request.Send(r.buildReply(request, &response))
+}
+
+func (r *Router) getResultsWeight(request routerRequest) {
+	var response types.MetaResponse
+	var err error
+	response.Weight, err = r.Scrutinizer.GetResultsWeight(request.ProcessID)
+	if err != nil {
+		r.sendError(request, fmt.Sprintf("cannot get results weight: %v", err))
+		return
+	}
 	request.Send(r.buildReply(request, &response))
 }
 

--- a/types/api.go
+++ b/types/api.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"reflect"
 	"strings"
 )
@@ -94,45 +95,47 @@ type ResponseMessage struct {
 // Fields must be in alphabetical order
 // Those fields with valid zero-values (such as bool) must be pointers
 type MetaResponse struct {
-	APIList              []string   `json:"apiList,omitempty"`
-	BlockTime            *[5]int32  `json:"blockTime,omitempty"`
-	BlockTimestamp       int32      `json:"blockTimestamp,omitempty"`
-	CensusID             string     `json:"censusId,omitempty"`
-	CensusList           []string   `json:"censusList,omitempty"`
-	CensusKeys           [][]byte   `json:"censusKeys,omitempty"`
-	CensusValues         []HexBytes `json:"censusValues,omitempty"`
-	CensusDump           []byte     `json:"censusDump,omitempty"`
-	CommitmentKeys       []Key      `json:"commitmentKeys,omitempty"`
-	Content              []byte     `json:"content,omitempty"`
-	EncryptionPrivKeys   []Key      `json:"encryptionPrivKeys,omitempty"`
-	EncryptionPublicKeys []Key      `json:"encryptionPubKeys,omitempty"`
-	EntityID             string     `json:"entityId,omitempty"`
-	EntityIDs            []string   `json:"entityIds,omitempty"`
-	Files                []byte     `json:"files,omitempty"`
-	Finished             *bool      `json:"finished,omitempty"`
-	Health               int32      `json:"health,omitempty"`
-	Height               *uint32    `json:"height,omitempty"`
-	InvalidClaims        []int      `json:"invalidClaims,omitempty"`
-	Message              string     `json:"message,omitempty"`
-	Nullifier            string     `json:"nullifier,omitempty"`
-	Nullifiers           *[]string  `json:"nullifiers,omitempty"`
-	Ok                   bool       `json:"ok"`
-	Paused               *bool      `json:"paused,omitempty"`
-	Payload              string     `json:"payload,omitempty"` // TODO: sometimes hex, sometimes base64 - consolidate with protobuf
-	ProcessIDs           []string   `json:"processIds,omitempty"`
-	ProcessList          []string   `json:"processList,omitempty"`
-	Registered           *bool      `json:"registered,omitempty"`
-	Request              string     `json:"request"`
-	Results              [][]string `json:"results,omitempty"`
-	RevealKeys           []Key      `json:"revealKeys,omitempty"`
-	Root                 HexBytes   `json:"root,omitempty"`
-	Siblings             HexBytes   `json:"siblings,omitempty"`
-	Size                 *int64     `json:"size,omitempty"`
-	State                string     `json:"state,omitempty"`
-	Timestamp            int32      `json:"timestamp"`
-	Type                 string     `json:"type,omitempty"`
-	URI                  string     `json:"uri,omitempty"`
-	ValidProof           *bool      `json:"validProof,omitempty"`
+	APIList              []string    `json:"apiList,omitempty"`
+	BlockTime            *[5]int32   `json:"blockTime,omitempty"`
+	BlockTimestamp       int32       `json:"blockTimestamp,omitempty"`
+	CensusID             string      `json:"censusId,omitempty"`
+	CensusList           []string    `json:"censusList,omitempty"`
+	CensusKeys           [][]byte    `json:"censusKeys,omitempty"`
+	CensusValues         []HexBytes  `json:"censusValues,omitempty"`
+	CensusDump           []byte      `json:"censusDump,omitempty"`
+	CommitmentKeys       []Key       `json:"commitmentKeys,omitempty"`
+	Content              []byte      `json:"content,omitempty"`
+	EncryptionPrivKeys   []Key       `json:"encryptionPrivKeys,omitempty"`
+	EncryptionPublicKeys []Key       `json:"encryptionPubKeys,omitempty"`
+	EntityID             string      `json:"entityId,omitempty"`
+	EntityIDs            []string    `json:"entityIds,omitempty"`
+	Files                []byte      `json:"files,omitempty"`
+	Finished             *bool       `json:"finished,omitempty"`
+	Health               int32       `json:"health,omitempty"`
+	Height               *uint32     `json:"height,omitempty"`
+	InvalidClaims        []int       `json:"invalidClaims,omitempty"`
+	Message              string      `json:"message,omitempty"`
+	Nullifier            string      `json:"nullifier,omitempty"`
+	Nullifiers           *[]string   `json:"nullifiers,omitempty"`
+	Ok                   bool        `json:"ok"`
+	Paused               *bool       `json:"paused,omitempty"`
+	Payload              string      `json:"payload,omitempty"`
+	ProcessIDs           []string    `json:"processIds,omitempty"`
+	ProcessInfo          interface{} `json:"processInfo,omitempty"`
+	ProcessList          []string    `json:"processList,omitempty"`
+	Registered           *bool       `json:"registered,omitempty"`
+	Request              string      `json:"request"`
+	Results              [][]string  `json:"results,omitempty"`
+	RevealKeys           []Key       `json:"revealKeys,omitempty"`
+	Root                 HexBytes    `json:"root,omitempty"`
+	Siblings             HexBytes    `json:"siblings,omitempty"`
+	Size                 *int64      `json:"size,omitempty"`
+	State                string      `json:"state,omitempty"`
+	Timestamp            int32       `json:"timestamp"`
+	Type                 string      `json:"type,omitempty"`
+	URI                  string      `json:"uri,omitempty"`
+	ValidProof           *bool       `json:"validProof,omitempty"`
+	Weight               *big.Int    `json:"weight,omitempty"`
 }
 
 func (r MetaResponse) String() string {

--- a/vochain/scrutinizer/db.go
+++ b/vochain/scrutinizer/db.go
@@ -1,75 +1,55 @@
 package scrutinizer
 
 import (
-	"fmt"
-	"reflect"
-	"strings"
+	"encoding/json"
+	"math/big"
 	"time"
 
 	"github.com/timshannon/badgerhold/v3"
+	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
+// Process represents an election process handled by the Vochain.
+// The scrutinizer Process data type is different from the vochain state data type
+// since it is optimized for querying purposes and not for keeping a shared consensus state.
 type Process struct {
-	ID            []byte `badgerholdKey:"ID"`
-	EntityID      []byte `badgerholdIndex:"EntityID"`
-	StartBlock    uint32
-	EndBlock      uint32 `badgerholdIndex:"EndBlock"`
-	Rheight       uint32 `badgerholdIndex:"Rheight"`
-	CensusRoot    []byte
-	CensusURI     string
-	CensusOrigin  int32
-	Status        int32  `badgerholdIndex:"Status"`
-	Namespace     uint32 `badgerholdIndex:"Namespace"`
-	Envelope      *models.EnvelopeType
-	Mode          *models.ProcessMode
-	VoteOpts      *models.ProcessVoteOptions
-	PrivateKeys   []string
-	PublicKeys    []string
-	QuestionIndex uint32
-	CreationTime  time.Time
-	HaveResults   bool
-	FinalResults  bool
+	ID            types.HexBytes             `badgerholdKey:"ID" json:"processId"`
+	EntityID      types.HexBytes             `badgerholdIndex:"EntityID" json:"entityId"`
+	StartBlock    uint32                     `json:"startBlock"`
+	EndBlock      uint32                     `badgerholdIndex:"EndBlock" json:"endBlock"`
+	Rheight       uint32                     `badgerholdIndex:"Rheight" json:"-"`
+	CensusRoot    types.HexBytes             `json:"censusRoot"`
+	CensusURI     string                     `json:"censusURI"`
+	CensusOrigin  int32                      `json:"censusOrigin"`
+	Status        int32                      `badgerholdIndex:"Status" json:"status"`
+	Namespace     uint32                     `badgerholdIndex:"Namespace" json:"namespace"`
+	Envelope      *models.EnvelopeType       `json:"envelopeType"`
+	Mode          *models.ProcessMode        `json:"processMode"`
+	VoteOpts      *models.ProcessVoteOptions `json:"voteOptions"`
+	PrivateKeys   []string                   `json:"-"`
+	PublicKeys    []string                   `json:"-"`
+	QuestionIndex uint32                     `json:"questionIndex"`
+	CreationTime  time.Time                  `json:"creationTime"`
+	HaveResults   bool                       `json:"haveResults"`
+	FinalResults  bool                       `json:"finalResults"`
 }
 
 func (p Process) String() string {
-	v := reflect.ValueOf(p)
-	t := v.Type()
-	var b strings.Builder
-	b.WriteString("{")
-	for i := 0; i < t.NumField(); i++ {
-		fv := v.Field(i)
-		if fv.IsZero() {
-			// omit zero values
-			continue
-		}
-		if b.Len() > 1 {
-			b.WriteString(" ")
-		}
-		ft := t.Field(i)
-		b.WriteString(ft.Name)
-		b.WriteString(":")
-		if ft.Type.Kind() == reflect.Slice && ft.Type.Elem().Kind() == reflect.Uint8 {
-			// print []byte as hexadecimal
-			fmt.Fprintf(&b, "%x", fv.Bytes())
-		} else {
-			fv = reflect.Indirect(fv) // print *T as T
-			fmt.Fprintf(&b, "%v", fv.Interface())
-		}
-	}
-	b.WriteString("}")
-	return b.String()
+	b, _ := json.Marshal(p)
+	return string(b)
 }
 
 type Entity struct {
-	ID           []byte `badgerholdKey:"ID"`
+	ID           types.HexBytes `badgerholdKey:"ID"`
 	CreationTime time.Time
 }
 
 type Results struct {
-	ProcessID  []byte `badgerholdKey:"ProcessID"`
+	ProcessID  types.HexBytes `badgerholdKey:"ProcessID"`
 	Votes      []*models.QuestionResult
-	Signatures [][]byte
+	Weight     *big.Int
+	Signatures []types.HexBytes
 }
 
 func InitDB(dataDir string) (*badgerhold.Store, error) {

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -9,6 +9,7 @@ import (
 	"go.vocdoni.io/proto/build/go/models"
 
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/types"
 )
 
 // ProcessInfo returns the available information regarding an election process id
@@ -208,7 +209,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 	if err := s.db.Insert(pid, &Results{
 		ProcessID:  pid,
 		Votes:      pv.GetVotes(),
-		Signatures: [][]byte{},
+		Signatures: []types.HexBytes{},
 	}); err != nil {
 		return err
 	}

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -71,7 +71,7 @@ func (s *Scrutinizer) Commit(height int64) {
 
 	// Add votes collected by onVote (live results)
 	for _, v := range s.votePool {
-		if err := s.addLiveResultsVote(v); err != nil {
+		if err := s.addLiveVote(v); err != nil {
 			log.Errorf("cannot add live vote: (%s)", err)
 			continue
 		}
@@ -115,14 +115,7 @@ func (s *Scrutinizer) OnProcess(pid, eid []byte, censusRoot, censusURI string) {
 
 // OnVote scrutinizer stores the votes if liveResults enabled
 func (s *Scrutinizer) OnVote(v *models.Vote) {
-	isLive, err := s.isLiveResultsProcess(v.ProcessId)
-	if err != nil {
-		log.Errorf("cannot check if process is live results: (%s)", err)
-		return
-	}
-	if isLive {
-		s.votePool = append(s.votePool, v)
-	}
+	s.votePool = append(s.votePool, v)
 }
 
 // OnCancel scrutinizer stores the processID and entityID

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -362,7 +362,7 @@ func TestLiveResults(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	v := &models.Vote{ProcessId: pid, VotePackage: vp}
 	for i := 0; i < 100; i++ {
-		if err := sc.addLiveResultsVote(v); err != nil {
+		if err := sc.addLiveVote(v); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -480,7 +480,7 @@ var vote = func(v []int, sc *Scrutinizer, pid []byte) error {
 	if err != nil {
 		return err
 	}
-	return sc.addLiveResultsVote(
+	return sc.addLiveVote(
 		&models.Vote{
 			ProcessId:   pid,
 			VotePackage: vp,


### PR DESCRIPTION
Add two new methods to the results API

- getResultsWeight: returns the current weight of included votes for
  a processId.
- getProcessInfo: returns the full information of an existing process

In addition the dvotecli has also been extended with the new commands.

Signed-off-by: p4u <pau@dabax.net>