### PR TITLE
census: add AddBatch method on censustree interface

### DIFF
--- a/censustree/censusTree.go
+++ b/censustree/censusTree.go
@@ -8,6 +8,7 @@ type Tree interface {
 	UnPublish()     // UnPublish will make the tree not available for queries
 	IsPublic() bool // Check if the census tree is available for queries or not
 	Add(key, value []byte) error
+	AddBatch(keys, values [][]byte) (failedIndexes []int, err error) // Must support values=nil
 	GenProof(key, value []byte) (mproof []byte, err error)
 	CheckProof(key, value, root, mproof []byte) (included bool, err error)
 	Root() []byte

--- a/service/census.go
+++ b/service/census.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"go.vocdoni.io/dvote/census"
-	"go.vocdoni.io/dvote/censustree/gravitontree"
+	tree "go.vocdoni.io/dvote/censustree/gravitontree"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/metrics"
 )
@@ -20,7 +20,7 @@ func Census(datadir string, ma *metrics.Agent) (*census.Manager, error) {
 			return nil, err
 		}
 	}
-	if err := censusManager.Init(stdir, "", gravitontree.NewTree); err != nil {
+	if err := censusManager.Init(stdir, "", tree.NewTree); err != nil {
 		return nil, err
 	}
 

--- a/statedb/gravitonstate/graviton.go
+++ b/statedb/gravitonstate/graviton.go
@@ -419,6 +419,10 @@ func (t *GravitonTree) count() (count uint64) {
 	return
 }
 
+func (t *GravitonTree) Commit() error {
+	return t.tree.Commit()
+}
+
 func (t *GravitonTree) Count() uint64 {
 	c := atomic.LoadUint64(&t.size)
 	if c == 0 {

--- a/statedb/iavlstate/iavlstate.go
+++ b/statedb/iavlstate/iavlstate.go
@@ -282,6 +282,11 @@ func (t *IavlTree) Hash() []byte {
 	}
 }
 
+func (t *IavlTree) Commit() error {
+	_, _, err := t.tree.SaveVersion()
+	return err
+}
+
 func (t *IavlTree) Count() uint64 {
 	if t.isImmutable {
 		return uint64(t.itree.Size())

--- a/statedb/statedb.go
+++ b/statedb/statedb.go
@@ -24,4 +24,5 @@ type StateTree interface {
 	Version() uint64
 	Proof(key []byte) ([]byte, error)
 	Verify(key, proof, root []byte) bool
+	Commit() error
 }

--- a/test/testcommon/apis.go
+++ b/test/testcommon/apis.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vocdoni/multirpc/transports"
 	"github.com/vocdoni/multirpc/transports/mhttp"
 	"go.vocdoni.io/dvote/census"
-	"go.vocdoni.io/dvote/censustree/gravitontree"
+	tree "go.vocdoni.io/dvote/censustree/gravitontree"
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/data"
@@ -90,7 +90,7 @@ func (d *DvoteAPIServer) Start(tb testing.TB, apis ...string) {
 	var cm census.Manager
 	d.CensusDir = tb.TempDir()
 
-	if err := cm.Init(d.CensusDir, "", gravitontree.NewTree); err != nil {
+	if err := cm.Init(d.CensusDir, "", tree.NewTree); err != nil {
 		tb.Fatal(err)
 	}
 

--- a/types/api.go
+++ b/types/api.go
@@ -19,33 +19,33 @@ type RequestMessage struct {
 // MetaRequest contains all of the possible request fields.
 // Fields must be in alphabetical order
 type MetaRequest struct {
-	CensusID     string     `json:"censusId,omitempty"`
-	CensusURI    string     `json:"censusUri,omitempty"`
-	CensusKey    []byte     `json:"censusKey,omitempty"`
-	CensusKeys   [][]byte   `json:"censusKeys,omitempty"`
-	CensusValue  HexBytes   `json:"censusValue,omitempty"`
-	CensusValues []HexBytes `json:"censusValues,omitempty"`
-	CensusDump   []byte     `json:"censusDump,omitempty"`
-	Content      []byte     `json:"content,omitempty"`
-	Digested     bool       `json:"digested,omitempty"`
-	EntityId     HexBytes   `json:"entityId,omitempty"`
-	From         int        `json:"from,omitempty"`
-	ListSize     int        `json:"listSize,omitempty"`
-	Method       string     `json:"method"`
-	Name         string     `json:"name,omitempty"`
-	Namespace    uint32     `json:"namespace,omitempty"`
-	Nullifier    HexBytes   `json:"nullifier,omitempty"`
-	Payload      []byte     `json:"payload,omitempty"`
-	ProcessID    HexBytes   `json:"processId,omitempty"`
-	ProofData    HexBytes   `json:"proofData,omitempty"`
-	PubKeys      []string   `json:"pubKeys,omitempty"`
-	RootHash     HexBytes   `json:"rootHash,omitempty"`
-	Signature    HexBytes   `json:"signature,omitempty"`
-	Status       string     `json:"status,omitempty"`
-	Timestamp    int32      `json:"timestamp"`
-	Type         string     `json:"type,omitempty"`
-	URI          string     `json:"uri,omitempty"`
-	WithResults  bool       `json:"withResults,omitempty"`
+	CensusID     string   `json:"censusId,omitempty"`
+	CensusURI    string   `json:"censusUri,omitempty"`
+	CensusKey    []byte   `json:"censusKey,omitempty"`
+	CensusKeys   [][]byte `json:"censusKeys,omitempty"`
+	CensusValue  []byte   `json:"censusValue,omitempty"`
+	CensusValues [][]byte `json:"censusValues,omitempty"`
+	CensusDump   []byte   `json:"censusDump,omitempty"`
+	Content      []byte   `json:"content,omitempty"`
+	Digested     bool     `json:"digested,omitempty"`
+	EntityId     HexBytes `json:"entityId,omitempty"`
+	From         int      `json:"from,omitempty"`
+	ListSize     int      `json:"listSize,omitempty"`
+	Method       string   `json:"method"`
+	Name         string   `json:"name,omitempty"`
+	Namespace    uint32   `json:"namespace,omitempty"`
+	Nullifier    HexBytes `json:"nullifier,omitempty"`
+	Payload      []byte   `json:"payload,omitempty"`
+	ProcessID    HexBytes `json:"processId,omitempty"`
+	ProofData    HexBytes `json:"proofData,omitempty"`
+	PubKeys      []string `json:"pubKeys,omitempty"`
+	RootHash     HexBytes `json:"rootHash,omitempty"`
+	Signature    HexBytes `json:"signature,omitempty"`
+	Status       string   `json:"status,omitempty"`
+	Timestamp    int32    `json:"timestamp"`
+	Type         string   `json:"type,omitempty"`
+	URI          string   `json:"uri,omitempty"`
+	WithResults  bool     `json:"withResults,omitempty"`
 }
 
 func (r MetaRequest) String() string {


### PR DESCRIPTION
AddBatch allows to import multiple keys/values to the trie making a
single commit. If the trie implementation supports it, this mechanism
can speed-up the census creation process.

Signed-off-by: p4u <pau@dabax.net>