### PR TITLE
do not use Poseidon hash

### DIFF
--- a/census/handler.go
+++ b/census/handler.go
@@ -11,7 +11,6 @@ import (
 
 	"go.vocdoni.io/dvote/crypto"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/snarks"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -207,9 +206,10 @@ func (m *Manager) Handler(ctx context.Context, r *types.MetaRequest, isAuth bool
 				return resp
 			}
 			data := r.CensusKey
-			if !r.Digested {
-				data = snarks.Poseidon.Hash(data)
-			}
+			// TO-DO: do a poseidon hash if census=snarks
+			//if !r.Digested {
+			// data = snarks.Poseidon.Hash(data)
+			//}
 			err := tr.Add(data, r.CensusValue)
 			if err != nil {
 				resp.SetError(err)
@@ -297,9 +297,10 @@ func (m *Manager) Handler(ctx context.Context, r *types.MetaRequest, isAuth bool
 		}
 		// Generate proof and return it
 		data := r.CensusKey
-		if !r.Digested {
-			data = snarks.Poseidon.Hash(data)
-		}
+		// TO-DO: if census=snarks do Poseidon hashing
+		//if !r.Digested {
+		//	data = snarks.Poseidon.Hash(data)
+		//}
 		validProof, err := tr.CheckProof(data, r.CensusValue, root, r.ProofData)
 		if err != nil {
 			resp.SetError(err)
@@ -323,9 +324,10 @@ func (m *Manager) Handler(ctx context.Context, r *types.MetaRequest, isAuth bool
 	switch r.Method {
 	case "genProof":
 		data := r.CensusKey
-		if !r.Digested {
-			data = snarks.Poseidon.Hash(data)
-		}
+		// TO-DO: if census=snarks do Poseidon hashing
+		//if !r.Digested {
+		//	data = snarks.Poseidon.Hash(data)
+		//}
 		siblings, err := tr.GenProof(data, r.CensusValue)
 		if err != nil {
 			resp.SetError(err)

--- a/censustree/gravitontree/trie.go
+++ b/censustree/gravitontree/trie.go
@@ -40,8 +40,8 @@ type exportData struct {
 }
 
 const (
-	MaxKeySize   = 32
-	MaxValueSize = 64
+	MaxKeySize   = 65
+	MaxValueSize = 65
 )
 
 // NewTree opens or creates a merkle tree under the given storage.

--- a/client/api.go
+++ b/client/api.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/snarks"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -43,8 +42,8 @@ func (c *Client) GetProof(pubkey, root []byte) ([]byte, error) {
 	var req types.MetaRequest
 	req.Method = "genProof"
 	req.CensusID = hex.EncodeToString(root)
-	req.Digested = true
-	req.CensusKey = snarks.Poseidon.Hash(pubkey)
+	req.Digested = false
+	req.CensusKey = pubkey
 
 	resp, err := c.Request(req, nil)
 	if err != nil {
@@ -569,7 +568,7 @@ func (c *Client) CreateCensus(signer *ethereum.SignKeys, censusSigners []*ethere
 	log.Infof("add bulk claims (size %d)", censusSize)
 	req.Method = "addClaimBulk"
 	req.CensusKey = []byte{}
-	req.Digested = true
+	req.Digested = false
 	currentSize := censusSize
 	i := 0
 	var hexpub string
@@ -588,7 +587,7 @@ func (c *Client) CreateCensus(signer *ethereum.SignKeys, censusSigners []*ethere
 			if err != nil {
 				return nil, "", err
 			}
-			claims = append(claims, snarks.Poseidon.Hash(pub))
+			claims = append(claims, pub)
 			currentSize--
 		}
 		req.CensusKeys = claims

--- a/test/census_test.go
+++ b/test/census_test.go
@@ -42,7 +42,6 @@ import (
 
 	"go.vocdoni.io/dvote/client"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/snarks"
 	"go.vocdoni.io/dvote/types"
 
 	"go.vocdoni.io/dvote/test/testcommon"
@@ -124,11 +123,12 @@ func TestCensus(t *testing.T) {
 	// addClaimBulk
 	var claims [][]byte
 	req.CensusKey = []byte{}
+	req.Digested = false
 	keys := testcommon.CreateEthRandomKeysBatch(t, *censusSize)
 	for _, key := range keys {
-		hash := snarks.Poseidon.Hash(crypto.FromECDSAPub(&key.Public))
-		qt.Assert(t, hash, qt.Not(qt.HasLen), 0)
-		claims = append(claims, hash)
+		claim := crypto.FromECDSAPub(&key.Public)
+		qt.Assert(t, claim, qt.Not(qt.HasLen), 0)
+		claims = append(claims, claim)
 	}
 	req.CensusKeys = claims
 	resp = doRequest("addClaimBulk", signer2)
@@ -210,5 +210,4 @@ func TestCensus(t *testing.T) {
 	// get census list
 	resp = doRequest("getCensusList", signer2)
 	qt.Assert(t, resp.CensusList, qt.HasLen, 4)
-	t.Logf("census list: %v", resp.CensusList)
 }

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -9,7 +9,6 @@ import (
 
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tree "go.vocdoni.io/dvote/censustree/gravitontree"
-	"go.vocdoni.io/dvote/crypto/snarks"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -51,7 +50,7 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication, nvoters int, tmpDir
 	}
 	claims := []string{}
 	for _, k := range keys {
-		c := snarks.Poseidon.Hash(k.PublicKey())
+		c := k.PublicKey()
 		if err := tr.Add(c, nil); err != nil {
 			b.Error(err)
 		}

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -9,7 +9,6 @@ import (
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/nacl"
-	"go.vocdoni.io/dvote/crypto/snarks"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
@@ -318,9 +317,9 @@ func (k *KeyKeeper) generateKeys(pid []byte) (*processKeys, error) {
 		return nil, fmt.Errorf("cannot generate encryption key: (%s)", err)
 	}
 	// Reveal and commitment keys
-	ckb := snarks.Poseidon.Hash(priv.Bytes())
+	ckb := ethereum.HashRaw(priv.Bytes())
 	ck := ckb[:commitmentKeySize]
-	ckhash := snarks.Poseidon.Hash(ckb)[:commitmentKeySize]
+	ckhash := ethereum.HashRaw(ckb)[:commitmentKeySize]
 
 	pk := &processKeys{
 		privKey:       priv.Bytes(),

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
 	tree "go.vocdoni.io/dvote/censustree/gravitontree"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/snarks"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
@@ -36,8 +35,10 @@ func TestMerkleTreeProof(t *testing.T) {
 	keys := util.CreateEthRandomKeysBatch(1000)
 	claims := []string{}
 	for _, k := range keys {
-		c := snarks.Poseidon.Hash(k.PublicKey())
-		tr.Add(c, nil)
+		c := k.PublicKey()
+		if err := tr.Add(c, nil); err != nil {
+			t.Fatal(err)
+		}
 		claims = append(claims, string(c))
 	}
 	censusURI := "ipfs://123456789"

--- a/vochain/scrutinizer/db.go
+++ b/vochain/scrutinizer/db.go
@@ -213,7 +213,7 @@ func (r *Results) AddVote(voteValues []int, weight *big.Int, mutex *sync.Mutex) 
 		}
 	} else {
 		// For the other cases, we use the results matrix index weighted
-		// as described in the Ballot Protocol
+		// as described in the Ballot Protocol.
 		for q, opt := range voteValues {
 			r.Votes[q][opt].Add(r.Votes[q][opt], weight)
 		}


### PR DESCRIPTION
While snarks are not integrated, we don't need to use Poseidon hash.

Signed-off-by: p4u <pau@dabax.net>