### PR TITLE
api: limit add and fetch file calls

### DIFF
--- a/census/handler.go
+++ b/census/handler.go
@@ -254,7 +254,7 @@ func (m *Manager) Handler(ctx context.Context, r *types.MetaRequest, isAuth bool
 			return resp
 		}
 		log.Infof("retrieving remote census %s", r.CensusURI)
-		censusRaw, err := m.RemoteStorage.Retrieve(ctx, r.URI[len(m.RemoteStorage.URIprefix()):])
+		censusRaw, err := m.RemoteStorage.Retrieve(ctx, r.URI[len(m.RemoteStorage.URIprefix()):], 0)
 		if err != nil {
 			log.Warnf("cannot retrieve census: %s", err)
 			resp.SetError("cannot retrieve census")

--- a/census/importqueue.go
+++ b/census/importqueue.go
@@ -91,7 +91,7 @@ func (m *Manager) importFailedQueueDaemon() {
 		for cid, uri := range m.ImportFailedQueue() {
 			log.Debugf("retrying census import %s %s", cid, uri)
 			ctx, cancel := context.WithTimeout(context.Background(), ImportRetrieveTimeout*2)
-			censusRaw, err := m.RemoteStorage.Retrieve(ctx, uri[len(m.RemoteStorage.URIprefix()):])
+			censusRaw, err := m.RemoteStorage.Retrieve(ctx, uri[len(m.RemoteStorage.URIprefix()):], 0)
 			cancel()
 			if err != nil {
 				continue
@@ -125,7 +125,7 @@ func (m *Manager) importQueueDaemon() {
 		log.Infof("retrieving remote census %s", uri)
 		m.queueAdd(1)
 		ctx, cancel := context.WithTimeout(context.Background(), ImportRetrieveTimeout)
-		censusRaw, err := m.RemoteStorage.Retrieve(ctx, uri[len(m.RemoteStorage.URIprefix()):])
+		censusRaw, err := m.RemoteStorage.Retrieve(ctx, uri[len(m.RemoteStorage.URIprefix()):], 0)
 		cancel()
 		if err != nil {
 			if os.IsTimeout(err) {

--- a/data/data.go
+++ b/data/data.go
@@ -12,7 +12,7 @@ import (
 type Storage interface {
 	Init(d *types.DataStore) error
 	Publish(ctx context.Context, o []byte) (string, error)
-	Retrieve(ctx context.Context, id string) ([]byte, error)
+	Retrieve(ctx context.Context, id string, maxSize int64) ([]byte, error)
 	Pin(ctx context.Context, path string) error
 	Unpin(ctx context.Context, path string) error
 	ListPins(ctx context.Context) (map[string]string, error)

--- a/data/ipfs.go
+++ b/data/ipfs.go
@@ -240,7 +240,7 @@ func (i *IPFSHandle) ListPins(ctx context.Context) (map[string]string, error) {
 	return pinMap, nil
 }
 
-func (i *IPFSHandle) Retrieve(ctx context.Context, path string) ([]byte, error) {
+func (i *IPFSHandle) Retrieve(ctx context.Context, path string, maxSize int64) ([]byte, error) {
 	path = strings.TrimPrefix(path, "ipfs://")
 	pth := corepath.New(path)
 
@@ -249,7 +249,10 @@ func (i *IPFSHandle) Retrieve(ctx context.Context, path string) ([]byte, error) 
 		return nil, err
 	}
 	defer node.Close()
-	if s, err := node.Size(); s > int64(MaxFileSizeBytes) || err != nil {
+	if maxSize == 0 {
+		maxSize = MaxFileSizeBytes
+	}
+	if s, err := node.Size(); s > maxSize || err != nil {
 		return nil, fmt.Errorf("file too big or size cannot be obtained")
 	}
 	r, ok := node.(files.File)

--- a/router/router.go
+++ b/router/router.go
@@ -214,7 +214,11 @@ func (r *Router) registerPublic(name string, handler func(routerRequest)) {
 func (r *Router) EnableFileAPI() {
 	r.APIs = append(r.APIs, "file")
 	r.registerPublic("fetchFile", r.fetchFile)
-	r.registerPrivate("addFile", r.addFile)
+	if r.allowPrivate {
+		r.registerPrivate("addFile", r.addFile)
+	} else {
+		r.registerPublic("addFile", r.addJSONfile)
+	}
 	r.registerPrivate("pinList", r.pinList)
 	r.registerPrivate("pinFile", r.pinFile)
 	r.registerPrivate("unpinFile", r.unpinFile)


### PR DESCRIPTION
if --apiAllowPrivate is false, only JSON files can be added (considering
    the metadata.json file) with a maximum of 10 KiB

for fetchFile the maximum is now 2 MiB (before 50)

Signed-off-by: p4u <pau@dabax.net>