### PR TITLE
Indexer: update process on results

### DIFF
--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -451,6 +451,7 @@ func (s *Scrutinizer) OnProcessResults(pid []byte, results []*models.QuestionRes
 				}
 			}
 		}
+		s.updateProcessPool = append(s.updateProcessPool, pid)
 		log.Infof("published results for process %x are correct!", pid)
 	}()
 	return nil


### PR DESCRIPTION
The indexer was not updating the process on results, meaning processes with results available were marked with the status `ENDED`. 

This change was tested by erasing local vochain storage and re-running a node, and then testing the `getResults` api with a finished process. It correctly returns a process status of `RESULTS` now.