### PR TITLE
vochain: refactor vote cache and VoteTxCheck

### DIFF
--- a/multirpc/endpoint/httpws.go
+++ b/multirpc/endpoint/httpws.go
@@ -107,7 +107,8 @@ func (e *HTTPWSendPoint) Init(listener chan transports.Message) error {
 	log.Infof("creating API service")
 
 	// Create a HTTP Proxy service
-	pxy, err := proxy(e.config.ListenHost, e.config.ListenPort, e.config.TLSconfig, e.config.TLSdomain, e.config.TLSdirCert)
+	pxy, err := proxy(e.config.ListenHost, e.config.ListenPort,
+		e.config.TLSconfig, e.config.TLSdomain, e.config.TLSdirCert)
 	if err != nil {
 		return err
 	}
@@ -125,7 +126,9 @@ func (e *HTTPWSendPoint) Init(listener chan transports.Message) error {
 		return fmt.Errorf("mode %d not supported", e.config.Mode)
 	}
 
-	ts.Init(new(transports.Connection))
+	if err := ts.Init(new(transports.Connection)); err != nil {
+		return err
+	}
 
 	switch e.config.Mode {
 	case 0:
@@ -141,7 +144,10 @@ func (e *HTTPWSendPoint) Init(listener chan transports.Message) error {
 	// Attach the metrics agent (Prometheus)
 	var ma *metrics.Agent
 	if e.config.Metrics != nil && e.config.Metrics.Enabled {
-		ma = metrics.NewAgent("/metrics", time.Second*time.Duration(e.config.Metrics.RefreshInterval), pxy)
+		ma = metrics.NewAgent("/metrics",
+			time.Second*time.Duration(
+				e.config.Metrics.RefreshInterval),
+			pxy)
 	}
 	e.id = "httpws"
 	e.Proxy = pxy
@@ -152,7 +158,8 @@ func (e *HTTPWSendPoint) Init(listener chan transports.Message) error {
 
 // proxy creates a new service for routing HTTP connections using go-chi server
 // if tlsDomain is specified, it will use letsencrypt to fetch a valid TLS certificate
-func proxy(host string, port int32, tlsConfig *tls.Config, tlsDomain, tlsDir string) (*mhttp.Proxy, error) {
+func proxy(host string, port int32, tlsConfig *tls.Config,
+	tlsDomain, tlsDir string) (*mhttp.Proxy, error) {
 	pxy := mhttp.NewProxy()
 	pxy.Conn.TLSdomain = tlsDomain
 	pxy.Conn.TLScertDir = tlsDir

--- a/multirpc/endpoint/subpub.go
+++ b/multirpc/endpoint/subpub.go
@@ -46,15 +46,15 @@ func (sp *SubPubEndpoint) SetOption(name string, value interface{}) error {
 	switch name {
 	case OptionListenPort:
 		if sp.port, ok = value.(int32); !ok {
-			return fmt.Errorf("ListenPort must be int32")
+			return fmt.Errorf("listenPort must be int32")
 		}
 	case OptionBootnodes:
 		if sp.bootnodes, ok = value.([]string); !ok {
-			return fmt.Errorf("Botnodes must be []string")
+			return fmt.Errorf("botnodes must be []string")
 		}
 	case OptionPrivKey:
 		if sp.privKey, ok = value.(string); !ok {
-			return fmt.Errorf("PrivKey must be of type string")
+			return fmt.Errorf("privKey must be of type string")
 		}
 	case OptionTransportKey:
 		if sp.transportKey, ok = value.(string); !ok {
@@ -73,6 +73,7 @@ func (sp *SubPubEndpoint) SetOption(name string, value interface{}) error {
 func (sp *SubPubEndpoint) Transport() transports.Transport {
 	return &sp.transport
 }
+
 func (sp *SubPubEndpoint) ID() string {
 	return "subpub"
 }

--- a/multirpc/router/router.go
+++ b/multirpc/router/router.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"go.vocdoni.io/dvote/crypto"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -240,12 +239,12 @@ func (r *Router) SendError(request RouterRequest, errMsg string) {
 }
 
 // AddAuthKey adds a new pubkey address that will have access to private methods
-func (r *Router) AddAuthKey(addr common.Address) {
+func (r *Router) AddAuthKey(addr ethcommon.Address) {
 	r.signer.AddAuthKey(addr)
 }
 
 // DelAuthKey deletes a pubkey address from the authorized list
-func (r *Router) DelAuthKey(addr common.Address) {
+func (r *Router) DelAuthKey(addr ethcommon.Address) {
 	delete(r.signer.Authorized, addr)
 }
 

--- a/test/iavl_test.go
+++ b/test/iavl_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.vocdoni.io/dvote/test/testcommon"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
+	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
 )
 
@@ -23,7 +24,10 @@ func TestVochainState(t *testing.T) {
 	}
 
 	// This used to panic due to nil *ImmutableTree fields.
-	exists := s.EnvelopeExists([]byte("foo"), []byte("bar"), false)
+	exists, err := s.EnvelopeExists(util.RandomBytes(32), util.RandomBytes(32), false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if exists {
 		t.Errorf("expected EnvelopeExists to return false")
 	}

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -312,7 +312,7 @@ func (app *BaseApplication) BeginBlock(
 		log.Fatal(err)
 	}
 	app.State.Unlock()
-	app.State.CachePurge(app.State.Header(true).Height)
+	go app.State.CachePurge(uint32(header.Height))
 
 	return abcitypes.ResponseBeginBlock{}
 }

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -122,7 +122,8 @@ func CheckProof(proof *models.Proof, censusOrigin models.CensusOrigin, censusRoo
 }
 
 // VerifySignatureAgainstOracles verifies that a signature match with one of the oracles
-func verifySignatureAgainstOracles(oracles []ethcommon.Address, message, signature []byte) (bool, ethcommon.Address, error) {
+func verifySignatureAgainstOracles(oracles []ethcommon.Address, message,
+	signature []byte) (bool, ethcommon.Address, error) {
 	signKeys := ethereum.NewSignKeys()
 	for _, oracle := range oracles {
 		signKeys.AddAuthKey(oracle)
@@ -131,8 +132,12 @@ func verifySignatureAgainstOracles(oracles []ethcommon.Address, message, signatu
 }
 
 // GenerateNullifier generates the nullifier of a vote (hash(address+processId))
+// This function assumes address and processID are correct.
 func GenerateNullifier(address ethcommon.Address, processID []byte) []byte {
-	return ethereum.HashRaw([]byte(fmt.Sprintf("%s%s", address.Bytes(), processID)))
+	nullifier := bytes.Buffer{}
+	nullifier.Write(address.Bytes())
+	nullifier.Write(processID)
+	return ethereum.HashRaw(nullifier.Bytes())
 }
 
 // NewPrivateValidator returns a tendermint file private validator (key and state)

--- a/vochain/cache.go
+++ b/vochain/cache.go
@@ -4,57 +4,70 @@ import (
 	"time"
 
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/proto/build/go/models"
 )
 
 // CacheAdd adds a new vote proof to the local cache
-func (v *State) CacheAdd(id [32]byte, vc *CacheTx) {
+func (v *State) CacheAdd(id [32]byte, vote *models.Vote) {
 	if len(id) == 0 {
 		return
 	}
-	v.voteCacheLock.Lock()
-	defer v.voteCacheLock.Unlock()
-	v.voteCache[id] = vc
+	v.voteCache.Add(id, vote)
 }
 
 // CacheDel deletes an existing vote proof from the local cache
 func (v *State) CacheDel(id [32]byte) {
-	v.voteCacheLock.Lock()
-	defer v.voteCacheLock.Unlock()
-	delete(v.voteCache, id)
+	v.voteCache.Remove(id)
 }
 
-// CacheGet fetch an existing vote proof from the local cache
-func (v *State) CacheGet(id [32]byte) *CacheTx {
-	v.voteCacheLock.RLock()
-	defer v.voteCacheLock.RUnlock()
-	return v.voteCache[id]
+// CacheGet fetch an existing vote from the local cache
+func (v *State) CacheGet(id [32]byte) *models.Vote {
+	record, ok := v.voteCache.Get(id)
+	if !ok || record == nil {
+		return nil
+	}
+	return record.(*models.Vote)
 }
 
 // CachePurge removes the old cache saved votes
-func (v *State) CachePurge(height int64) {
-	if height%6 != 0 {
+func (v *State) CachePurge(height uint32) {
+	// Purge only every 6 blocks (3 minute)
+	if height%18 != 0 {
 		return
 	}
-	v.voteCacheLock.Lock()
-	defer v.voteCacheLock.Unlock()
+	start := time.Now()
 	purged := 0
-	for id, vp := range v.voteCache {
-		if time.Since(vp.Created) > voteCachePurgeThreshold {
-			delete(v.voteCache, id)
+	v.voteCache.Keys()
+	for _, id := range v.voteCache.Keys() {
+		record, ok := v.voteCache.Get(id)
+		if !ok {
+			// vote have been already deleted?
+			continue
+		}
+		vote, ok := record.(*models.Vote)
+		if !ok {
+			log.Warn("vote cache is not models.Vote")
+			continue
+		}
+		vid, ok := id.([32]byte)
+		if !ok {
+			log.Warn("vote cache index is not [32]byte")
+			continue
+		}
+		if vote.Height+voteCachePurgeThreshold >= height {
+			v.voteCache.Remove(vid)
 			if v.MemPoolRemoveTxKey != nil {
-				v.MemPoolRemoveTxKey(id, true)
+				v.MemPoolRemoveTxKey(vid, true)
 				purged++
 			}
 		}
 	}
 	if purged > 0 {
-		log.Infof("[txcache] purged %d transactions", purged)
+		log.Infof("[txcache] purged %d transactions, took %s", purged, time.Since(start))
 	}
 }
 
 // CacheSize returns the current size of the vote cache
 func (v *State) CacheSize() int {
-	v.voteCacheLock.RLock()
-	defer v.voteCacheLock.RUnlock()
-	return len(v.voteCache)
+	return v.voteCache.Len()
 }

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -15,8 +15,8 @@ var Genesis = map[string]VochainGenesis{
 		SeedNodes:         []string{"121e65eb5994874d9c05cd8d584a54669d23f294@seed.vocdoni.net:26656"},
 		Genesis: `
    {
-      "genesis_time":"2021-05-07T17:38:33.672114557Z",
-      "chain_id":"vocdoni-release-1.0",
+      "genesis_time":"2021-05-12T12:38:33.672114557Z",
+      "chain_id":"vocdoni-release-1.0.1",
       "consensus_params":{
          "block":{
             "max_bytes":"10485760",
@@ -144,8 +144,8 @@ var Genesis = map[string]VochainGenesis{
 		SeedNodes:         []string{"7440a5b086e16620ce7b13198479016aa2b07988@seed.dev.vocdoni.net:26656"},
 		Genesis: `
 {
-   "genesis_time":"2021-05-07T17:43:28.668436552Z",
-   "chain_id":"vocdoni-development-42",
+   "genesis_time":"2021-05-12T12:43:28.668436552Z",
+   "chain_id":"vocdoni-development-43",
    "consensus_params":{
       "block":{
          "max_bytes":"10485760",
@@ -254,8 +254,8 @@ var Genesis = map[string]VochainGenesis{
 		SeedNodes:         []string{"588133b8309363a2a852e853424251cd6e8c5330@seed.stg.vocdoni.net:26656"},
 		Genesis: `
 {
-   "genesis_time":"2021-02-09T17:41:19.055210151Z",
-   "chain_id":"vocdoni-stage-7",
+   "genesis_time":"2021-05-12T12:41:19.055210151Z",
+   "chain_id":"vocdoni-stage-8",
    "consensus_params":{
       "block":{
          "max_bytes":"22020096",

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -56,7 +56,9 @@ func TestMerkleTreeProof(t *testing.T) {
 		BlockCount:   1024,
 	}
 	t.Logf("adding process %s", log.FormatProto(process))
-	app.State.AddProcess(process)
+	if err := app.State.AddProcess(process); err != nil {
+		t.Fatal(err)
+	}
 
 	var cktx abcitypes.RequestCheckTx
 	var detx abcitypes.RequestDeliverTx
@@ -73,13 +75,21 @@ func TestMerkleTreeProof(t *testing.T) {
 			t.Fatal(err)
 		}
 		tx := &models.VoteEnvelope{
-			Nonce:       util.RandomBytes(32),
-			ProcessId:   pid,
-			Proof:       &models.Proof{Payload: &models.Proof_Graviton{Graviton: &models.ProofGraviton{Siblings: proof}}},
+			Nonce:     util.RandomBytes(32),
+			ProcessId: pid,
+			Proof: &models.Proof{
+				Payload: &models.Proof_Graviton{
+					Graviton: &models.ProofGraviton{
+						Siblings: proof,
+					},
+				},
+			},
 			VotePackage: vp,
 		}
 
-		if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: tx}}); err != nil {
+		if stx.Tx, err = proto.Marshal(&models.Tx{
+			Payload: &models.Tx_Vote{Vote: tx},
+		}); err != nil {
 			t.Fatal(err)
 		}
 

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -90,11 +90,14 @@ func NewState(dataDir string) (*State, error) {
 			if err := os.RemoveAll(dataDir); err != nil {
 				log.Errorf("%s", err)
 			}
-			vs.Store.Close()
+			_ = vs.Store.Close()
 			if err := initStore(dataDir, vs); err != nil {
 				return nil, fmt.Errorf("cannot init db: %s", err)
 			}
 			vs.voteCache, err = lru.New(voteCacheSize)
+			if err != nil {
+				return nil, err
+			}
 			log.Infof("application trees successfully loaded at version %d", vs.Store.Version())
 			return vs, nil
 		}
@@ -102,6 +105,9 @@ func NewState(dataDir string) (*State, error) {
 	}
 
 	vs.voteCache, err = lru.New(voteCacheSize)
+	if err != nil {
+		return nil, err
+	}
 	log.Infof("state database is ready at version %d with hash %x",
 		vs.Store.Version(), vs.Store.Hash())
 	vs.txCounter = new(int32)

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -2,38 +2,39 @@ package vochain
 
 import (
 	"encoding/json"
-	"math/big"
+	"fmt"
 	"time"
 
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
+const (
+	// db names
+	AppTree                 = "app"
+	ProcessTree             = "process"
+	VoteTree                = "vote"
+	voteCachePurgeThreshold = uint32(60) // in blocks, 10 minutes
+	voteCacheSize           = 50000
+)
+
+var (
+	ErrVoteDoesNotExist = fmt.Errorf("vote does not exist")
+	ErrProcessNotFound  = fmt.Errorf("process not found")
+	// keys; not constants because of []byte
+	headerKey    = []byte("header")
+	oracleKey    = []byte("oracle")
+	validatorKey = []byte("validator")
+)
+
+// PrefixDBCacheSize is the size of the cache for the MutableTree IAVL databases
+var PrefixDBCacheSize = 0
+
 // VotePackage represents the payload of a vote (usually base64 encoded)
 type VotePackage struct {
 	Nonce string `json:"nonce,omitempty"`
 	Votes []int  `json:"votes"`
 }
-
-// ________________________ STATE ________________________
-// Defined in ../../db/iavl.go for convenience
-
-// ________________________ VOTE ________________________
-
-// CacheTx contains the proof indicating that the user is in the census of the process
-type CacheTx struct {
-	Type         *models.TxType
-	Proof        *models.Proof `json:"proof,omitempty"`
-	PubKey       []byte        `json:"pubKey,omitempty"`
-	PubKeyDigest []byte        `json:"pubKeyDigest,omitempty"`
-	Nullifier    []byte        `json:"nullifier,omitempty"`
-	Weight       *big.Int      `json:"weight,omitempty"`
-	Created      time.Time     `json:"timestamp"`
-}
-
-// ________________________ PROCESS ________________________
-
-// ________________________ TX ________________________
 
 // UniqID returns a uniq identifier for the VoteTX. It depends on the Type.
 func UniqID(tx *models.SignedTx, isAnonymous bool) string {
@@ -44,8 +45,6 @@ func UniqID(tx *models.SignedTx, isAnonymous bool) string {
 	}
 	return ""
 }
-
-// ________________________ VALIDATORS ________________________
 
 // ________________________ QUERIES ________________________
 


### PR DESCRIPTION
- Use a LRU cache instead of a map.
- Store models.Vote instead of a custom type.
- Use height instead of timestamp for purgning cache.
- Make VoteTxCheck logic more clear

Signed-off-by: p4u <pau@dabax.net>