### PR TITLE
Indexer: Update process directly on results

### DIFF
--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -451,9 +451,9 @@ func (s *Scrutinizer) OnProcessResults(pid []byte, results []*models.QuestionRes
 				}
 			}
 		}
-		s.updateProcessPool = append(s.updateProcessPool, pid)
 		log.Infof("published results for process %x are correct!", pid)
 	}()
+	s.updateProcessPool = append(s.updateProcessPool, pid)
 	return nil
 }
 


### PR DESCRIPTION
With the old code, it is possible for RollBack() to be called before Commit(), refreshing the updateProcessPool before processing its contents. This leaves the given process non-updated, and the status remains ENDED. 
This change directly updates the process, ensuring its state will be set to RESULTS