### PR TITLE
Indexer: cache process envelope height even in process not in LRU

### DIFF
--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -286,10 +286,12 @@ func (s *Scrutinizer) Commit(height uint32) error {
 	startTime = time.Now()
 
 	for pid, votes := range s.votePool {
-		// Update the cache of envelopes height by process ID (if exist)
+		// Update or set the cache of envelopes height by process ID
 		if vcount, ok := s.envelopeHeightCache.Get(pid); ok {
 			c := vcount.(uint64) + uint64(len(votes))
 			s.envelopeHeightCache.Add(pid, c)
+		} else {
+			s.envelopeHeightCache.Add(pid, uint64(len(votes)))
 		}
 		// Get the process information
 		proc, err := s.ProcessInfo([]byte(pid))


### PR DESCRIPTION
We keep a cache of 1024 envelope heights for given process ids. The lru only updates if a user actually accesses one of these values, meaning the first time a process is accessed its height can take more than a second (badgerhold.Count takes a while). This PR updates the cache on every vote, even if the given process id is not yet stored in the cache. 

IMO a process receiving a new vote means its information is more likely to be accessed in the near future. Therefore I don't think this undoes the LRU nature of the cache.