### PR TITLE
Indexer: don't sort envelopes by index, just by height

### DIFF
--- a/vochain/scrutinizer/vote.go
+++ b/vochain/scrutinizer/vote.go
@@ -175,7 +175,7 @@ func (s *Scrutinizer) GetEnvelopes(processId []byte, max, from int,
 		err = s.db.ForEach(
 			badgerhold.
 				Where("Nullifier").MatchFunc(searchMatchFunc(searchTerm)).
-				SortBy("Height", "TxIndex").
+				SortBy("Height").
 				Skip(from).
 				Limit(max),
 			func(txRef *indexertypes.VoteReference) error {


### PR DESCRIPTION
We removed index sorting for requests without a search term, but not for those with a search term.