### PR TITLE
Router: move getProcessSummary to vote api

### DIFF
--- a/router/apis.go
+++ b/router/apis.go
@@ -66,6 +66,7 @@ func (r *Router) EnableResultsAPI(vocapp *vochain.BaseApplication,
 	r.APIs = append(r.APIs, "results")
 	r.RegisterPublic("getProcessList", r.getProcessList)
 	r.RegisterPublic("getProcessInfo", r.getProcessInfo)
+	r.RegisterPublic("getProcessSummary", r.getProcessSummary)
 	r.RegisterPublic("getProcessCount", r.getProcessCount)
 	r.RegisterPublic("getResults", r.getResults)
 	r.RegisterPublic("getResultsWeight", r.getResultsWeight)
@@ -82,7 +83,6 @@ func (r *Router) EnableIndexerAPI(vocapp *vochain.BaseApplication,
 	}
 	r.APIs = append(r.APIs, "indexer")
 	r.RegisterPublic("getStats", r.getStats)
-	r.RegisterPublic("getProcessSummary", r.getProcessSummary)
 	r.RegisterPublic("getEnvelopeList", r.getEnvelopeList)
 	r.RegisterPublic("getBlock", r.getBlock)
 	r.RegisterPublic("getBlockByHash", r.getBlockByHash)

--- a/router/indexerCallbacks.go
+++ b/router/indexerCallbacks.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -174,48 +173,6 @@ func (r *Router) getTxListForBlock(request RouterRequest) {
 			Index: int32(i),
 			Hash:  tmtypes.Tx(block.Txs[i]).Hash(),
 		})
-	}
-	if err := request.Send(r.BuildReply(request, &response)); err != nil {
-		log.Warnf("error sending response: %s", err)
-	}
-}
-
-func (r *Router) getProcessSummary(request RouterRequest) {
-	var response api.MetaResponse
-	if len(request.ProcessID) != types.ProcessIDsize {
-		r.SendError(request, "cannot get envelope status: (malformed processId)")
-		return
-	}
-
-	// Get process info
-	procInfo, err := r.Scrutinizer.ProcessInfo(request.ProcessID)
-	if err != nil {
-		log.Warn(err)
-		r.SendError(request, err.Error())
-		return
-	}
-
-	// Get total number of votes (including invalid/null)
-	eh, err := r.Scrutinizer.GetEnvelopeHeight(request.ProcessID)
-	if err != nil {
-		response.Message = fmt.Sprintf("cannot get envelope height: %v", err)
-		if err := request.Send(r.BuildReply(request, &response)); err != nil {
-			log.Warnf("error sending response: %s", err)
-		}
-		return
-	}
-	votes := uint32(eh)
-
-	response.ProcessSummary = &api.ProcessSummary{
-		BlockCount:      procInfo.EndBlock - procInfo.StartBlock,
-		EntityID:        hex.EncodeToString(procInfo.EntityID),
-		EntityIndex:     procInfo.EntityIndex,
-		EnvelopeHeight:  &votes,
-		Metadata:        procInfo.Metadata,
-		SourceNetworkID: procInfo.SourceNetworkId,
-		StartBlock:      procInfo.StartBlock,
-		State:           models.ProcessStatus(procInfo.Status).String(),
-		EnvelopeType:    procInfo.Envelope,
 	}
 	if err := request.Send(r.BuildReply(request, &response)); err != nil {
 		log.Warnf("error sending response: %s", err)


### PR DESCRIPTION
`getProcessSummary` was originally just for the explorer, so it was fine to be enabled only on gateways with the indexer api. Now this api call is used by the clients, so we need it to be available on all gateways with the vote api. 