### PR TITLE
Scrutinizer: Don't use badgerhold.Key

### DIFF
--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -19,7 +19,7 @@ import (
 // ProcessInfo returns the available information regarding an election process id
 func (s *Scrutinizer) ProcessInfo(pid []byte) (*indexertypes.Process, error) {
 	proc := &indexertypes.Process{}
-	err := s.db.FindOne(proc, badgerhold.Where(badgerhold.Key).Eq(pid))
+	err := s.db.FindOne(proc, badgerhold.Where("ID").Eq(pid))
 	return proc, err
 }
 
@@ -185,7 +185,7 @@ func (s *Scrutinizer) EntityList(max, from int, searchTerm string) []string {
 // EntityProcessCount returns the number of processes that an entity holds
 func (s *Scrutinizer) EntityProcessCount(entityId []byte) (uint32, error) {
 	entity := &indexertypes.Entity{}
-	if err := s.db.FindOne(entity, badgerhold.Where(badgerhold.Key).Eq(entityId)); err != nil {
+	if err := s.db.FindOne(entity, badgerhold.Where("ID").Eq(entityId)); err != nil {
 		return 0, err
 	}
 	return entity.ProcessCount, nil
@@ -270,7 +270,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 	eid := p.GetEntityId()
 	entity := &indexertypes.Entity{}
 	// If entity is not registered in db, add to entity count cache and insert to db
-	if err := s.db.FindOne(entity, badgerhold.Where(badgerhold.Key).Eq(eid)); err != nil {
+	if err := s.db.FindOne(entity, badgerhold.Where("ID").Eq(eid)); err != nil {
 		if err != badgerhold.ErrNotFound {
 			return err
 		}
@@ -360,7 +360,7 @@ func (s *Scrutinizer) updateProcess(pid []byte) error {
 	// Retry if error is "Transaction Conflict"
 	for {
 		if err := s.db.UpdateMatching(&indexertypes.Process{},
-			badgerhold.Where(badgerhold.Key).Eq(pid), updateFunc); err != nil {
+			badgerhold.Where("ID").Eq(pid), updateFunc); err != nil {
 			if strings.Contains(err.Error(), kvErrorStringForRetry) {
 				continue
 			}
@@ -372,7 +372,7 @@ func (s *Scrutinizer) updateProcess(pid []byte) error {
 }
 
 func (s *Scrutinizer) setResultsHeight(pid []byte, height uint32) error {
-	return s.db.UpdateMatching(&indexertypes.Process{}, badgerhold.Where(badgerhold.Key).Eq(pid),
+	return s.db.UpdateMatching(&indexertypes.Process{}, badgerhold.Where("ID").Eq(pid),
 		func(record interface{}) error {
 			update, ok := record.(*indexertypes.Process)
 			if !ok {

--- a/vochain/scrutinizer/vote.go
+++ b/vochain/scrutinizer/vote.go
@@ -39,7 +39,7 @@ const kvErrorStringForRetry = "Transaction Conflict"
 // This reference can then be used to fetch the vote transaction directly from the BlockStore.
 func (s *Scrutinizer) GetEnvelopeReference(nullifier []byte) (*indexertypes.VoteReference, error) {
 	txRef := &indexertypes.VoteReference{}
-	return txRef, s.db.FindOne(txRef, badgerhold.Where(badgerhold.Key).Eq(nullifier))
+	return txRef, s.db.FindOne(txRef, badgerhold.Where("Nullifier").Eq(nullifier))
 }
 
 // GetEnvelope retreives an Envelope from the Blockchain block store identified by its nullifier.
@@ -318,7 +318,7 @@ func (s *Scrutinizer) GetResults(processID []byte) (*indexertypes.Results, error
 	s.addVoteLock.RLock()
 	defer s.addVoteLock.RUnlock()
 	results := &indexertypes.Results{}
-	if err := s.db.FindOne(results, badgerhold.Where(badgerhold.Key).
+	if err := s.db.FindOne(results, badgerhold.Where("ProcessID").
 		Eq(processID)); err != nil {
 		if err == badgerhold.ErrNotFound {
 			return nil, ErrNoResultsYet
@@ -333,7 +333,7 @@ func (s *Scrutinizer) GetResultsWeight(processID []byte) (*big.Int, error) {
 	s.addVoteLock.RLock()
 	defer s.addVoteLock.RUnlock()
 	results := &indexertypes.Results{}
-	if err := s.db.FindOne(results, badgerhold.Where(badgerhold.Key).Eq(processID)); err != nil {
+	if err := s.db.FindOne(results, badgerhold.Where("ProcessID").Eq(processID)); err != nil {
 		return nil, err
 	}
 	return results.Weight, nil


### PR DESCRIPTION
the use of Badgerhold.Key can lead to really bad performance issues. This PR replaces Badgerhold.Key with the key itself (eg. "ID") for all badgerhold queries. 