### PR TITLE
scrutinizer: add results cache

### DIFF
--- a/db/lru/atomic.go
+++ b/db/lru/atomic.go
@@ -1,0 +1,76 @@
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// AtomicCache implements a least-recently-used cache that is safe for concurrent use.
+// All operations are atomic.
+type AtomicCache struct {
+	lruMu sync.Mutex
+	lru   simplelru.LRU
+}
+
+// NewAtomic creates a new Cache with a given maximum number of entries.
+func NewAtomic(size int) *AtomicCache {
+	lru, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		// simplelru.NewLRU will only error if size is negative.
+		// If that happens, panic, because our sizes should be static.
+		// Arguably, their API should take an uint, or just panic too.
+		panic(err)
+	}
+	return &AtomicCache{lru: *lru}
+}
+
+type entry struct {
+	valueMu sync.Mutex // while value is built or updated
+	value   interface{}
+}
+
+// GetAndUpdate is a high-level method to be used with cache entries which are
+// expensive to obtain from scratch.
+//
+// If the key is not in the cache, we insert a new entry into the cache, calling
+// updateValue(nil) to obtain the expensive value to be stored. Note that the global
+// cache mutex is not locked while updateValue is running.
+//
+// If the key is in the cache, we update its cached value by calling updateValue
+// on it, and return the new value. If updateValue was already working for that
+// entry, we wait for it to finish first.
+//
+// If existing entries shouldn't be updated, one can use an updateValue func
+// that simply returns its input parameter when it's non-nil.
+func (l *AtomicCache) GetAndUpdate(key interface{},
+	updateValue func(interface{}) interface{}) interface{} {
+	l.lruMu.Lock()
+
+	// If the value is in the cache, release the lock and return the value.
+	if prev, ok := l.lru.Get(key); ok {
+		l.lruMu.Unlock()
+
+		// After we release lruMu, wait for the value to be ready.
+		entry := prev.(*entry)
+		entry.valueMu.Lock()
+		defer entry.valueMu.Unlock()
+
+		entry.value = updateValue(entry.value)
+
+		return entry.value
+	}
+
+	// Insert an empty entry with a grabbed valueMu, and drop lruMu.
+	// If a GetOrUpdate call grabs the entry while we're building the value,
+	// they'll wait until our Done call below.
+	entry := &entry{}
+	entry.valueMu.Lock()
+	defer entry.valueMu.Unlock()
+	l.lru.Add(key, entry)
+	l.lruMu.Unlock()
+
+	// Once the value is ready, we can release valueMu.
+	entry.value = updateValue(nil)
+	return entry.value
+}

--- a/db/lru/lru.go
+++ b/db/lru/lru.go
@@ -1,74 +1,33 @@
 package lru
 
 import (
-	"sync"
-
-	"github.com/hashicorp/golang-lru/simplelru"
+	glru "github.com/hashicorp/golang-lru"
 )
 
 // Cache implements a least-recently-used cache that is safe for concurrent use.
 type Cache struct {
-	lruMu sync.Mutex
-	lru   simplelru.LRU
+	lru *glru.Cache
 }
 
-// New creates a new Cache with a given maximum number of entries.
+// New creates a new LRU Cache with a given maximum number of entries.
 func New(size int) *Cache {
-	lru, err := simplelru.NewLRU(size, nil)
+	lru, err := glru.New(size)
 	if err != nil {
-		// simplelru.NewLRU will only error if size is negative.
-		// If that happens, panic, because our sizes should be static.
-		// Arguably, their API should take an uint, or just panic too.
 		panic(err)
 	}
-	return &Cache{lru: *lru}
+	return &Cache{lru: lru}
 }
 
-type entry struct {
-	valueMu sync.Mutex // while value is built or updated
-	value   interface{}
+// Add inserts a new element to the cache
+func (l *Cache) Add(key, value interface{}) {
+	l.lru.Add(key, value)
 }
 
-// GetOrUpdate is a high-level method to be used with cache entries which are
-// expensive to obtain from scratch.
-//
-// If the key is not in the cache, we insert a new entry into the cache, calling
-// updateValue(nil) to obtain the expensive value to be stored. Note that the global
-// cache mutex is not locked while updateValue is running.
-//
-// If the key is in the cache, we update its cached value by calling updateValue
-// on it, and return the new value. If updateValue was already working for that
-// entry, we wait for it to finish first.
-//
-// If existing entries shouldn't be updated, one can use an updateValue func
-// that simply returns its input parameter when it's non-nil.
-func (l *Cache) GetOrUpdate(key interface{}, updateValue func(interface{}) interface{}) interface{} {
-	l.lruMu.Lock()
-
-	// If the value is in the cache, release the lock and return the value.
-	if prev, ok := l.lru.Get(key); ok {
-		l.lruMu.Unlock()
-
-		// After we release lruMu, wait for the value to be ready.
-		entry := prev.(*entry)
-		entry.valueMu.Lock()
-		defer entry.valueMu.Unlock()
-
-		entry.value = updateValue(entry.value)
-
-		return entry.value
+// Get retrives an element from the cache
+func (l *Cache) Get(key interface{}) interface{} {
+	value, ok := l.lru.Get(key)
+	if !ok {
+		return nil
 	}
-
-	// Insert an empty entry with a grabbed valueMu, and drop lruMu.
-	// If a GetOrUpdate call grabs the entry while we're building the value,
-	// they'll wait until our Done call below.
-	entry := &entry{}
-	entry.valueMu.Lock()
-	defer entry.valueMu.Unlock()
-	l.lru.Add(key, entry)
-	l.lruMu.Unlock()
-
-	// Once the value is ready, we can release valueMu.
-	entry.value = updateValue(nil)
-	return entry.value
+	return value
 }

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -113,7 +113,11 @@ func CheckProof(proof *models.Proof, censusOrigin models.CensusOrigin, censusRoo
 		hexamount := hexutil.Big(amount)
 		log.Debugf("validating erc20 storage proof for key %x and amount %s", p.Key, amount.String())
 		valid, err := ethstorageproof.VerifyEthStorageProof(
-			&ethstorageproof.StorageResult{Key: fmt.Sprintf("%x", p.Key), Proof: hexproof, Value: &hexamount},
+			&ethstorageproof.StorageResult{
+				Key:   fmt.Sprintf("%x", p.Key),
+				Proof: hexproof,
+				Value: &hexamount,
+			},
 			ethcommon.BytesToHash(censusRoot),
 		)
 		return valid, &amount, err


### PR DESCRIPTION
Once results are final we store them in a LRU cache.
If not final, they will be queried to the underlaying
kv store.

In addition remove an unnecessary check on GetResults

Signed-off-by: p4u <pau@dabax.net>