### PR TITLE
Tx indexer

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -267,6 +267,7 @@ type VochainStats struct {
 	EntityCount      int64     `json:"entity_count"`
 	EnvelopeCount    uint64    `json:"envelope_count"`
 	ProcessCount     int64     `json:"process_count"`
+	TransactionCount uint64    `json:"transaction_count"`
 	ValidatorCount   int       `json:"validator_count"`
 	BlockTime        [5]int32  `json:"block_time"`
 	BlockTimeStamp   int32     `json:"block_time_stamp"`

--- a/router/apis.go
+++ b/router/apis.go
@@ -88,6 +88,7 @@ func (r *Router) EnableIndexerAPI(vocapp *vochain.BaseApplication,
 	r.RegisterPublic("getBlockByHash", r.getBlockByHash)
 	r.RegisterPublic("getBlockList", r.getBlockList)
 	r.RegisterPublic("getTx", r.getTx)
+	r.RegisterPublic("getTxByHeight", r.getTxByHeight)
 	r.RegisterPublic("getValidatorList", r.getValidatorList)
 	r.RegisterPublic("getTxListForBlock", r.getTxListForBlock)
 }

--- a/router/indexerCallbacks.go
+++ b/router/indexerCallbacks.go
@@ -19,11 +19,11 @@ func (r *Router) getStats(request RouterRequest) {
 	stats.BlockTimeStamp = int32(r.vocapp.State.Header(true).Timestamp)
 	stats.EntityCount = int64(r.Scrutinizer.EntityCount())
 	if stats.EnvelopeCount, err = r.Scrutinizer.GetEnvelopeHeight([]byte{}); err != nil {
-		log.Warnf("could not count vote envelopes: %s", err)
+		r.SendError(request, fmt.Sprintf("could not count vote envelopes: (%s)", err))
 	}
 	stats.ProcessCount = int64(r.Scrutinizer.ProcessCount([]byte{}))
 	if stats.TransactionCount, err = r.Scrutinizer.TransactionCount(); err != nil {
-		log.Warnf("could not count transactions: %s", err)
+		r.SendError(request, fmt.Sprintf("could not count transactions: (%s)", err))
 	}
 	vals, _ := r.vocapp.State.Validators(true)
 	stats.ValidatorCount = len(vals)
@@ -35,7 +35,8 @@ func (r *Router) getStats(request RouterRequest) {
 	var response api.MetaResponse
 	response.Stats = stats
 	if err != nil {
-		log.Errorf("could not marshal vochainStats: %s", err)
+		r.SendError(request, fmt.Sprintf("could not marshal vochainStats: (%s)", err))
+		return
 	}
 	if err := request.Send(r.BuildReply(request, &response)); err != nil {
 		log.Warnf("error sending response: %s", err)

--- a/router/indexerCallbacks.go
+++ b/router/indexerCallbacks.go
@@ -22,7 +22,9 @@ func (r *Router) getStats(request RouterRequest) {
 		log.Warnf("could not count vote envelopes: %s", err)
 	}
 	stats.ProcessCount = int64(r.Scrutinizer.ProcessCount([]byte{}))
-	stats.TransactionCount = r.Scrutinizer.TransactionCount()
+	if stats.TransactionCount, err = r.Scrutinizer.TransactionCount(); err != nil {
+		log.Warnf("could not count transactions: %s", err)
+	}
 	vals, _ := r.vocapp.State.Validators(true)
 	stats.ValidatorCount = len(vals)
 	stats.BlockTime = *r.vocinfo.BlockTimes()

--- a/router/indexerCallbacks.go
+++ b/router/indexerCallbacks.go
@@ -148,6 +148,7 @@ func (r *Router) getTxByHeight(request RouterRequest) {
 	}
 	response.Tx = &indexertypes.TxPackage{
 		Tx:          tx.Tx,
+		Height:      uint32(txRef.Index),
 		Index:       int32(txRef.TxBlockIndex),
 		BlockHeight: txRef.BlockHeight,
 		Hash:        hash,

--- a/router/indexerCallbacks.go
+++ b/router/indexerCallbacks.go
@@ -17,11 +17,11 @@ func (r *Router) getStats(request RouterRequest) {
 	stats := new(api.VochainStats)
 	stats.BlockHeight = r.vocapp.Height()
 	stats.BlockTimeStamp = int32(r.vocapp.State.Header(true).Timestamp)
-	stats.EntityCount = r.Scrutinizer.EntityCount()
+	stats.EntityCount = int64(r.Scrutinizer.EntityCount())
 	if stats.EnvelopeCount, err = r.Scrutinizer.GetEnvelopeHeight([]byte{}); err != nil {
 		log.Warnf("could not count vote envelopes: %s", err)
 	}
-	stats.ProcessCount = r.Scrutinizer.ProcessCount([]byte{})
+	stats.ProcessCount = int64(r.Scrutinizer.ProcessCount([]byte{}))
 	vals, _ := r.vocapp.State.Validators(true)
 	stats.ValidatorCount = len(vals)
 	stats.BlockTime = *r.vocinfo.BlockTimes()

--- a/router/indexerCallbacks.go
+++ b/router/indexerCallbacks.go
@@ -141,14 +141,14 @@ func (r *Router) getTxByHeight(request RouterRequest) {
 			request.Height, err))
 		return
 	}
-	tx, hash, err := r.Scrutinizer.App.GetTxHash(txRef.BlockHeight, int32(txRef.Index))
+	tx, hash, err := r.Scrutinizer.App.GetTxHash(txRef.BlockHeight, int32(txRef.TxBlockIndex))
 	if err != nil {
 		r.SendError(request, fmt.Sprintf("cannot get tx: %v", err))
 		return
 	}
 	response.Tx = &indexertypes.TxPackage{
 		Tx:          tx.Tx,
-		Index:       int32(txRef.Index),
+		Index:       int32(txRef.TxBlockIndex),
 		BlockHeight: txRef.BlockHeight,
 		Hash:        hash,
 		Signature:   tx.Signature,

--- a/router/voteCallbacks.go
+++ b/router/voteCallbacks.go
@@ -254,7 +254,7 @@ func (r *Router) getProcessCount(request RouterRequest) {
 	var response api.MetaResponse
 	response.Size = new(int64)
 	count := r.Scrutinizer.ProcessCount(request.EntityId)
-	*response.Size = count
+	*response.Size = int64(count)
 	if err := request.Send(r.BuildReply(request, &response)); err != nil {
 		log.Warnf("error sending response: %s", err)
 	}
@@ -263,7 +263,7 @@ func (r *Router) getProcessCount(request RouterRequest) {
 func (r *Router) getEntityCount(request RouterRequest) {
 	var response api.MetaResponse
 	response.Size = new(int64)
-	*response.Size = r.Scrutinizer.EntityCount()
+	*response.Size = int64(r.Scrutinizer.EntityCount())
 	if err := request.Send(r.BuildReply(request, &response)); err != nil {
 		log.Warnf("error sending response: %s", err)
 	}

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -351,9 +351,7 @@ func (app *BaseApplication) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.
 			return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}
 		}
 		for _, e := range app.State.eventListeners {
-			if err := e.OnNewTx(app.Height()+1, app.State.TxCounter()); err != nil {
-				log.Warnf("deliverTx: %v", err)
-			}
+			e.OnNewTx(app.Height()+1, app.State.TxCounter())
 		}
 	} else {
 		return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -353,7 +353,7 @@ func (app *BaseApplication) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.
 		for _, e := range app.State.eventListeners {
 			err := e.OnNewTx(app.State.height+1, uint32(app.State.TxCounter()))
 			if err != nil {
-				log.Errorf("DeliverTx: %v", err)
+				log.Errorf("deliverTx: %v", err)
 			}
 		}
 	} else {

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -351,9 +351,8 @@ func (app *BaseApplication) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.
 			return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}
 		}
 		for _, e := range app.State.eventListeners {
-			err := e.OnNewTx(app.State.height+1, uint32(app.State.TxCounter()))
-			if err != nil {
-				log.Errorf("deliverTx: %v", err)
+			if err := e.OnNewTx(app.Height()+1, app.State.TxCounter()); err != nil {
+				log.Warnf("deliverTx: %v", err)
 			}
 		}
 	} else {

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -350,6 +350,9 @@ func (app *BaseApplication) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.
 			log.Debugf("rejected tx: %v", err)
 			return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}
 		}
+		for _, e := range app.State.eventListeners {
+			e.OnNewTx(uint32(app.State.TxCounter()), app.State.height)
+		}
 	} else {
 		return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}
 	}

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -351,7 +351,10 @@ func (app *BaseApplication) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.
 			return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}
 		}
 		for _, e := range app.State.eventListeners {
-			e.OnNewTx(app.State.height+1, uint32(app.State.TxCounter()))
+			err := e.OnNewTx(app.State.height+1, uint32(app.State.TxCounter()))
+			if err != nil {
+				log.Errorf("DeliverTx: %v", err)
+			}
 		}
 	} else {
 		return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -351,7 +351,7 @@ func (app *BaseApplication) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.
 			return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}
 		}
 		for _, e := range app.State.eventListeners {
-			e.OnNewTx(uint32(app.State.TxCounter()), app.State.height)
+			e.OnNewTx(app.State.height+1, uint32(app.State.TxCounter()))
 		}
 	} else {
 		return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}

--- a/vochain/censusdownloader/censusdownloader.go
+++ b/vochain/censusdownloader/censusdownloader.go
@@ -81,7 +81,7 @@ func (c *CensusDownloader) OnProcess(pid, eid []byte, censusRoot, censusURI stri
 // NOT USED but required for implementing the interface
 func (c *CensusDownloader) OnCancel(pid []byte, txindex int32)                       {}
 func (c *CensusDownloader) OnVote(v *models.Vote, txindex int32)                     {}
-func (c *CensusDownloader) OnNewTx(blockHeight, txIndex uint32)                      {}
+func (c *CensusDownloader) OnNewTx(blockHeight, txIndex uint32) error                { return nil }
 func (c *CensusDownloader) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}
 func (c *CensusDownloader) OnRevealKeys(pid []byte, priv, rev string, txindex int32) {}
 func (c *CensusDownloader) OnProcessStatusChange(pid []byte,

--- a/vochain/censusdownloader/censusdownloader.go
+++ b/vochain/censusdownloader/censusdownloader.go
@@ -81,7 +81,7 @@ func (c *CensusDownloader) OnProcess(pid, eid []byte, censusRoot, censusURI stri
 // NOT USED but required for implementing the interface
 func (c *CensusDownloader) OnCancel(pid []byte, txindex int32)                       {}
 func (c *CensusDownloader) OnVote(v *models.Vote, txindex int32)                     {}
-func (c *CensusDownloader) OnNewTx(blockHeight uint32, txIndex int32) error          { return nil }
+func (c *CensusDownloader) OnNewTx(blockHeight uint32, txIndex int32)                {}
 func (c *CensusDownloader) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}
 func (c *CensusDownloader) OnRevealKeys(pid []byte, priv, rev string, txindex int32) {}
 func (c *CensusDownloader) OnProcessStatusChange(pid []byte,

--- a/vochain/censusdownloader/censusdownloader.go
+++ b/vochain/censusdownloader/censusdownloader.go
@@ -81,7 +81,7 @@ func (c *CensusDownloader) OnProcess(pid, eid []byte, censusRoot, censusURI stri
 // NOT USED but required for implementing the interface
 func (c *CensusDownloader) OnCancel(pid []byte, txindex int32)                       {}
 func (c *CensusDownloader) OnVote(v *models.Vote, txindex int32)                     {}
-func (c *CensusDownloader) OnNewTx(blockHeight, txIndex uint32) error                { return nil }
+func (c *CensusDownloader) OnNewTx(blockHeight uint32, txIndex int32) error          { return nil }
 func (c *CensusDownloader) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}
 func (c *CensusDownloader) OnRevealKeys(pid []byte, priv, rev string, txindex int32) {}
 func (c *CensusDownloader) OnProcessStatusChange(pid []byte,

--- a/vochain/censusdownloader/censusdownloader.go
+++ b/vochain/censusdownloader/censusdownloader.go
@@ -81,6 +81,7 @@ func (c *CensusDownloader) OnProcess(pid, eid []byte, censusRoot, censusURI stri
 // NOT USED but required for implementing the interface
 func (c *CensusDownloader) OnCancel(pid []byte, txindex int32)                       {}
 func (c *CensusDownloader) OnVote(v *models.Vote, txindex int32)                     {}
+func (c *CensusDownloader) OnNewTx(blockHeight, txIndex uint32)                      {}
 func (c *CensusDownloader) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}
 func (c *CensusDownloader) OnRevealKeys(pid []byte, priv, rev string, txindex int32) {}
 func (c *CensusDownloader) OnProcessStatusChange(pid []byte,

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -257,9 +257,8 @@ func (k *KeyKeeper) OnVote(v *models.Vote, txindex int32) {
 }
 
 // OnNewTx is not used by the KeyKeeper
-func (k *KeyKeeper) OnNewTx(blockHeight uint32, txIndex int32) error {
+func (k *KeyKeeper) OnNewTx(blockHeight uint32, txIndex int32) {
 	// do nothing
-	return nil
 }
 
 // OnProcessStatusChange will publish the private

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -257,8 +257,9 @@ func (k *KeyKeeper) OnVote(v *models.Vote, txindex int32) {
 }
 
 // OnNewTx is not used by the KeyKeeper
-func (k *KeyKeeper) OnNewTx(blockHeight, txIndex uint32) {
+func (k *KeyKeeper) OnNewTx(blockHeight, txIndex uint32) error {
 	// do nothing
+	return nil
 }
 
 // OnProcessStatusChange will publish the private

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -256,6 +256,11 @@ func (k *KeyKeeper) OnVote(v *models.Vote, txindex int32) {
 	// do nothing
 }
 
+// OnNewTx is not used by the KeyKeeper
+func (k *KeyKeeper) OnNewTx(blockHeight, txIndex uint32) {
+	// do nothing
+}
+
 // OnProcessStatusChange will publish the private
 // and reveal keys of the ended process, if required
 func (k *KeyKeeper) OnProcessStatusChange(pid []byte, status models.ProcessStatus, txindex int32) {

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -257,7 +257,7 @@ func (k *KeyKeeper) OnVote(v *models.Vote, txindex int32) {
 }
 
 // OnNewTx is not used by the KeyKeeper
-func (k *KeyKeeper) OnNewTx(blockHeight, txIndex uint32) error {
+func (k *KeyKeeper) OnNewTx(blockHeight uint32, txIndex int32) error {
 	// do nothing
 	return nil
 }

--- a/vochain/processarchive/processarchive.go
+++ b/vochain/processarchive/processarchive.go
@@ -148,6 +148,9 @@ func (i *ProcessArchive) OnCancel(pid []byte, txindex int32) {}
 // OnCancOnVoteel does nothing
 func (i *ProcessArchive) OnVote(v *models.Vote, txindex int32) {}
 
+// OnNewTx does nothing
+func (i *ProcessArchive) OnNewTx(blockHeight, txIndex uint32) {}
+
 // OnProcessKeys does nothing
 func (i *ProcessArchive) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}
 

--- a/vochain/processarchive/processarchive.go
+++ b/vochain/processarchive/processarchive.go
@@ -149,7 +149,7 @@ func (i *ProcessArchive) OnCancel(pid []byte, txindex int32) {}
 func (i *ProcessArchive) OnVote(v *models.Vote, txindex int32) {}
 
 // OnNewTx does nothing
-func (i *ProcessArchive) OnNewTx(blockHeight, txIndex uint32) {}
+func (i *ProcessArchive) OnNewTx(blockHeight, txIndex uint32) error { return nil }
 
 // OnProcessKeys does nothing
 func (i *ProcessArchive) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}

--- a/vochain/processarchive/processarchive.go
+++ b/vochain/processarchive/processarchive.go
@@ -149,7 +149,7 @@ func (i *ProcessArchive) OnCancel(pid []byte, txindex int32) {}
 func (i *ProcessArchive) OnVote(v *models.Vote, txindex int32) {}
 
 // OnNewTx does nothing
-func (i *ProcessArchive) OnNewTx(blockHeight, txIndex uint32) error { return nil }
+func (i *ProcessArchive) OnNewTx(blockHeight uint32, txIndex int32) error { return nil }
 
 // OnProcessKeys does nothing
 func (i *ProcessArchive) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}

--- a/vochain/processarchive/processarchive.go
+++ b/vochain/processarchive/processarchive.go
@@ -149,7 +149,7 @@ func (i *ProcessArchive) OnCancel(pid []byte, txindex int32) {}
 func (i *ProcessArchive) OnVote(v *models.Vote, txindex int32) {}
 
 // OnNewTx does nothing
-func (i *ProcessArchive) OnNewTx(blockHeight uint32, txIndex int32) error { return nil }
+func (i *ProcessArchive) OnNewTx(blockHeight uint32, txIndex int32) {}
 
 // OnProcessKeys does nothing
 func (i *ProcessArchive) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -14,13 +14,13 @@ import (
 
 const (
 	// CountStore_Entities is the key for the entity count db reference
-	CountStore_Entities = 0
+	CountStore_Entities uint8 = 0
 	// CountStore_Processes is the key for the process count db reference
-	CountStore_Processes = 1
+	CountStore_Processes uint8 = 1
 	// CountStore_Envelopes is the key for the envelope count db reference
-	CountStore_Envelopes = 2
+	CountStore_Envelopes uint8 = 2
 	// CountStore_Transactions is the key for the transaction count db reference
-	CountStore_Transactions = 3
+	CountStore_Transactions uint8 = 3
 )
 
 // CountStore holds the count of envelopes, processes, entities, or transactions

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -13,10 +13,14 @@ import (
 )
 
 const (
-	Entities     = 0
-	Processes    = 1
-	Envelopes    = 2
-	Transactions = 3
+	// CountStore_Entities is the key for the entity count db reference
+	CountStore_Entities = 0
+	// CountStore_Processes is the key for the process count db reference
+	CountStore_Processes = 1
+	// CountStore_Envelopes is the key for the envelope count db reference
+	CountStore_Envelopes = 2
+	// CountStore_Transactions is the key for the transaction count db reference
+	CountStore_Transactions = 3
 )
 
 // CountStore holds the count of envelopes, processes, entities, or transactions

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -13,14 +13,14 @@ import (
 )
 
 const (
-	// CountStore_Entities is the key for the entity count db reference
-	CountStore_Entities uint8 = 0
-	// CountStore_Processes is the key for the process count db reference
-	CountStore_Processes uint8 = 1
-	// CountStore_Envelopes is the key for the envelope count db reference
-	CountStore_Envelopes uint8 = 2
-	// CountStore_Transactions is the key for the transaction count db reference
-	CountStore_Transactions uint8 = 3
+	// CountStoreEntities is the key for the entity count db reference
+	CountStoreEntities uint8 = 0
+	// CountStoreProcesses is the key for the process count db reference
+	CountStoreProcesses uint8 = 1
+	// CountStoreEnvelopes is the key for the envelope count db reference
+	CountStoreEnvelopes uint8 = 2
+	// CountStoreTransactions is the key for the transaction count db reference
+	CountStoreTransactions uint8 = 3
 )
 
 // CountStore holds the count of envelopes, processes, entities, or transactions

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -21,7 +21,7 @@ const (
 
 // CountStore holds the count of envelopes, processes, entities, or transactions
 type CountStore struct {
-	Type  int `badgerholdKey:"Type"`
+	Type  uint8 `badgerholdKey:"Type"`
 	Count uint64
 }
 
@@ -123,7 +123,7 @@ type TxMetadata struct {
 type TxReference struct {
 	Index        uint64 `badgerholdKey:"Index"`
 	BlockHeight  uint32
-	TxBlockIndex uint32
+	TxBlockIndex int32
 }
 
 // BlockMetadata contains the metadata for a single tendermint block

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -12,6 +12,19 @@ import (
 	"go.vocdoni.io/proto/build/go/models"
 )
 
+const (
+	Entities     = 0
+	Processes    = 1
+	Envelopes    = 2
+	Transactions = 3
+)
+
+// CountStore holds the count of envelopes, processes, entities, or transactions
+type CountStore struct {
+	Type  int `badgerholdKey:"Type"`
+	Count uint64
+}
+
 // Process represents an election process handled by the Vochain.
 // The scrutinizer Process data type is different from the vochain state data type
 // since it is optimized for querying purposes and not for keeping a shared consensus state.
@@ -103,6 +116,13 @@ type TxMetadata struct {
 	BlockHeight uint32         `json:"block_height,omitempty"`
 	Index       int32          `json:"index"`
 	Hash        types.HexBytes `json:"hash"`
+}
+
+// TxReference holds the db reference for a single transaction
+type TxReference struct {
+	Index        uint64 `badgerholdKey:"Index"`
+	BlockHeight  uint32
+	TxBlockIndex uint32
 }
 
 // BlockMetadata contains the metadata for a single tendermint block

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -14,13 +14,13 @@ import (
 
 const (
 	// CountStoreEntities is the key for the entity count db reference
-	CountStoreEntities uint8 = 0
+	CountStoreEntities = uint8(iota)
 	// CountStoreProcesses is the key for the process count db reference
-	CountStoreProcesses uint8 = 1
+	CountStoreProcesses
 	// CountStoreEnvelopes is the key for the envelope count db reference
-	CountStoreEnvelopes uint8 = 2
+	CountStoreEnvelopes
 	// CountStoreTransactions is the key for the transaction count db reference
-	CountStoreTransactions uint8 = 3
+	CountStoreTransactions
 )
 
 // CountStore holds the count of envelopes, processes, entities, or transactions

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -104,8 +104,9 @@ type EnvelopePackage struct {
 // TxPackage contains a SignedTx and auxiliary information for the Transaction api
 type TxPackage struct {
 	Tx          []byte         `json:"tx"`
-	BlockHeight uint32         `json:"block_height"`
-	Index       int32          `json:"index"`
+	Height      uint32         `json:"height,omitempty"`
+	BlockHeight uint32         `json:"block_height,omitempty"`
+	Index       int32          `json:"index,omitempty"`
 	Hash        types.HexBytes `json:"hash"`
 	Signature   types.HexBytes `json:"signature"`
 }

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -274,14 +274,16 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 	s.addVoteLock.Unlock()
 
 	// Increment the total process count storage
-	s.db.UpdateMatching(&indexertypes.CountStore{}, badgerhold.Where(badgerhold.Key).Eq(indexertypes.CountStore_Processes), func(record interface{}) error {
+	s.db.UpdateMatching(&indexertypes.CountStore{}, badgerhold.Where(badgerhold.Key).
+		Eq(indexertypes.CountStore_Processes), func(record interface{}) error {
 		update, ok := record.(*indexertypes.CountStore)
 		if !ok {
 			return fmt.Errorf("record isn't the correct type! Wanted CountStore, got %T", record)
 		}
 		update.Count++
 		return nil
-	})
+	},
+	)
 
 	// Get the block time from the Header
 	currentBlockTime := time.Unix(s.App.State.Header(false).Timestamp, 0)

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -153,7 +153,7 @@ func (s *Scrutinizer) ProcessList(entityID []byte,
 	return procs, err
 }
 
-// ProcessCount return the number of processes indexed
+// ProcessCount returns the number of processes indexed
 func (s *Scrutinizer) ProcessCount(entityID []byte) uint64 {
 	startTime := time.Now()
 	defer func() { log.Debugf("ProcessCount took %s", time.Since(startTime)) }()

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -154,19 +154,19 @@ func (s *Scrutinizer) ProcessList(entityID []byte,
 }
 
 // ProcessCount return the number of processes indexed
-func (s *Scrutinizer) ProcessCount(entityID []byte) int64 {
+func (s *Scrutinizer) ProcessCount(entityID []byte) uint64 {
 	startTime := time.Now()
 	defer func() { log.Debugf("ProcessCount took %s", time.Since(startTime)) }()
 	var c uint32
 	var err error
 	if len(entityID) == 0 {
 		// If no entity ID, return the cached count of all processes
-		return atomic.LoadInt64(&s.countTotalProcesses)
+		return atomic.LoadUint64(&s.countTotalProcesses)
 	}
 	if c, err = s.EntityProcessCount(entityID); err != nil {
 		log.Warnf("processCount: cannot fetch entity process count: %v", err)
 	}
-	return int64(c)
+	return uint64(c)
 }
 
 // EntityList returns the list of entities indexed by the scrutinizer
@@ -198,8 +198,8 @@ func (s *Scrutinizer) EntityProcessCount(entityId []byte) (uint32, error) {
 }
 
 // EntityCount return the number of entities indexed by the scrutinizer
-func (s *Scrutinizer) EntityCount() int64 {
-	return atomic.LoadInt64(&s.countTotalEntities)
+func (s *Scrutinizer) EntityCount() uint64 {
+	return atomic.LoadUint64(&s.countTotalEntities)
 }
 
 // Return whether a process must have live results or not
@@ -267,7 +267,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 	s.addVoteLock.Unlock()
 
 	// Increment the total process count cache
-	atomic.AddInt64(&s.countTotalProcesses, 1)
+	atomic.AddUint64(&s.countTotalProcesses, 1)
 
 	// Get the block time from the Header
 	currentBlockTime := time.Unix(s.App.State.Header(false).Timestamp, 0)
@@ -283,7 +283,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 		entity.ID = eid
 		entity.CreationTime = currentBlockTime
 		entity.ProcessCount = 0
-		atomic.AddInt64(&s.countTotalEntities, 1)
+		atomic.AddUint64(&s.countTotalEntities, 1)
 	}
 	// Increase the entity process count (and create new entity if does not exist)
 	entity.ProcessCount++

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -161,7 +161,7 @@ func (s *Scrutinizer) ProcessCount(entityID []byte) uint64 {
 	if len(entityID) == 0 {
 		// If no entity ID, return the stored count of all processes
 		processCountStore := &indexertypes.CountStore{}
-		if err = s.db.Get(indexertypes.CountStore_Processes, processCountStore); err != nil {
+		if err = s.db.Get(indexertypes.CountStoreProcesses, processCountStore); err != nil {
 			log.Warnf("could not get the process count: %v", err)
 		}
 		return processCountStore.Count
@@ -203,8 +203,9 @@ func (s *Scrutinizer) EntityProcessCount(entityId []byte) (uint32, error) {
 // EntityCount return the number of entities indexed by the scrutinizer
 func (s *Scrutinizer) EntityCount() uint64 {
 	entityCountStore := &indexertypes.CountStore{}
-	if err := s.db.Get(indexertypes.CountStore_Entities, entityCountStore); err != nil {
+	if err := s.db.Get(indexertypes.CountStoreEntities, entityCountStore); err != nil {
 		log.Warnf("could not get the process count: %v", err)
+		return 0
 	}
 	return entityCountStore.Count
 }
@@ -275,7 +276,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 
 	// Increment the total process count storage
 	s.db.UpdateMatching(&indexertypes.CountStore{}, badgerhold.Where(badgerhold.Key).
-		Eq(indexertypes.CountStore_Processes), func(record interface{}) error {
+		Eq(indexertypes.CountStoreProcesses), func(record interface{}) error {
 		update, ok := record.(*indexertypes.CountStore)
 		if !ok {
 			return fmt.Errorf("record isn't the correct type! Wanted CountStore, got %T", record)
@@ -300,7 +301,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 		entity.CreationTime = currentBlockTime
 		entity.ProcessCount = 0
 		// Increment the total entity count storage
-		s.db.UpdateMatching(&indexertypes.CountStore{}, badgerhold.Where(badgerhold.Key).Eq(indexertypes.CountStore_Entities), func(record interface{}) error {
+		s.db.UpdateMatching(&indexertypes.CountStore{}, badgerhold.Where(badgerhold.Key).Eq(indexertypes.CountStoreEntities), func(record interface{}) error {
 			update, ok := record.(*indexertypes.CountStore)
 			if !ok {
 				return fmt.Errorf("record isn't the correct type! Wanted CountStore, got %T", record)

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -162,12 +162,14 @@ func (s *Scrutinizer) ProcessCount(entityID []byte) uint64 {
 		// If no entity ID, return the stored count of all processes
 		processCountStore := &indexertypes.CountStore{}
 		if err = s.db.Get(indexertypes.CountStoreProcesses, processCountStore); err != nil {
-			log.Warnf("could not get the process count: %v", err)
+			log.Errorf("could not get the process count: %v", err)
+			return 0
 		}
 		return processCountStore.Count
 	}
 	if c, err = s.EntityProcessCount(entityID); err != nil {
-		log.Warnf("processCount: cannot fetch entity process count: %v", err)
+		log.Errorf("processCount: cannot fetch entity process count: %v", err)
+		return 0
 	}
 	return uint64(c)
 }
@@ -204,7 +206,7 @@ func (s *Scrutinizer) EntityProcessCount(entityId []byte) (uint32, error) {
 func (s *Scrutinizer) EntityCount() uint64 {
 	entityCountStore := &indexertypes.CountStore{}
 	if err := s.db.Get(indexertypes.CountStoreEntities, entityCountStore); err != nil {
-		log.Warnf("could not get the process count: %v", err)
+		log.Errorf("could not get the entity count: %v", err)
 		return 0
 	}
 	return entityCountStore.Count

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -99,27 +99,23 @@ func NewScrutinizer(dbPath string, app *vochain.BaseApplication) (*Scrutinizer, 
 	startTime := time.Now()
 
 	txCountStore := new(indexertypes.CountStore)
-	err = s.db.FindOne(txCountStore,
-		badgerhold.Where(badgerhold.Key).Eq(indexertypes.Transactions))
-	if err != nil {
+	if err = s.db.FindOne(txCountStore,
+		badgerhold.Where(badgerhold.Key).Eq(indexertypes.Transactions)); err != nil {
 		log.Warnf("could not get the transaction count: %v", err)
 	}
 	envelopeCountStore := new(indexertypes.CountStore)
-	err = s.db.FindOne(envelopeCountStore,
-		badgerhold.Where(badgerhold.Key).Eq(indexertypes.Envelopes))
-	if err != nil {
+	if err = s.db.FindOne(envelopeCountStore,
+		badgerhold.Where(badgerhold.Key).Eq(indexertypes.Envelopes)); err != nil {
 		log.Warnf("could not get the envelope count: %v", err)
 	}
 	processCountStore := new(indexertypes.CountStore)
-	err = s.db.FindOne(processCountStore,
-		badgerhold.Where(badgerhold.Key).Eq(indexertypes.Processes))
-	if err != nil {
+	if err = s.db.FindOne(processCountStore,
+		badgerhold.Where(badgerhold.Key).Eq(indexertypes.Processes)); err != nil {
 		log.Warnf("could not get the process count: %v", err)
 	}
 	entityCountStore := new(indexertypes.CountStore)
-	err = s.db.FindOne(entityCountStore,
-		badgerhold.Where(badgerhold.Key).Eq(indexertypes.Entities))
-	if err != nil {
+	if err = s.db.FindOne(entityCountStore,
+		badgerhold.Where(badgerhold.Key).Eq(indexertypes.Entities)); err != nil {
 		log.Warnf("could not get the entity count: %v", err)
 	}
 

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -153,14 +153,13 @@ func (s *Scrutinizer) retrieveCounts() (*indexertypes.CountStore,
 		log.Warnf("could not get the process count: %v", err)
 		count, err := s.db.Count(&indexertypes.Process{}, &badgerhold.Query{})
 		if err != nil {
-			log.Warnf("could not count total processes: %v", err)
-		} else {
-			// Store new countStore value
-			processCountStore.Count = uint64(count)
-			processCountStore.Type = indexertypes.CountStore_Processes
-			if err := s.db.Upsert(processCountStore.Type, processCountStore); err != nil {
-				log.Warnf("could not store process count: %v", err)
-			}
+			log.Fatalf("could not count total processes: %v", err)
+		}
+		// Store new countStore value
+		processCountStore.Count = uint64(count)
+		processCountStore.Type = indexertypes.CountStore_Processes
+		if err := s.db.Upsert(processCountStore.Type, processCountStore); err != nil {
+			log.Warnf("could not store process count: %v", err)
 		}
 	}
 	entityCountStore := new(indexertypes.CountStore)

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -256,6 +256,9 @@ func (s *Scrutinizer) Commit(height uint32) error {
 
 	// Index new transactions
 	for _, tx := range s.newTxPool {
+		// Add confirmed txs to transaction count
+		txCount := atomic.AddUint64(&s.countTotalTransactions, 1)
+		tx.Index = txCount
 		if err := s.db.Insert(tx.Index, tx); err != nil {
 			log.Errorf("cannot store tx at height %d: %v", tx.Index, err)
 		}

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -367,19 +367,6 @@ func (s *Scrutinizer) OnVote(v *models.Vote, txIndex int32) {
 	s.voteIndexPool = append(s.voteIndexPool, &VoteWithIndex{vote: v, txIndex: txIndex})
 }
 
-// OnNewTx does nothing
-func (s *Scrutinizer) OnNewTx(blockHeight, txIndex uint32) {
-	txCount := atomic.AddUint64(&s.countTotalTransactions, 1)
-	err := s.db.Insert(txCount, indexertypes.TxReference{
-		Index:        txCount,
-		BlockHeight:  blockHeight,
-		TxBlockIndex: txIndex,
-	})
-	if err != nil {
-		log.Errorf("cannot store tx at height %d: %v", txCount, err)
-	}
-}
-
 // OnCancel scrutinizer stores the processID and entityID
 func (s *Scrutinizer) OnCancel(pid []byte, txIndex int32) {
 	s.updateProcessPool = append(s.updateProcessPool, pid)

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -99,7 +99,7 @@ func NewScrutinizer(dbPath string, app *vochain.BaseApplication) (*Scrutinizer, 
 	}
 	startTime := time.Now()
 
-	txCountStore, envelopeCountStore, processCountStore, entityCountStore, err := s.retrieveCounts()
+	countMap, err := s.retrieveCounts()
 	if err != nil {
 		return nil, fmt.Errorf("could not create scrutinizer: %v", err)
 	}
@@ -107,10 +107,10 @@ func NewScrutinizer(dbPath string, app *vochain.BaseApplication) (*Scrutinizer, 
 	log.Infof("indexer initialization took %s, stored %d "+
 		"transactions, %d envelopes, %d processes and %d entities",
 		time.Since(startTime),
-		txCountStore.Count,
-		envelopeCountStore.Count,
-		processCountStore.Count,
-		entityCountStore.Count)
+		countMap[indexertypes.CountStoreTransactions],
+		countMap[indexertypes.CountStoreEnvelopes],
+		countMap[indexertypes.CountStoreProcesses],
+		countMap[indexertypes.CountStoreEntities])
 	// Subscrive to events
 	s.App.State.AddEventListener(s)
 	s.envelopeHeightCache = lru.New(countEnvelopeCacheSize)
@@ -120,8 +120,7 @@ func NewScrutinizer(dbPath string, app *vochain.BaseApplication) (*Scrutinizer, 
 
 // retrieveCounts returns a count for txs, envelopes, processes, and entities, in that order.
 // If no CountStore model is stored for the type, it counts all db entries of that type.
-func (s *Scrutinizer) retrieveCounts() (*indexertypes.CountStore,
-	*indexertypes.CountStore, *indexertypes.CountStore, *indexertypes.CountStore, error) {
+func (s *Scrutinizer) retrieveCounts() (map[uint8]uint64, error) {
 	var err error
 	txCountStore := new(indexertypes.CountStore)
 	if err = s.db.Get(indexertypes.CountStoreTransactions, txCountStore); err != nil {
@@ -129,7 +128,7 @@ func (s *Scrutinizer) retrieveCounts() (*indexertypes.CountStore,
 		count, err := s.db.Count(&indexertypes.TxReference{}, &badgerhold.Query{})
 		if err != nil {
 			if err != badger.ErrKeyNotFound {
-				return nil, nil, nil, nil, fmt.Errorf("could not count total transactions: %v", err)
+				return nil, fmt.Errorf("could not count total transactions: %v", err)
 			}
 			// If keyNotFound error, ensure count is 0
 			count = 0
@@ -138,67 +137,57 @@ func (s *Scrutinizer) retrieveCounts() (*indexertypes.CountStore,
 		txCountStore.Count = uint64(count)
 		txCountStore.Type = indexertypes.CountStoreTransactions
 		if err := s.db.Upsert(txCountStore.Type, txCountStore); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("could not store transaction count: %v", err)
+			return nil, fmt.Errorf("could not store transaction count: %v", err)
 		}
 	}
 	envelopeCountStore := new(indexertypes.CountStore)
 	if err = s.db.Get(indexertypes.CountStoreEnvelopes, envelopeCountStore); err != nil {
 		log.Warnf("could not get the envelope count: %v", err)
 		count, err := s.db.Count(&indexertypes.VoteReference{}, &badgerhold.Query{})
-		if err != nil {
-
-			if err != badger.ErrKeyNotFound {
-				return nil, nil, nil, nil, fmt.Errorf("could not count total envelopes: %v", err)
-			}
-			// If keyNotFound error, ensure count is 0
-			count = 0
+		if err != nil && err != badger.ErrKeyNotFound {
+			return nil, fmt.Errorf("could not count total envelopes: %v", err)
 		}
 		// Store new countStore value
 		envelopeCountStore.Count = uint64(count)
 		envelopeCountStore.Type = indexertypes.CountStoreEnvelopes
 		if err := s.db.Upsert(envelopeCountStore.Type, envelopeCountStore); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("could not store envelope count: %v", err)
+			return nil, fmt.Errorf("could not store envelope count: %v", err)
 		}
 	}
 	processCountStore := new(indexertypes.CountStore)
 	if err = s.db.Get(indexertypes.CountStoreProcesses, processCountStore); err != nil {
 		log.Warnf("could not get the process count: %v", err)
 		count, err := s.db.Count(&indexertypes.Process{}, &badgerhold.Query{})
-		if err != nil {
-
-			if err != badger.ErrKeyNotFound {
-				return nil, nil, nil, nil, fmt.Errorf("could not count total processes: %v", err)
-			}
-			// If keyNotFound error, ensure count is 0
-			count = 0
+		if err != nil && err != badger.ErrKeyNotFound {
+			return nil, fmt.Errorf("could not count total processes: %v", err)
 		}
 		// Store new countStore value
 		processCountStore.Count = uint64(count)
 		processCountStore.Type = indexertypes.CountStoreProcesses
 		if err := s.db.Upsert(processCountStore.Type, processCountStore); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("could not store process count: %v", err)
+			return nil, fmt.Errorf("could not store process count: %v", err)
 		}
 	}
 	entityCountStore := new(indexertypes.CountStore)
 	if err = s.db.Get(indexertypes.CountStoreEntities, entityCountStore); err != nil {
 		log.Warnf("could not get the entity count: %v", err)
 		count, err := s.db.Count(&indexertypes.Entity{}, &badgerhold.Query{})
-		if err != nil {
-
-			if err != badger.ErrKeyNotFound {
-				return nil, nil, nil, nil, fmt.Errorf("could not count total entities: %v", err)
-			}
-			// If keyNotFound error, ensure count is 0
-			count = 0
+		if err != nil && err != badger.ErrKeyNotFound {
+			return nil, fmt.Errorf("could not count total entities: %v", err)
 		}
 		// Store new countStore value
 		entityCountStore.Count = uint64(count)
 		entityCountStore.Type = indexertypes.CountStoreEntities
 		if err := s.db.Upsert(entityCountStore.Type, entityCountStore); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("could not store entity count: %v", err)
+			return nil, fmt.Errorf("could not store entity count: %v", err)
 		}
 	}
-	return txCountStore, envelopeCountStore, processCountStore, entityCountStore, nil
+	return map[uint8]uint64{
+		indexertypes.CountStoreTransactions: txCountStore.Count,
+		indexertypes.CountStoreEnvelopes:    envelopeCountStore.Count,
+		indexertypes.CountStoreProcesses:    processCountStore.Count,
+		indexertypes.CountStoreEntities:     entityCountStore.Count,
+	}, nil
 }
 
 // AfterSyncBootstrap is a blocking function that waits until the Vochain is synchronized

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -15,7 +15,7 @@ import (
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/dvote/vochain/scrutinizer/indexertypes"
-	"go.vocdoni.io/proto/build/go/models"
+	models "go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -952,4 +952,29 @@ func TestCountVotes(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, ref.Height, qt.CmpEquals(), blockHeight)
 	qt.Assert(t, ref.TxIndex, qt.CmpEquals(), txIndex)
+}
+
+func TestTxIndexer(t *testing.T) {
+	app, err := vochain.NewBaseApplication(t.TempDir())
+	qt.Assert(t, err, qt.IsNil)
+
+	sc, err := NewScrutinizer(t.TempDir(), app)
+	qt.Assert(t, err, qt.IsNil)
+	app.SetTestingMethods()
+
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 10; j++ {
+			err := sc.OnNewTx(uint32(i), uint32(j))
+			qt.Assert(t, err, qt.IsNil)
+		}
+	}
+
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 10; j++ {
+			ref, err := sc.GetTxReference(uint64(i*10 + j + 1))
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, ref.BlockHeight, qt.CmpEquals(), uint32(i))
+			qt.Assert(t, ref.TxBlockIndex, qt.CmpEquals(), uint32(j))
+		}
+	}
 }

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -51,7 +51,7 @@ func testEntityList(t *testing.T, entityCount int) {
 		}
 	}
 	entities := make(map[string]bool)
-	if ec := sc.EntityCount(); ec != int64(entityCount) {
+	if ec := sc.EntityCount(); ec != uint64(entityCount) {
 		t.Fatalf("entity count is wrong, got %d expected %d", ec, entityCount)
 	}
 	var list []string

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -968,6 +969,7 @@ func TestTxIndexer(t *testing.T) {
 		}
 	}
 	qt.Assert(t, sc.Commit(0), qt.IsNil)
+	time.Sleep(3 * time.Second)
 
 	for i := 0; i < 10; i++ {
 		for j := 0; j < 10; j++ {

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -964,7 +964,7 @@ func TestTxIndexer(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		for j := 0; j < 10; j++ {
-			err := sc.OnNewTx(uint32(i), uint32(j))
+			err := sc.OnNewTx(uint32(i), int32(j))
 			qt.Assert(t, err, qt.IsNil)
 		}
 	}
@@ -973,8 +973,8 @@ func TestTxIndexer(t *testing.T) {
 		for j := 0; j < 10; j++ {
 			ref, err := sc.GetTxReference(uint64(i*10 + j + 1))
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, ref.BlockHeight, qt.CmpEquals(), uint32(i))
-			qt.Assert(t, ref.TxBlockIndex, qt.CmpEquals(), uint32(j))
+			qt.Assert(t, ref.BlockHeight, qt.Equals, uint32(i))
+			qt.Assert(t, ref.TxBlockIndex, qt.Equals, int32(j))
 		}
 	}
 }

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -964,10 +964,10 @@ func TestTxIndexer(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		for j := 0; j < 10; j++ {
-			err := sc.OnNewTx(uint32(i), int32(j))
-			qt.Assert(t, err, qt.IsNil)
+			sc.OnNewTx(uint32(i), int32(j))
 		}
 	}
+	sc.Commit(0)
 
 	for i := 0; i < 10; i++ {
 		for j := 0; j < 10; j++ {

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -967,7 +967,7 @@ func TestTxIndexer(t *testing.T) {
 			sc.OnNewTx(uint32(i), int32(j))
 		}
 	}
-	sc.Commit(0)
+	qt.Assert(t, sc.Commit(0), qt.IsNil)
 
 	for i := 0; i < 10; i++ {
 		for j := 0; j < 10; j++ {

--- a/vochain/scrutinizer/transaction.go
+++ b/vochain/scrutinizer/transaction.go
@@ -2,15 +2,18 @@ package scrutinizer
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/timshannon/badgerhold/v3"
 	"go.vocdoni.io/dvote/vochain/scrutinizer/indexertypes"
 )
 
 // TransactionCount returns the number of transactions indexed
-func (s *Scrutinizer) TransactionCount() uint64 {
-	return atomic.LoadUint64(&s.countTotalTransactions)
+func (s *Scrutinizer) TransactionCount() (uint64, error) {
+	txCountStore := &indexertypes.CountStore{}
+	if err := s.db.Get(indexertypes.CountStore_Transactions, txCountStore); err != nil {
+		return txCountStore.Count, err
+	}
+	return txCountStore.Count, nil
 }
 
 // GetTxReference fetches the txReference for the given tx height

--- a/vochain/scrutinizer/transaction.go
+++ b/vochain/scrutinizer/transaction.go
@@ -25,9 +25,7 @@ func (s *Scrutinizer) GetTxReference(height uint64) (*indexertypes.TxReference, 
 
 // OnNewTx stores the transaction reference in the indexer database
 func (s *Scrutinizer) OnNewTx(blockHeight uint32, txIndex int32) {
-	txCount := atomic.AddUint64(&s.countTotalTransactions, 1)
 	s.newTxPool = append(s.newTxPool, &indexertypes.TxReference{
-		Index:        txCount,
 		BlockHeight:  blockHeight,
 		TxBlockIndex: txIndex,
 	})

--- a/vochain/scrutinizer/transaction.go
+++ b/vochain/scrutinizer/transaction.go
@@ -24,14 +24,13 @@ func (s *Scrutinizer) GetTxReference(height uint64) (*indexertypes.TxReference, 
 }
 
 // OnNewTx stores the transaction reference in the indexer database
-func (s *Scrutinizer) OnNewTx(blockHeight, txIndex uint32) error {
+func (s *Scrutinizer) OnNewTx(blockHeight uint32, txIndex int32) error {
 	txCount := atomic.AddUint64(&s.countTotalTransactions, 1)
-	err := s.db.Insert(txCount, &indexertypes.TxReference{
+	if err := s.db.Insert(txCount, &indexertypes.TxReference{
 		Index:        txCount,
 		BlockHeight:  blockHeight,
 		TxBlockIndex: txIndex,
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("cannot store tx at height %d: %v", txCount, err)
 	}
 	return nil

--- a/vochain/scrutinizer/transaction.go
+++ b/vochain/scrutinizer/transaction.go
@@ -24,14 +24,11 @@ func (s *Scrutinizer) GetTxReference(height uint64) (*indexertypes.TxReference, 
 }
 
 // OnNewTx stores the transaction reference in the indexer database
-func (s *Scrutinizer) OnNewTx(blockHeight uint32, txIndex int32) error {
+func (s *Scrutinizer) OnNewTx(blockHeight uint32, txIndex int32) {
 	txCount := atomic.AddUint64(&s.countTotalTransactions, 1)
-	if err := s.db.Insert(txCount, &indexertypes.TxReference{
+	s.newTxPool = append(s.newTxPool, &indexertypes.TxReference{
 		Index:        txCount,
 		BlockHeight:  blockHeight,
 		TxBlockIndex: txIndex,
-	}); err != nil {
-		return fmt.Errorf("cannot store tx at height %d: %v", txCount, err)
-	}
-	return nil
+	})
 }

--- a/vochain/scrutinizer/transaction.go
+++ b/vochain/scrutinizer/transaction.go
@@ -1,0 +1,38 @@
+package scrutinizer
+
+import (
+	"sync/atomic"
+
+	"github.com/timshannon/badgerhold/v3"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/vochain/scrutinizer/indexertypes"
+)
+
+// TransactionCount returns the number of transactions indexed
+func (s *Scrutinizer) TransactionCount() uint64 {
+	return atomic.LoadUint64(&s.countTotalTransactions)
+}
+
+// GetTxReference fetches the txReference for the given tx height
+func (s *Scrutinizer) GetTxReference(height uint64) (*indexertypes.TxReference, error) {
+	txReference := &indexertypes.TxReference{}
+	err := s.db.FindOne(txReference, badgerhold.Where(badgerhold.Key).Eq(height))
+	if err != nil {
+		return nil, err
+	}
+	return txReference, nil
+}
+
+// OnNewTx stores the transaction reference in the indexer database
+func (s *Scrutinizer) OnNewTx(blockHeight, txIndex uint32) {
+	txCount := atomic.AddUint64(&s.countTotalTransactions, 1)
+	log.Debugf("Storing tx %d: block %d tx %d", txCount, blockHeight, txIndex)
+	err := s.db.Insert(txCount, &indexertypes.TxReference{
+		Index:        txCount,
+		BlockHeight:  blockHeight,
+		TxBlockIndex: txIndex,
+	})
+	if err != nil {
+		log.Errorf("cannot store tx at height %d: %v", txCount, err)
+	}
+}

--- a/vochain/scrutinizer/transaction.go
+++ b/vochain/scrutinizer/transaction.go
@@ -38,20 +38,24 @@ func (s *Scrutinizer) OnNewTx(blockHeight uint32, txIndex int32) {
 // indexNewTxs indexes the txs pending in the newTxPool and updates the transaction count
 // this function should only be called within Commit(), on a new block.
 func (s *Scrutinizer) indexNewTxs(txList []*indexertypes.TxReference) {
-	txCount := &indexertypes.CountStore{}
-	if err := s.db.Get(indexertypes.CountStore_Transactions, txCount); err != nil {
-		log.Errorf("could not get tx count: %v", err)
-	}
-	for i, tx := range txList {
-		// Add confirmed txs to transaction count
-		tx.Index = txCount.Count + uint64(i) + 1 // Start indexing at 1
-		if err := s.db.Insert(tx.Index, tx); err != nil {
-			log.Errorf("cannot store tx at height %d: %v", tx.Index, err)
+	if len(txList) > 0 {
+		s.txIndexLock.Lock()
+		txCount := &indexertypes.CountStore{}
+		if err := s.db.Get(indexertypes.CountStore_Transactions, txCount); err != nil {
+			log.Errorf("could not get tx count: %v", err)
 		}
-	}
-	// Store new transaction count
-	txCount.Count += uint64(len(txList))
-	if err := s.db.Upsert(indexertypes.CountStore_Transactions, txCount); err != nil {
-		log.Errorf("could not update tx count: %v", err)
+		for i, tx := range txList {
+			// Add confirmed txs to transaction count
+			tx.Index = txCount.Count + uint64(i) + 1 // Start indexing at 1
+			if err := s.db.Insert(tx.Index, tx); err != nil {
+				log.Errorf("cannot store tx at height %d: %v", tx.Index, err)
+			}
+		}
+		// Store new transaction count
+		txCount.Count += uint64(len(txList))
+		if err := s.db.Upsert(indexertypes.CountStore_Transactions, txCount); err != nil {
+			log.Errorf("could not update tx count: %v", err)
+		}
+		s.txIndexLock.Unlock()
 	}
 }

--- a/vochain/scrutinizer/transaction.go
+++ b/vochain/scrutinizer/transaction.go
@@ -11,7 +11,7 @@ import (
 // TransactionCount returns the number of transactions indexed
 func (s *Scrutinizer) TransactionCount() (uint64, error) {
 	txCountStore := &indexertypes.CountStore{}
-	if err := s.db.Get(indexertypes.CountStore_Transactions, txCountStore); err != nil {
+	if err := s.db.Get(indexertypes.CountStoreTransactions, txCountStore); err != nil {
 		return txCountStore.Count, err
 	}
 	return txCountStore.Count, nil
@@ -41,7 +41,7 @@ func (s *Scrutinizer) indexNewTxs(txList []*indexertypes.TxReference) {
 	if len(txList) > 0 {
 		s.txIndexLock.Lock()
 		txCount := &indexertypes.CountStore{}
-		if err := s.db.Get(indexertypes.CountStore_Transactions, txCount); err != nil {
+		if err := s.db.Get(indexertypes.CountStoreTransactions, txCount); err != nil {
 			log.Errorf("could not get tx count: %v", err)
 		}
 		for i, tx := range txList {
@@ -53,7 +53,7 @@ func (s *Scrutinizer) indexNewTxs(txList []*indexertypes.TxReference) {
 		}
 		// Store new transaction count
 		txCount.Count += uint64(len(txList))
-		if err := s.db.Upsert(indexertypes.CountStore_Transactions, txCount); err != nil {
+		if err := s.db.Upsert(indexertypes.CountStoreTransactions, txCount); err != nil {
 			log.Errorf("could not update tx count: %v", err)
 		}
 		s.txIndexLock.Unlock()

--- a/vochain/scrutinizer/transaction.go
+++ b/vochain/scrutinizer/transaction.go
@@ -18,7 +18,7 @@ func (s *Scrutinizer) GetTxReference(height uint64) (*indexertypes.TxReference, 
 	txReference := &indexertypes.TxReference{}
 	err := s.db.FindOne(txReference, badgerhold.Where(badgerhold.Key).Eq(height))
 	if err != nil {
-		return nil, fmt.Errorf("Tx height %d not found: %v", height, err)
+		return nil, fmt.Errorf("tx height %d not found: %v", height, err)
 	}
 	return txReference, nil
 }

--- a/vochain/scrutinizer/vote.go
+++ b/vochain/scrutinizer/vote.go
@@ -219,8 +219,8 @@ func (s *Scrutinizer) GetEnvelopeHeight(processID []byte) (uint64, error) {
 	if len(processID) == 0 {
 		// If no processID is provided, count all envelopes
 		envelopeCountStore := &indexertypes.CountStore{}
-		if err := s.db.Get(indexertypes.CountStore_Envelopes, envelopeCountStore); err != nil {
-			return envelopeCountStore.Count, err
+		if err := s.db.Get(indexertypes.CountStoreEnvelopes, envelopeCountStore); err != nil {
+			return 0, err
 		}
 		return envelopeCountStore.Count, nil
 	}

--- a/vochain/scrutinizer/vote.go
+++ b/vochain/scrutinizer/vote.go
@@ -218,7 +218,11 @@ func (s *Scrutinizer) GetEnvelopeHeight(processID []byte) (uint64, error) {
 	defer func() { log.Debugf("GetEnvelopeHeight took %s", time.Since(startTime)) }()
 	if len(processID) == 0 {
 		// If no processID is provided, count all envelopes
-		return atomic.LoadUint64(&s.countTotalEnvelopes), nil
+		envelopeCountStore := &indexertypes.CountStore{}
+		if err := s.db.Get(indexertypes.CountStore_Envelopes, envelopeCountStore); err != nil {
+			return envelopeCountStore.Count, err
+		}
+		return envelopeCountStore.Count, nil
 	}
 	// Check if the envelope height is cached
 	val := s.envelopeHeightCache.Get(string(processID))

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -38,7 +38,7 @@ import (
 // valid or not since the Vochain State do not validate results.
 type EventListener interface {
 	OnVote(vote *models.Vote, txIndex int32)
-	OnNewTx(blockHeight, txIndex uint32)
+	OnNewTx(blockHeight, txIndex uint32) error
 	OnProcess(pid, eid []byte, censusRoot, censusURI string, txIndex int32)
 	OnProcessStatusChange(pid []byte, status models.ProcessStatus, txIndex int32)
 	OnCancel(pid []byte, txIndex int32)

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -38,7 +38,7 @@ import (
 // valid or not since the Vochain State do not validate results.
 type EventListener interface {
 	OnVote(vote *models.Vote, txIndex int32)
-	OnNewTx(blockHeight, txIndex uint32) error
+	OnNewTx(blockHeight uint32, txIndex int32) error
 	OnProcess(pid, eid []byte, censusRoot, censusURI string, txIndex int32)
 	OnProcessStatusChange(pid []byte, status models.ProcessStatus, txIndex int32)
 	OnCancel(pid []byte, txIndex int32)

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -38,7 +38,7 @@ import (
 // valid or not since the Vochain State do not validate results.
 type EventListener interface {
 	OnVote(vote *models.Vote, txIndex int32)
-	OnNewTx(blockHeight uint32, txIndex int32) error
+	OnNewTx(blockHeight uint32, txIndex int32)
 	OnProcess(pid, eid []byte, censusRoot, censusURI string, txIndex int32)
 	OnProcessStatusChange(pid []byte, status models.ProcessStatus, txIndex int32)
 	OnCancel(pid []byte, txIndex int32)

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -38,6 +38,7 @@ import (
 // valid or not since the Vochain State do not validate results.
 type EventListener interface {
 	OnVote(vote *models.Vote, txIndex int32)
+	OnNewTx(blockHeight, txIndex uint32)
 	OnProcess(pid, eid []byte, censusRoot, censusURI string, txIndex int32)
 	OnProcessStatusChange(pid []byte, status models.ProcessStatus, txIndex int32)
 	OnCancel(pid []byte, txIndex int32)


### PR DESCRIPTION
Indexes transactions on the scrutinizer.

Store `TxReference`s containing each tx's height, blockHeight, and txIndex. 
Also provides the getTxByHeight api, allowing transactions to be queried by transaction height, not just block/txIndex