### PR TITLE
Indexer db transaction wrapper

### DIFF
--- a/vochain/scrutinizer/db.go
+++ b/vochain/scrutinizer/db.go
@@ -30,7 +30,8 @@ func InitDB(dataDir string) (*badgerhold.Store, error) {
 }
 
 func (s *Scrutinizer) updateMatchingWithoutTxConflicts(datatype interface{},
-	query *badgerhold.Query, update func(record interface{}) error, maxTries int) error {
+	query *badgerhold.Query, update func(record interface{}) error) error {
+	maxTries := 1000
 	for {
 		if err := s.db.UpdateMatching(datatype,
 			query,
@@ -45,6 +46,42 @@ func (s *Scrutinizer) updateMatchingWithoutTxConflicts(datatype interface{},
 				continue
 			}
 			return fmt.Errorf("cannot update record: %w, ", err)
+		}
+		return nil
+	}
+}
+
+func (s *Scrutinizer) upsertWithoutTxConflicts(key interface{}, data interface{}) error {
+	maxTries := 1000
+	for {
+		if err := s.db.Upsert(key, data); err != nil {
+			if strings.Contains(err.Error(), kvErrorStringForRetry) {
+				maxTries--
+				if maxTries == 0 {
+					return fmt.Errorf("cannot update record: max retires reached")
+				}
+				time.Sleep(time.Millisecond * 5)
+				continue
+			}
+			return fmt.Errorf("cannot update record %v: %w, ", key, err)
+		}
+		return nil
+	}
+}
+
+func (s *Scrutinizer) insertWithoutTxConflicts(key interface{}, data interface{}) error {
+	maxTries := 1000
+	for {
+		if err := s.db.Insert(key, data); err != nil {
+			if strings.Contains(err.Error(), kvErrorStringForRetry) {
+				maxTries--
+				if maxTries == 0 {
+					return fmt.Errorf("cannot update record: max retires reached")
+				}
+				time.Sleep(time.Millisecond * 5)
+				continue
+			}
+			return fmt.Errorf("cannot update record %v: %w, ", key, err)
 		}
 		return nil
 	}

--- a/vochain/scrutinizer/db.go
+++ b/vochain/scrutinizer/db.go
@@ -1,8 +1,19 @@
 package scrutinizer
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/timshannon/badgerhold/v3"
 )
+
+// The string to search on the KV database error to identify a transaction conflict.
+// If the KV (currently badger) returns this error, it is considered non fatal and the
+// transaction will be retried until it works.
+// This check is made comparing string in order to avoid importing a specific KV
+// implementation.
+const kvErrorStringForRetry = "Transaction Conflict"
 
 // InitDB initializes a badgerhold db at the location given by dataDir
 func InitDB(dataDir string) (*badgerhold.Store, error) {
@@ -16,4 +27,25 @@ func InitDB(dataDir string) (*badgerhold.Store, error) {
 	opts.ValueDir = dataDir
 	// TO-DO set custom logger
 	return badgerhold.Open(opts)
+}
+
+func (s *Scrutinizer) updateMatchingWithoutTxConflicts(datatype interface{},
+	query *badgerhold.Query, update func(record interface{}) error, maxTries int) error {
+	for {
+		if err := s.db.UpdateMatching(datatype,
+			query,
+			update,
+		); err != nil {
+			if strings.Contains(err.Error(), kvErrorStringForRetry) {
+				maxTries--
+				if maxTries == 0 {
+					return fmt.Errorf("cannot update record: max retires reached")
+				}
+				time.Sleep(time.Millisecond * 5)
+				continue
+			}
+			return fmt.Errorf("cannot update record: %w, ", err)
+		}
+		return nil
+	}
 }

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -252,7 +252,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 
 	// Create results in the indexer database
 	s.addVoteLock.Lock()
-	if err := s.db.Insert(pid, &indexertypes.Results{
+	if err := s.insertWithoutTxConflicts(pid, &indexertypes.Results{
 		ProcessID: pid,
 		// MaxValue requires +1 since 0 is also an option
 		Votes:        indexertypes.NewEmptyVotes(int(options.MaxCount), int(options.MaxValue)+1),
@@ -287,7 +287,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 	}
 	// Increase the entity process count (and create new entity if does not exist)
 	entity.ProcessCount++
-	if err := s.db.Upsert(eid, entity); err != nil {
+	if err := s.upsertWithoutTxConflicts(eid, entity); err != nil {
 		return err
 	}
 
@@ -325,7 +325,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 		EntityIndex:       entity.ProcessCount,
 	}
 	log.Debugf("new indexer process %s", proc.String())
-	return s.db.Insert(pid, proc)
+	return s.insertWithoutTxConflicts(pid, proc)
 }
 
 // updateProcess synchronize those fields that can be updated on a existing process
@@ -364,7 +364,7 @@ func (s *Scrutinizer) updateProcess(pid []byte) error {
 		return nil
 	}
 	return s.updateMatchingWithoutTxConflicts(&indexertypes.Process{},
-		badgerhold.Where(badgerhold.Key).Eq(pid), updateFunc, 1000)
+		badgerhold.Where(badgerhold.Key).Eq(pid), updateFunc)
 }
 
 // setResultsHeight updates the Rheight of any process whose ID is pid.
@@ -377,8 +377,7 @@ func (s *Scrutinizer) setResultsHeight(pid []byte, height uint32) error {
 			}
 			update.Rheight = height
 			return nil
-		},
-		1000)
+		})
 }
 
 // searchMatchFunc generates a function which compares a badgerhold record against searchTerm.

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -179,7 +179,7 @@ func (s *Scrutinizer) AfterSyncBootstrap() {
 			continue
 		}
 		options := process.GetVoteOptions()
-		if err := s.db.Upsert(p, &indexertypes.Results{
+		if err := s.upsertWithoutTxConflicts(p, &indexertypes.Results{
 			ProcessID: p,
 			// MaxValue requires +1 since 0 is also an option
 			Votes:        indexertypes.NewEmptyVotes(int(options.MaxCount), int(options.MaxValue)+1),

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -179,14 +179,16 @@ func (s *Scrutinizer) AfterSyncBootstrap() {
 			continue
 		}
 		options := process.GetVoteOptions()
-		if err := s.upsertWithoutTxConflicts(p, &indexertypes.Results{
-			ProcessID: p,
-			// MaxValue requires +1 since 0 is also an option
-			Votes:        indexertypes.NewEmptyVotes(int(options.MaxCount), int(options.MaxValue)+1),
-			Weight:       new(big.Int).SetUint64(0),
-			VoteOpts:     options,
-			EnvelopeType: process.GetEnvelopeType(),
-			Signatures:   []types.HexBytes{},
+		if err := s.queryWithRetries(func() error {
+			return s.db.Upsert(p, &indexertypes.Results{
+				ProcessID: p,
+				// MaxValue requires +1 since 0 is also an option
+				Votes:        indexertypes.NewEmptyVotes(int(options.MaxCount), int(options.MaxValue)+1),
+				Weight:       new(big.Int).SetUint64(0),
+				VoteOpts:     options,
+				EnvelopeType: process.GetEnvelopeType(),
+				Signatures:   []types.HexBytes{},
+			})
 		}); err != nil {
 			log.Errorf("cannot upsert results to db: %v", err)
 			continue


### PR DESCRIPTION
Implements wrappers for the most commonly used update/insert db transactions. These wrappers check for transaction conflict error and re-try transactions with these errors. Transaction conflicts are caused by timing and are normal, but they transactions need to be attempted again. 
This was previously done in many places, or sometimes just ignored, leaving the possibility for db transactions that didn't happen due to conflicts. 