### PR TITLE
Add interface check to db & censustree impl

### DIFF
--- a/censustree/gravitontree/trie.go
+++ b/censustree/gravitontree/trie.go
@@ -30,6 +30,8 @@ type Tree struct {
 	lastAccessUnix int64 // a unix timestamp, used via sync/atomic
 }
 
+var _ censustree.Tree = (*Tree)(nil)
+
 type exportElement struct {
 	Key   []byte `bare:"key"`
 	Value []byte `bare:"value"`

--- a/censustree/iden3tree/tree.go
+++ b/censustree/iden3tree/tree.go
@@ -25,6 +25,8 @@ type Tree struct {
 	lastAccessUnix int64 // a unix timestamp, used via sync/atomic
 }
 
+var _ censustree.Tree = (*Tree)(nil)
+
 type exportElement struct {
 	Key   []byte `bare:"key"`
 	Value []byte `bare:"value"`

--- a/db/badger.go
+++ b/db/badger.go
@@ -13,6 +13,8 @@ type BadgerDB struct {
 	db   *badger.DB
 }
 
+var _ Database = (*BadgerDB)(nil)
+
 func NewBadgerDB(path string) (*BadgerDB, error) {
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {
 		return nil, err


### PR DESCRIPTION
Adds interface checks to ensure that the different implementations of
`db.Database` & `censustree.Tree` match the interfaces.