### PR TITLE
Router: count api calls with atomic methods

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -246,9 +247,9 @@ func (r *Router) Route() {
 		}
 		log.Debugf("api query %s", request.MetaRequest.String())
 		if request.private {
-			r.PrivateCalls++
+			atomic.AddUint64(&r.PrivateCalls, 1)
 		} else {
-			r.PublicCalls++
+			atomic.AddUint64(&r.PublicCalls, 1)
 		}
 
 		if r.metricsagent != nil {

--- a/service/api.go
+++ b/service/api.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"go.vocdoni.io/dvote/census"
@@ -83,7 +84,7 @@ func API(apiconfig *config.API, pxy *mhttp.Proxy, storage data.Storage, cm *cens
 		for {
 			time.Sleep(120 * time.Second)
 			log.Infof("[router info] privateReqs:%d publicReqs:%d",
-				routerAPI.PrivateCalls, routerAPI.PublicCalls)
+				atomic.LoadUint64(&routerAPI.PrivateCalls), atomic.LoadUint64(&routerAPI.PublicCalls))
 		}
 	}()
 	return routerAPI, nil


### PR DESCRIPTION
Use atomic methods to update/access r.PublicCalls, r.PrivateCalls.

fixes #220