### PR TITLE
oracle: add oracle web3 endpoint pool

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,8 +116,8 @@ type EthCfg struct {
 type W3Cfg struct {
 	// ChainType chain to connect with
 	ChainType string
-	// W3External URL of an external ethereum node to connect with
-	W3External string
+	// W3External URLs of an external ethereum nodes to connect with
+	W3External []string
 }
 
 type EthEventCfg struct {

--- a/oracle/apioracle/apioracle.go
+++ b/oracle/apioracle/apioracle.go
@@ -51,8 +51,8 @@ func NewAPIoracle(o *oracle.Oracle, r *router.Router) (*APIoracle, error) {
 	return a, nil
 }
 
-func (a *APIoracle) EnableERC20(chainName, web3Endpoint string) error {
-	if chainName == "" || web3Endpoint == "" {
+func (a *APIoracle) EnableERC20(chainName string, web3Endpoints []string) error {
+	if chainName == "" || len(web3Endpoints) == 0 {
 		return fmt.Errorf("no web3 endpoint or chain name provided")
 	}
 	specs, err := chain.SpecsFor(chainName)
@@ -64,7 +64,7 @@ func (a *APIoracle) EnableERC20(chainName, web3Endpoint string) error {
 	if !ok {
 		srcNetId = srcNetworkIds["default"]
 	}
-	a.eh, err = ethereumhandler.NewEthereumHandler(specs.Contracts, srcNetId, web3Endpoint)
+	a.eh, err = ethereumhandler.NewEthereumHandler(specs.Contracts, srcNetId, web3Endpoints)
 	if err != nil {
 		return err
 	}

--- a/service/ethevents.go
+++ b/service/ethevents.go
@@ -8,6 +8,7 @@ import (
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	chain "go.vocdoni.io/dvote/ethereum"
 	"go.vocdoni.io/dvote/ethereum/ethevents"
+	ethereumhandler "go.vocdoni.io/dvote/ethereum/handler"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/dvote/vochain/scrutinizer"
@@ -19,9 +20,9 @@ import (
 // If endBlock=0 is enabled the service will only subscribe for new blocks
 func EthEvents(
 	ctx context.Context,
-	w3uri string,
+	w3uris []string,
 	networkName string,
-	startBlock *int64,
+	startBlock int64,
 	cm *census.Manager,
 	signer *ethereum.SignKeys,
 	vocapp *vochain.BaseApplication,
@@ -40,19 +41,47 @@ func EthEvents(
 		specs.Contracts,
 		specs.NetworkSource,
 		signer,
-		w3uri,
+		w3uris,
 		cm,
 		vocapp,
 		ethereumWhiteList,
 	)
+	ev.EthereumLastKnownBlock = startBlock
+
 	if err != nil {
 		return fmt.Errorf("couldn't create ethereum events listener: %w", err)
 	}
 	for _, e := range evh {
 		ev.AddEventHandler(e)
 	}
+
+	// This goroutine sets a context with cancel to free all the resources
+	// used by the subscription on the ethereum logs in case the mentioned
+	// subscription breaks (e.g connection is dropped).
+	// Once all the resources are freed the Ethereum handler is initialized
+	// again as well as the subscription mechanism
 	go func() {
-		ev.SubscribeEthereumEventLogs(ctx, startBlock)
+		// TODO: @jordipainan
+		// Since the NewEthEvents service calls NewEthereumHandler
+		// the initialized boolean avoids to create the new ethereum hanler
+		// twice on the first run. NewEthEvents and the handler creation
+		// should be decoupled.
+		var initialized bool
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			ctx, cancel := context.WithCancel(ctx)
+			if initialized {
+				if ev.VotingHandle, err = ethereumhandler.NewEthereumHandler(ev.ContractsInfo, specs.NetworkSource, w3uris); err != nil {
+					log.Fatalf("cannot restart ethereum events, cannot create ethereum handler: %v", err)
+				}
+			}
+			ev.SubscribeEthereumEventLogs(ctx, ev.EthereumLastKnownBlock)
+			initialized = true
+			// stop all child goroutines if error on subscription
+			cancel()
+		}
 	}()
 
 	return nil


### PR DESCRIPTION
If an Oracle that is subscribed to one or more
ethereum smart contract events
have any problem with the endpoint that is
connected with, after some retries, another
web3 endpoint will be used.

If there is not any web3 endpoint working
the application will terminate.

When a new connection is created the ethevents
service will be restarted as well as the
PrintInfo go routine.

A context.WithCancel is being used to terminate
all the goroutines created by the ethereum events
service and the contracts will be resolved on
the ENS an instanciated again. That way if any
event is lost during the time that there
are connection issues, will be catch again
on restart.