### PR TITLE
WIP: censusTree: add support for multiple census

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -95,6 +95,7 @@ type MetaRequest struct {
 	CensusValue  []byte                         `json:"censusValue,omitempty"`
 	CensusValues [][]byte                       `json:"censusValues,omitempty"`
 	CensusDump   []byte                         `json:"censusDump,omitempty"`
+	CensusType   int                            `json:"censusType,omitempty"`
 	Content      []byte                         `json:"content,omitempty"`
 	Digested     bool                           `json:"digested,omitempty"`
 	EntityId     types.HexBytes                 `json:"entityId,omitempty"`

--- a/census/census.go
+++ b/census/census.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"go.vocdoni.io/dvote/censustree"
+	censustreefactory "go.vocdoni.io/dvote/censustree/factory"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/data"
 	"go.vocdoni.io/dvote/log"
@@ -42,6 +43,7 @@ type Namespaces struct {
 // Namespace is composed by a list of keys which are capable to execute private operations
 // on the namespace.
 type Namespace struct {
+	Type int      `json:"type"`
 	Name string   `json:"name"`
 	Keys []string `json:"keys"`
 }
@@ -63,7 +65,6 @@ type Manager struct {
 	failedQueueLock sync.RWMutex
 	failedQueue     map[string]string
 	compressor
-	newTreeFunc func(name, storage string) (censustree.Tree, error)
 }
 
 // Data helps satisfy an ethevents interface.
@@ -71,16 +72,11 @@ func (m *Manager) Data() data.Storage { return m.RemoteStorage }
 
 // Init creates a new census manager.
 // A constructor function for the interface censustree.Tree must be provided.
-func (m *Manager) Init(storageDir, rootKey string,
-	newTreeImpl func(name, storageDir string) (censustree.Tree, error)) error {
+func (m *Manager) Init(storageDir, rootAuthPubKey string) error {
 	nsConfig := fmt.Sprintf("%s/namespaces.json", storageDir)
 	m.StorageDir = storageDir
 	m.Trees = make(map[string]censustree.Tree)
 	m.failedQueue = make(map[string]string)
-	if newTreeImpl == nil {
-		return fmt.Errorf("missing census tree implementation")
-	}
-	m.newTreeFunc = newTreeImpl
 	// add a bit of buffering, to try to keep AddToImportQueue non-blocking.
 	m.importQueue = make(chan censusImport, importQueueBuffer)
 	m.AuthWindow = 10
@@ -97,10 +93,10 @@ func (m *Manager) Init(storageDir, rootKey string,
 	if _, err := os.Stat(nsConfig); os.IsNotExist(err) {
 		log.Info("creating new config file")
 		var cns Namespaces
-		if len(rootKey) < ethereum.PubKeyLengthBytes*2 {
+		if len(rootAuthPubKey) < ethereum.PubKeyLengthBytes*2 {
 			// log.Warn("no root key provided or invalid, anyone will be able to create new census")
 		} else {
-			cns.RootKey = rootKey
+			cns.RootKey = rootAuthPubKey
 		}
 		m.Census = cns
 		if err := os.WriteFile(filepath.Clean(nsConfig), []byte(""), 0o600); err != nil {
@@ -117,14 +113,14 @@ func (m *Manager) Init(storageDir, rootKey string,
 		log.Warn("could not unmarshal json config file, probably empty. Skipping")
 		return nil
 	}
-	if len(rootKey) >= ethereum.PubKeyLengthBytes*2 {
-		log.Infof("updating root key to %s", rootKey)
-		m.Census.RootKey = rootKey
-	} else if rootKey != "" {
-		log.Infof("current root key %s", rootKey)
+	if len(rootAuthPubKey) >= ethereum.PubKeyLengthBytes*2 {
+		log.Infof("updating root key to %s", rootAuthPubKey)
+		m.Census.RootKey = rootAuthPubKey
+	} else if rootAuthPubKey != "" {
+		log.Infof("current root key %s", rootAuthPubKey)
 	}
 	for _, v := range m.Census.Namespaces {
-		if _, err := m.LoadTree(v.Name); err != nil {
+		if _, err := m.LoadTree(v.Name, v.Type); err != nil {
 			log.Warnf("census %s cannot be loaded: (%v)", v.Name, err)
 		}
 	}
@@ -133,11 +129,11 @@ func (m *Manager) Init(storageDir, rootKey string,
 
 // LoadTree opens the database containing the merkle tree or returns nil if already loaded
 // Not thread safe
-func (m *Manager) LoadTree(name string) (censustree.Tree, error) {
+func (m *Manager) LoadTree(name string, treeType int) (censustree.Tree, error) {
 	if _, exist := m.Trees[name]; exist {
 		return m.Trees[name], nil
 	}
-	tr, err := m.newTreeFunc(name, m.StorageDir)
+	tr, err := censustreefactory.NewCensusTree(treeType, name, m.StorageDir)
 	if err != nil {
 		return nil, err
 	}
@@ -169,20 +165,21 @@ func (m *Manager) Exists(name string) bool {
 
 // AddNamespace adds a new merkletree identified by a censusId (name), and
 // returns the new tree.
-func (m *Manager) AddNamespace(name string, pubKeys []string) (censustree.Tree, error) {
+func (m *Manager) AddNamespace(name string, treeType int, authPubKeys []string) (censustree.Tree, error) {
 	m.TreesMu.Lock()
 	defer m.TreesMu.Unlock()
 	if m.Exists(name) {
 		return nil, ErrNamespaceExist
 	}
-	tr, err := m.newTreeFunc(name, m.StorageDir)
+	tr, err := censustreefactory.NewCensusTree(treeType, name, m.StorageDir)
 	if err != nil {
 		return nil, err
 	}
 	m.Trees[name] = tr
 	m.Census.Namespaces = append(m.Census.Namespaces, Namespace{
+		Type: treeType,
 		Name: name,
-		Keys: pubKeys,
+		Keys: authPubKeys,
 	})
 	return tr, m.save()
 }

--- a/census/handler.go
+++ b/census/handler.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"go.vocdoni.io/dvote/api"
-	"go.vocdoni.io/dvote/crypto"
-	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -20,9 +18,11 @@ import (
 const (
 	censusHTTPhandlerTimeout   = 30 * time.Second
 	censusRemoteStorageTimeout = 1 * time.Minute
+	censusDefaultType          = 3
 )
 
 type CensusDump struct {
+	Type     int    `json:"type"`
 	RootHash []byte `json:"rootHash"`
 	Data     []byte `json:"data"`
 }
@@ -42,66 +42,6 @@ func checkRequest(w http.ResponseWriter, req *http.Request) bool {
 		return false
 	}
 	return true
-}
-
-// HTTPhandler handles an API census manager request via HTTP
-func (m *Manager) HTTPhandler(ctx context.Context, w http.ResponseWriter,
-	req *http.Request, signer *ethereum.SignKeys) {
-	log.Debug("new request received")
-	if ok := checkRequest(w, req); !ok {
-		return
-	}
-	// Decode JSON
-	log.Debug("decoding JSON")
-	var reqOuter api.RequestMessage
-	if err := json.NewDecoder(req.Body).Decode(&reqOuter); err != nil {
-		log.Warnf("cannot decode JSON: %s", err)
-		http.Error(w, err.Error(), 400)
-		return
-	}
-	var reqInner api.MetaRequest
-	if err := json.Unmarshal(reqOuter.MetaRequest, &reqInner); err != nil {
-		log.Warnf("cannot decode JSON: %s", err)
-		http.Error(w, err.Error(), 400)
-		return
-	}
-	if len(reqInner.Method) < 1 {
-		http.Error(w, "method must be specified", 400)
-		return
-	}
-	log.Debugf("found method %s", reqInner.Method)
-	auth := true
-	if err := m.CheckAuth(&reqOuter, &reqInner); err != nil {
-		log.Warnf("authorization error: %s", err)
-		auth = false
-	}
-	toWait := censusHTTPhandlerTimeout
-	// use a bigger timeout for remote storage operations
-	if req.Method == "importRemote" || req.Method == "publish" {
-		toWait = censusRemoteStorageTimeout
-	}
-	tctx, cancel := context.WithTimeout(ctx, toWait)
-	defer cancel()
-	resp := m.Handler(tctx, &reqInner, auth, "")
-	resp.Request = reqOuter.ID
-
-	respInner, err := crypto.SortedMarshalJSON(resp)
-	if err != nil {
-		log.Errorf("cannot encode JSON: %s", err)
-		http.Error(w, err.Error(), 500)
-		return
-	}
-	signature, err := signer.Sign(respInner)
-	if err != nil {
-		log.Error(err)
-	}
-
-	respOuter := &api.ResponseMessage{
-		ID:           reqOuter.ID,
-		Signature:    signature,
-		MetaResponse: respInner,
-	}
-	httpReply(respOuter, w)
 }
 
 // Handler handles an API census manager request.
@@ -124,7 +64,10 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 	// Special methods not depending on census existence
 	if r.Method == "addCensus" {
 		if isAuth {
-			t, err := m.AddNamespace(censusPrefix+r.CensusID, r.PubKeys)
+			if r.CensusType == 0 {
+				r.CensusType = censusDefaultType
+			}
+			t, err := m.AddNamespace(censusPrefix+r.CensusID, r.CensusType, r.PubKeys)
 			if err != nil {
 				log.Warnf("error creating census: %s", err)
 				resp.SetError(err)
@@ -414,7 +357,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 		// adding published census with censusID = rootHash
 		log.Infof("adding new namespace for published census %x", resp.Root)
 		namespace := hex.EncodeToString(resp.Root)
-		tr2, err := m.AddNamespace(namespace, r.PubKeys)
+		tr2, err := m.AddNamespace(namespace, tr.FactoryID(), r.PubKeys)
 		if err != nil && err != ErrNamespaceExist {
 			log.Warnf("error creating local published census: %s", err)
 		} else if err == nil {

--- a/census/importqueue.go
+++ b/census/importqueue.go
@@ -30,7 +30,7 @@ func (m *Manager) importTree(tree []byte, cid string) error {
 	if len(dump.Data) == 0 {
 		return fmt.Errorf("no claims found on the retreived census")
 	}
-	tr, err := m.AddNamespace(cid, []string{})
+	tr, err := m.AddNamespace(cid, dump.Type, []string{})
 	if err == ErrNamespaceExist {
 		return nil
 	} else if err != nil {

--- a/censustree/arbotree/wrapper.go
+++ b/censustree/arbotree/wrapper.go
@@ -48,6 +48,22 @@ func NewTree(name, storageDir string, hashFunc arbo.HashFunction) (censustree.Tr
 	return tree, nil
 }
 
+// Type returns the name identifying the censustree implementation
+func (t *Tree) Type() string {
+	return fmt.Sprintf("arbo-%s", t.Tree.HashFunction().Type())
+}
+
+// FactoryID returns the numeric identifier of the censustree implementation
+func (t *Tree) FactoryID() int {
+	switch string(t.Tree.HashFunction().Type()) {
+	case "blake2b":
+		return 1
+	case "poseidon":
+		return 2
+	}
+	return 0
+}
+
 // Init initializes the Tree using the given storage directory, by default is
 // used the Blake2b hash function. If another hash function is desired, should
 // use NewTree method or even censustree/util.NewCensusTree method, which allows

--- a/censustree/censusTree.go
+++ b/censustree/censusTree.go
@@ -1,6 +1,10 @@
 package censustree
 
 type Tree interface {
+	// Type returns a human readable name for the censusTree implementation
+	Type() string
+	// ID returns the numeric identifier for the censusTree implementation
+	FactoryID() int
 	// Init initializes the Tree using the given storage directory.
 	Init(name, storage string) error
 	// MaxKeySize returns the maximum key size supported by the Tree
@@ -27,6 +31,7 @@ type Tree interface {
 	GenProof(key, value []byte) (mproof []byte, err error)
 	// CheckProof validates a merkle proof and its data for the Tree hash function
 	CheckProof(key, value, root, mproof []byte) (included bool, err error)
+	// Root returns the current merkle tree root
 	Root() []byte
 	// Dump exports all the Tree leafs in a byte array, which can later be
 	// imported using the ImportDump method

--- a/censustree/factory/factory.go
+++ b/censustree/factory/factory.go
@@ -10,10 +10,13 @@ import (
 )
 
 const (
+	// TreeUnknown is the default value used for censusTree implementations
+	// which are not part of the this factory.
+	TreeUnknown = iota
 	// TreeTypeArboBlake2b defines a tree type that uses arbo with Blake2b
 	// hash function. Is thought for being used when computation speed is
 	// important.
-	TreeTypeArboBlake2b = iota
+	TreeTypeArboBlake2b
 	// TreeTypeArboPoseidon defines a tree type that uses arbo with Poseidon
 	// hash function. Is thought for being used when zkSNARK compatibility
 	// is needed (with circomlib).
@@ -23,7 +26,7 @@ const (
 )
 
 // NewCensusTree creates a merkle tree using the given storage and hash
-// function.  Note that each tree should use an entirely separate namespace for
+// function. Note that each tree should use an entirely separate namespace for
 // its database keys.
 func NewCensusTree(treeType int, name, storageDir string) (censustree.Tree, error) {
 	var err error

--- a/censustree/gravitontree/trie.go
+++ b/censustree/gravitontree/trie.go
@@ -45,6 +45,7 @@ type exportData struct {
 const (
 	MaxKeySize   = 65
 	MaxValueSize = 65
+	FactoryID    = 3
 )
 
 // NewTree opens or creates a merkle tree under the given storage.
@@ -83,6 +84,16 @@ func (t *Tree) Init(name, storageDir string) error {
 	t.dataDir = ct.(*Tree).dataDir
 	t.updateAccessTime()
 	return nil
+}
+
+// Type returns the name identifying the censustree implementation
+func (t *Tree) Type() string {
+	return "graviton"
+}
+
+// FactoryID returns the numeric identifier of the censustree implementation
+func (t *Tree) FactoryID() int {
+	return FactoryID
 }
 
 // MaxKeySize returns the maximum key size supported by the Tree

--- a/service/census.go
+++ b/service/census.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"go.vocdoni.io/dvote/census"
-	tree "go.vocdoni.io/dvote/censustree/gravitontree"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/metrics"
 )
@@ -20,7 +19,7 @@ func Census(datadir string, ma *metrics.Agent) (*census.Manager, error) {
 			return nil, err
 		}
 	}
-	if err := censusManager.Init(stdir, "", tree.NewTree); err != nil {
+	if err := censusManager.Init(stdir, ""); err != nil {
 		return nil, err
 	}
 

--- a/test/census_test.go
+++ b/test/census_test.go
@@ -77,6 +77,7 @@ func TestCensus(t *testing.T) {
 
 	// Create census
 	req.CensusID = "test"
+	req.CensusType = 3
 	resp := doRequest("addCensus", signer2)
 	qt.Assert(t, err, qt.IsNil)
 	censusID := resp.CensusID
@@ -115,6 +116,7 @@ func TestCensus(t *testing.T) {
 
 	// Create census2
 	req.CensusID = "test2"
+	req.CensusType = 3
 	resp = doRequest("addCensus", signer2)
 	qt.Assert(t, resp.Ok, qt.IsTrue)
 	censusID = resp.CensusID
@@ -189,6 +191,7 @@ func TestCensus(t *testing.T) {
 
 	// add second census
 	req.CensusID = "importTest"
+	req.CensusType = 3
 	resp = doRequest("addCensus", signer2)
 	qt.Assert(t, resp.Ok, qt.IsTrue)
 

--- a/test/testcommon/apis.go
+++ b/test/testcommon/apis.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"go.vocdoni.io/dvote/census"
-	graviton "go.vocdoni.io/dvote/censustree/gravitontree"
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/data"
@@ -90,12 +89,8 @@ func (d *DvoteAPIServer) Start(tb testing.TB, apis ...string) {
 	// Create the Census Manager and enable it trough the router
 	var cm census.Manager
 	d.CensusDir = tb.TempDir()
-	if d.CensusBackend == "" || d.CensusBackend == "graviton" {
-		if err := cm.Init(d.CensusDir, "", graviton.NewTree); err != nil {
-			tb.Fatal(err)
-		}
-	} else {
-		tb.Fatalf("census backend %s is unknown", d.CensusBackend)
+	if err := cm.Init(d.CensusDir, ""); err != nil {
+		tb.Fatal(err)
 	}
 
 	for _, api := range apis {


### PR DESCRIPTION
The census manager handler now receives a constructor function from the
censustree factory which allows to add and manage multiple census types.

The API exposes a new field named "censusType" which can be used by the
caller in order to choose the census type.

The default census (if not escpecified) is Graviton in order to keep
backwards compatibility.

Signed-off-by: p4u <pau@dabax.net>