### PR TITLE
Census Manager.LoadTree set default CensusType

### DIFF
--- a/census/census.go
+++ b/census/census.go
@@ -134,6 +134,14 @@ func (m *Manager) LoadTree(name string, treeType models.Census_Type) (censustree
 	if _, exist := m.Trees[name]; exist {
 		return m.Trees[name], nil
 	}
+
+	// ensure backwards compatibility to CensusTrees created before the
+	// Protobuf CensusTypes implementation. When TreeType is set to 0, uses
+	// the 'default' tree type
+	if treeType == models.Census_UNKNOWN {
+		treeType = censusDefaultType
+	}
+
 	tr, err := censustreefactory.NewCensusTree(treeType, name, m.StorageDir)
 	if err != nil {
 		return nil, err

--- a/census/census_test.go
+++ b/census/census_test.go
@@ -25,3 +25,14 @@ func TestCompressor(t *testing.T) {
 	// Decompressing should give us the original input back.
 	qt.Assert(t, comp.decompressBytes(compressed), qt.DeepEquals, input)
 }
+
+func TestLoadTreeDefaultCensusType(t *testing.T) {
+	m := &Manager{}
+	err := m.Init(t.TempDir(), "")
+	qt.Assert(t, err, qt.IsNil)
+
+	// ensure that when TreeType is set to 0, uses the 'default' tree type
+	tree, err := m.LoadTree("testtree", 0)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, censusDefaultType, qt.Equals, tree.Type())
+}


### PR DESCRIPTION
Ensure backwards compatibility to CensusTrees created before the
Protobuf CensusTypes implementation. When TreeType is set to 0, uses the
'default' tree type.