### PR TITLE
Feature/update storage proofs eth go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/timshannon/badgerhold/v3 v3.0.0-20210415132401-e7c90fb5919f
 	github.com/vocdoni/arbo v0.0.0-20210616072504-a8c7ea980892
 	github.com/vocdoni/go-external-ip v0.0.0-20210705122950-fae6195a1d44 // indirect
-	github.com/vocdoni/storage-proofs-eth-go v0.1.5
+	github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210713135939-56f40edd0def
 	go.uber.org/zap v1.16.0
 	go.vocdoni.io/proto v1.0.4-0.20210705131333-7925ca319268 // indirect
 	golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670

--- a/go.sum
+++ b/go.sum
@@ -1737,6 +1737,14 @@ github.com/vocdoni/multirpc v0.1.21/go.mod h1:zCx0l/hu/Vdeav44geFJmK4PAawN+qoo1H
 github.com/vocdoni/storage-proofs-eth-go v0.1.4/go.mod h1:8XF/0CpAetwlQJRgQgwBFEbfaYcjrU9gWUBR4F2Aqso=
 github.com/vocdoni/storage-proofs-eth-go v0.1.5 h1:/QTLeM1tkRIruA0LIB9yIMhBTk5++Pm7t2Zp0gCT1Xs=
 github.com/vocdoni/storage-proofs-eth-go v0.1.5/go.mod h1:8XF/0CpAetwlQJRgQgwBFEbfaYcjrU9gWUBR4F2Aqso=
+github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210707140958-25d9ba8e545e h1:vp11RDkYnViVDMj6oVGN9rXAi+IbxhtU+qhlGpCcL4o=
+github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210707140958-25d9ba8e545e/go.mod h1:xSAcW2zYbTehWJvFyXOLNBBnETqj90+B5vytqRpvlFg=
+github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210709100659-da492b36b7d0 h1:/gRjgHfgWk4e11YULAz0X/yHir5U8BghyPghaELN0pA=
+github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210709100659-da492b36b7d0/go.mod h1:/xP265mk9OwnrnfPwPFpdf+GEZ5Kc4w1hWZvic4YiT0=
+github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210712180028-635e3f56567d h1:WrsWm8DpXXxvLjFMvzcyp0e8P1hfFaw9wjSUE48rdy8=
+github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210712180028-635e3f56567d/go.mod h1:/xP265mk9OwnrnfPwPFpdf+GEZ5Kc4w1hWZvic4YiT0=
+github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210713135939-56f40edd0def h1:WYeNuiiVMqd4BZqUwyYuxcrF+vivP4v+r1YCwNLlBo0=
+github.com/vocdoni/storage-proofs-eth-go v0.1.6-0.20210713135939-56f40edd0def/go.mod h1:/xP265mk9OwnrnfPwPFpdf+GEZ5Kc4w1hWZvic4YiT0=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -20,7 +20,6 @@ import (
 	blind "github.com/arnaucube/go-blindsecp256k1"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	cfg "github.com/tendermint/tendermint/config"
 	crypto25519 "github.com/tendermint/tendermint/crypto/ed25519"
 	tmjson "github.com/tendermint/tendermint/libs/json"
@@ -106,19 +105,15 @@ func CheckProof(proof *models.Proof, censusOrigin models.CensusOrigin,
 		if !bytes.Equal(p.Key, key) {
 			return false, nil, fmt.Errorf("proof key and leafData do not match (%x != %x)", p.Key, key)
 		}
-		hexproof := []string{}
-		for _, s := range p.Siblings {
-			hexproof = append(hexproof, fmt.Sprintf("%x", s))
-		}
 		amount := big.Int{}
 		amount.SetBytes(p.Value)
-		hexamount := hexutil.Big(amount)
 		log.Debugf("validating erc20 storage proof for key %x and amount %s", p.Key, amount.String())
+		// TODO mapbased.VerifyProof()
 		valid, err := ethstorageproof.VerifyEthStorageProof(
 			&ethstorageproof.StorageResult{
-				Key:   fmt.Sprintf("%x", p.Key),
-				Proof: hexproof,
-				Value: &hexamount,
+				Key:   p.Key,
+				Proof: p.Siblings,
+				Value: p.Value,
 			},
 			ethcommon.BytesToHash(censusRoot),
 		)

--- a/vochain/proof.go
+++ b/vochain/proof.go
@@ -1,0 +1,139 @@
+package vochain
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+
+	"go.vocdoni.io/dvote/censustree/gravitontree"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/log"
+	"google.golang.org/protobuf/proto"
+
+	blind "github.com/arnaucube/go-blindsecp256k1"
+	"github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
+	"github.com/vocdoni/storage-proofs-eth-go/token/mapbased"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+// VerifyProofFunc is the generic function type to verify a proof of belonging
+// into a census within a process.
+type VerifyProofFunc func(process *models.Process, proof *models.Proof,
+	censusOrigin models.CensusOrigin,
+	censusRoot, processID, pubKey []byte, addr common.Address) (bool, *big.Int, error)
+
+// VerifyProofOffChainTree verifies a proof with census origin OFF_CHAIN_TREE.
+// Returns verification result and weight.
+func VerifyProofOffChainTree(process *models.Process, proof *models.Proof,
+	censusOrigin models.CensusOrigin,
+	censusRoot, processID, pubKey []byte, addr common.Address) (bool, *big.Int, error) {
+	var key []byte
+	if process.EnvelopeType.Anonymous {
+		// TODO Poseidon hash of pubKey
+		// pubKeyDigested = snarks.Poseidon.Hash(pubKey)
+		// NOT IMPLEMENTED
+		return false, nil, fmt.Errorf("census origin OFF_CHAIN_TREE with " +
+			"EnvelopeType.Anonymous not implemented")
+	} else {
+		key = pubKey
+	}
+	switch proof.Payload.(type) {
+	case *models.Proof_Graviton:
+		p := proof.GetGraviton()
+		if p == nil {
+			return false, nil, fmt.Errorf("graviton proof is empty")
+		}
+		valid, err := gravitontree.CheckProof(key, []byte{}, censusRoot, p.Siblings)
+		return valid, big.NewInt(1), err
+	case *models.Proof_Iden3:
+		// NOT IMPLEMENTED
+		return false, nil, fmt.Errorf("iden3 proof not implemented")
+	default:
+		return false, nil, fmt.Errorf("unexpected proof.Payload type: %T",
+			proof.Payload)
+	}
+}
+
+// VerifyProofOffChainCA verifies a proof with census origin OFF_CHAIN_CA.
+// Returns verification result and weight.
+func VerifyProofOffChainCA(process *models.Process, proof *models.Proof,
+	censusOrigin models.CensusOrigin,
+	censusRoot, processID, pubKey []byte, addr common.Address) (bool, *big.Int, error) {
+	key := addr.Bytes()
+
+	p := proof.GetCa()
+	if !bytes.Equal(p.Bundle.Address, key) {
+		return false, nil, fmt.Errorf(
+			"CA bundle address and key do not match: %x != %x", key, p.Bundle.Address)
+	}
+	if !bytes.Equal(p.Bundle.ProcessId, processID) {
+		return false, nil, fmt.Errorf("CA bundle processID does not match")
+	}
+	caBundle, err := proto.Marshal(p.Bundle)
+	if err != nil {
+		return false, nil, fmt.Errorf("cannot marshal ca bundle to protobuf: %w", err)
+	}
+	var caPubk []byte
+
+	// depending on signature type, use a mechanism for extracting the ca publickey from signature
+	switch p.GetType() {
+	case models.ProofCA_ECDSA:
+		caPubk, err = ethereum.PubKeyFromSignature(caBundle, p.GetSignature())
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot fetch ca address from signature: %w", err)
+		}
+		if !bytes.Equal(caPubk, censusRoot) {
+			return false, nil, fmt.Errorf("ca bundle signature does not match")
+		}
+	case models.ProofCA_ECDSA_BLIND:
+		// Blind CA check
+		pubdesc, err := ethereum.DecompressPubKey(censusRoot)
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot decompress CA public key: %w", err)
+		}
+		pub, err := blind.NewPublicKeyFromECDSA(pubdesc)
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot compute blind CA public key: %w", err)
+		}
+		signature, err := blind.NewSignatureFromBytes(p.GetSignature())
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot compute blind CA signature: %w", err)
+		}
+		if !blind.Verify(new(big.Int).SetBytes(ethereum.HashRaw(caBundle)), signature, pub) {
+			return false, nil, fmt.Errorf("blind CA verification failed %s", log.FormatProto(p.Bundle))
+		}
+	default:
+		return false, nil, fmt.Errorf("ca proof %s type not supported", p.Type.String())
+	}
+	return true, big.NewInt(1), nil
+}
+
+// VerifyProofERC20 verifies a proof with census origin ERC20 (mapbased).
+// Returns verification result and weight.
+func VerifyProofERC20(process *models.Process, proof *models.Proof,
+	censusOrigin models.CensusOrigin,
+	censusRoot, processID, pubKey []byte, addr common.Address) (bool, *big.Int, error) {
+	if process.EthIndexSlot == nil {
+		return false, nil, fmt.Errorf("index slot not found for process %x", process.ProcessId)
+	}
+	p := proof.GetEthereumStorage()
+	if p == nil {
+		return false, nil, fmt.Errorf("ethereum proof is empty")
+	}
+
+	balance := new(big.Int).SetBytes(p.Value)
+	log.Debugf("validating erc20 storage proof for key %x and balance %v", p.Key, balance)
+	err := mapbased.VerifyProof(addr, ethcommon.BytesToHash(censusRoot),
+		ethstorageproof.StorageResult{
+			Key:   p.Key,
+			Proof: p.Siblings,
+			Value: p.Value,
+		},
+		int(*process.EthIndexSlot),
+		balance,
+		nil)
+	return err == nil, balance, err
+}

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -1,7 +1,6 @@
 package vochain
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -465,23 +464,11 @@ func testEthSendVotes(t *testing.T, s testStorageProof,
 
 	var stx models.SignedTx
 
-	t.Logf("voting %s", s.StorageProof.Key)
-	k, err := hex.DecodeString(s.StorageProof.Key)
-	if err != nil {
-		t.Fatal(err)
-	}
-	siblings := [][]byte{}
-	for _, sib := range s.StorageProof.Proof {
-		sibb, err := hex.DecodeString(util.TrimHex(sib))
-		if err != nil {
-			t.Fatal(err)
-		}
-		siblings = append(siblings, sibb)
-	}
+	t.Logf("voting %x", s.StorageProof.Key)
 	proof := models.ProofEthereumStorage{
-		Key:      k,
-		Value:    s.StorageProof.Value.ToInt().Bytes(),
-		Siblings: siblings,
+		Key:      s.StorageProof.Key,
+		Value:    s.StorageProof.Value,
+		Siblings: s.StorageProof.Proof,
 	}
 	tx := &models.VoteEnvelope{
 		Nonce:       util.RandomBytes(32),
@@ -509,6 +496,7 @@ func testEthSendVotes(t *testing.T, s testStorageProof,
 	pub, _ := signer.HexString()
 	t.Logf("addr: %s pubKey: %s", signer.Address(), pub)
 
+	var err error
 	if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: tx}}); err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -251,6 +251,8 @@ func VoteTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State,
 			if process.EnvelopeType.Anonymous {
 				// TODO Poseidon hash of pubKey
 				// pubKeyDigested = snarks.Poseidon.Hash(pubKey)
+				return nil, fmt.Errorf("census origin OFF_CHAIN_TREE with " +
+					"EnvelopeType.Anonymousnot implemented")
 			} else {
 				proofKey = pubKey
 			}
@@ -265,12 +267,6 @@ func VoteTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State,
 			log.Debugf("ERC20 index slot %d, storage slot %x", *process.EthIndexSlot, proofKey)
 		default:
 			return nil, fmt.Errorf("census origin not compatible")
-		}
-
-		// check the proofKey  has a minimum length
-		if len(proofKey) < 20 { // Minimum size is an Ethereum Address
-			return nil, fmt.Errorf("proof key too short: expected len >= 20, got %v",
-				len(proofKey))
 		}
 
 		// check census proof


### PR DESCRIPTION
### Upgrade storage-proofs-eth-go dependency

### vocchain: Remove unecessary len(proofKey) check

In VoteTxCheck remove the check that len(proofKey) must be >= 20.
proofKey can be one of the tree:

1. `pubKey` (censusOrigin_OFF_CHAIN_TREE)
Comes from:
`pubKey, err = ethereum.PubKeyFromSignature(txBytes, signature)`
so it will be 33 bytes (compressed ethereum key) if err == nil.

2. `addr.Bytes()` (CensusOrigin_OFF_CHAIN_CA)
Comes from:
`addr, err := ethereum.AddrFromPublicKey(pubKey)`
so it will be 20 bytes (ethereum Address) if err == nil

3. `slot` (CensusOrigin_ERC20)
Comes from:
`sphelpers.GetMapSlot(addr, int(*process.EthIndexSlot))`
so it will be 32 bytes (ethereum Hash) if err == nil

There's no case in which len(proofKey) can be < 20, so we remove the
check.

### Split vochain CheckProof into smaller fns