### PR TITLE
scrutinizer: add custom big Int implementation

### DIFF
--- a/types/big.go
+++ b/types/big.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// BigInt is a big.Int wrapper which marshals JSON to a string representation of the big number
+type BigInt big.Int
+
+func (i BigInt) MarshalText() ([]byte, error) {
+	return []byte((*big.Int)(&i).String()), nil
+}
+
+func (i *BigInt) UnmarshalText(data []byte) error {
+	i2, ok := new(big.Int).SetString(string(data), 0)
+	if !ok {
+		return fmt.Errorf("wrong format for bigInt")
+	}
+	*i = (BigInt)(*i2)
+	return nil
+}
+
+func (i *BigInt) GobEncode() ([]byte, error) {
+	return i.ToInt().GobEncode()
+}
+
+func (i *BigInt) GobDecode(buf []byte) error {
+	return i.ToInt().GobDecode(buf)
+}
+
+// String returns the string representation of the big number
+func (i *BigInt) String() string {
+	return (*big.Int)(i).String()
+}
+
+// SetBytes interprets buf as big-endian unsigned integer
+func (i *BigInt) SetBytes(buf []byte) *BigInt {
+	return (*BigInt)(i.ToInt().SetBytes(buf))
+}
+
+// Bytes returns the bytes representation of the big number
+func (i *BigInt) Bytes() []byte {
+	return (*big.Int)(i).Bytes()
+}
+
+// ToInt converts b to a big.Int.
+func (i *BigInt) ToInt() *big.Int {
+	return (*big.Int)(i)
+}
+
+// Add sum x+y
+func (i *BigInt) Add(x *BigInt, y *BigInt) *BigInt {
+	return (*BigInt)(i.ToInt().Add(x.ToInt(), y.ToInt()))
+}
+
+// Mul multiplies x*y
+func (i *BigInt) Mul(x *BigInt, y *BigInt) *BigInt {
+	return (*BigInt)(i.ToInt().Mul(x.ToInt(), y.ToInt()))
+}
+
+// SetUint64 sets the value of x to the big number
+func (i *BigInt) SetUint64(x uint64) *BigInt {
+	return (*BigInt)(i.ToInt().SetUint64(x))
+}

--- a/types/big_test.go
+++ b/types/big_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBigInt(t *testing.T) {
+	// Test basic
+	a := new(BigInt).SetUint64(100)
+	b := new(BigInt).SetUint64(200)
+
+	a.Add(a, b)
+	qt.Assert(t, a.String(), qt.DeepEquals, "300")
+
+	a.ToInt().Add(a.ToInt(), b.ToInt())
+	qt.Assert(t, a.String(), qt.DeepEquals, "500")
+
+	// Test single text Marshaling
+	j, err := a.MarshalText()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, string(j), qt.DeepEquals, "500")
+
+	c := new(BigInt)
+	err = c.UnmarshalText([]byte("123"))
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, c.String(), qt.DeepEquals, "123")
+
+	// Test text Marshaling inside a struct
+	js := &jsonStructTest{
+		Name:   "first",
+		BigInt: new(BigInt).SetUint64(12312312312312312312),
+	}
+	data, err := json.Marshal(js)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, string(data), qt.DeepEquals,
+		`{"name":"first","number":"12312312312312312312"}`)
+
+	// Test bytes compatibility with standard library
+	d := new(big.Int).SetInt64(456).Bytes()
+	c.SetBytes(d)
+	qt.Assert(t, c.String(), qt.DeepEquals, "456")
+}
+
+type jsonStructTest struct {
+	Name   string  `json:"name"`
+	BigInt *BigInt `json:"number"`
+}

--- a/vochain/scrutinizer/indexertypes/results.go
+++ b/vochain/scrutinizer/indexertypes/results.go
@@ -20,8 +20,8 @@ const (
 // Results holds the final results and relevant process info for a vochain process
 type Results struct {
 	ProcessID      types.HexBytes             `badgerholdKey:"ProcessID" json:"processId"`
-	Votes          [][]*big.Int               `json:"votes"`
-	Weight         *big.Int                   `json:"weight"`
+	Votes          [][]*types.BigInt          `json:"votes"`
+	Weight         *types.BigInt              `json:"weight"`
 	EnvelopeHeight uint64                     `json:"envelopeHeight"`
 	EnvelopeType   *models.EnvelopeType       `json:"envelopeType"`
 	VoteOpts       *models.ProcessVoteOptions `json:"voteOptions"`
@@ -147,7 +147,7 @@ func (r *Results) AddVote(voteValues []int, weight *big.Int, mutex *sync.Mutex) 
 	}
 
 	// Add the Election weight (tells how much voting power have already been processed)
-	r.Weight.Add(r.Weight, weight)
+	r.Weight.Add(r.Weight, (*types.BigInt)(weight))
 	if len(r.Votes) == 0 {
 		r.Votes = NewEmptyVotes(int(r.VoteOpts.MaxCount), int(r.VoteOpts.MaxValue)+1)
 	}
@@ -174,31 +174,31 @@ func (r *Results) AddVote(voteValues []int, weight *big.Int, mutex *sync.Mutex) 
 		for q, value := range voteValues {
 			r.Votes[q][0].Add(
 				r.Votes[q][0],
-				new(big.Int).Mul(
-					new(big.Int).SetUint64(uint64(value)),
-					weight),
+				new(types.BigInt).Mul(
+					new(types.BigInt).SetUint64(uint64(value)),
+					(*types.BigInt)(weight)),
 			)
 		}
 	} else {
 		// For the other cases, we use the results matrix index weighted
 		// as described in the Ballot Protocol.
 		for q, opt := range voteValues {
-			r.Votes[q][opt].Add(r.Votes[q][opt], weight)
+			r.Votes[q][opt].Add(r.Votes[q][opt], (*types.BigInt)(weight))
 		}
 	}
 	return nil
 }
 
 // NewEmptyVotes creates a new results struct with the given number of questions and options
-func NewEmptyVotes(questions, options int) [][]*big.Int {
+func NewEmptyVotes(questions, options int) [][]*types.BigInt {
 	if questions == 0 || options == 0 {
 		return nil
 	}
-	results := [][]*big.Int{}
+	results := [][]*types.BigInt{}
 	for i := 0; i < questions; i++ {
-		question := []*big.Int{}
+		question := []*types.BigInt{}
 		for j := 0; j < options; j++ {
-			question = append(question, big.NewInt(0))
+			question = append(question, new(types.BigInt).SetUint64(0))
 		}
 		results = append(results, question)
 	}

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -3,7 +3,6 @@ package indexertypes
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"reflect"
 	"strings"
 	"time"
@@ -81,7 +80,7 @@ type VoteReference struct {
 	Nullifier    types.HexBytes `badgerholdKey:"Nullifier"`
 	ProcessID    types.HexBytes `badgerholdIndex:"ProcessID"`
 	Height       uint32
-	Weight       *big.Int
+	Weight       *types.BigInt
 	TxIndex      int32
 	CreationTime time.Time
 }

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -3,7 +3,6 @@ package scrutinizer
 import (
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"strings"
 	"time"
 
@@ -267,7 +266,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 			ProcessID: pid,
 			// MaxValue requires +1 since 0 is also an option
 			Votes:        indexertypes.NewEmptyVotes(int(options.MaxCount), int(options.MaxValue)+1),
-			Weight:       new(big.Int).SetUint64(0),
+			Weight:       new(types.BigInt).SetUint64(0),
 			Signatures:   []types.HexBytes{},
 			VoteOpts:     p.GetVoteOptions(),
 			EnvelopeType: p.GetEnvelopeType(),
@@ -392,7 +391,7 @@ func (s *Scrutinizer) updateProcess(pid []byte) error {
 						return fmt.Errorf("record isn't the correct type! Wanted Result, got %T", record)
 					}
 					// On cancelled process, remove all results except for envelope height, weight, pid
-					results.Votes = [][]*big.Int{}
+					results.Votes = [][]*types.BigInt{}
 					results.EnvelopeType = &models.EnvelopeType{}
 					results.VoteOpts = &models.ProcessVoteOptions{}
 					results.Signatures = []types.HexBytes{}

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -257,7 +257,7 @@ func (s *Scrutinizer) AfterSyncBootstrap() {
 				ProcessID: p,
 				// MaxValue requires +1 since 0 is also an option
 				Votes:        indexertypes.NewEmptyVotes(int(options.MaxCount), int(options.MaxValue)+1),
-				Weight:       new(big.Int).SetUint64(0),
+				Weight:       new(types.BigInt).SetUint64(0),
 				VoteOpts:     options,
 				EnvelopeType: process.GetEnvelopeType(),
 				Signatures:   []types.HexBytes{},
@@ -269,7 +269,7 @@ func (s *Scrutinizer) AfterSyncBootstrap() {
 
 		// Count the votes, add them to results (in memory, without any db transaction)
 		results := &indexertypes.Results{
-			Weight:       new(big.Int).SetUint64(0),
+			Weight:       new(types.BigInt).SetUint64(0),
 			VoteOpts:     options,
 			EnvelopeType: process.EnvelopeType,
 		}
@@ -383,7 +383,7 @@ func (s *Scrutinizer) Commit(height uint32) error {
 		// This is a temporary "results" for computing votes
 		// of a single processId for the current block.
 		results := &indexertypes.Results{
-			Weight:       new(big.Int).SetUint64(0),
+			Weight:       new(types.BigInt).SetUint64(0),
 			VoteOpts:     proc.VoteOpts,
 			EnvelopeType: proc.Envelope,
 		}
@@ -559,7 +559,7 @@ func (s *Scrutinizer) OnProcessResults(pid []byte, results *models.ProcessResult
 }
 
 // GetFriendlyResults translates votes into a matrix of strings
-func GetFriendlyResults(votes [][]*big.Int) [][]string {
+func GetFriendlyResults(votes [][]*types.BigInt) [][]string {
 	r := [][]string{}
 	for i := range votes {
 		r = append(r, []string{})

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -534,7 +534,7 @@ func TestResults(t *testing.T) {
 			if qi > 3 {
 				t.Fatalf("found more questions that expected")
 			}
-			value = result.Votes[q][qi]
+			value = result.Votes[q][qi].ToInt()
 			if qi != 1 && value.Cmp(v0) != 0 {
 				t.Fatalf("result is not correct, %d is not 0 as expected", value.Uint64())
 			}
@@ -592,7 +592,7 @@ func TestLiveResults(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	r := &indexertypes.Results{
 		Votes:        indexertypes.NewEmptyVotes(3, 100),
-		Weight:       new(big.Int).SetUint64(0),
+		Weight:       new(types.BigInt).SetUint64(0),
 		VoteOpts:     &models.ProcessVoteOptions{MaxCount: 3, MaxValue: 100},
 		EnvelopeType: &models.EnvelopeType{},
 	}
@@ -623,7 +623,7 @@ func TestLiveResults(t *testing.T) {
 			if qi > 100 {
 				t.Fatalf("found more questions that expected")
 			}
-			value = result.Votes[q][qi]
+			value = result.Votes[q][qi].ToInt()
 			if qi == 0 && value.Cmp(v0) != 0 {
 				t.Fatalf("result is not correct, %d is not 0 as expected", value.Uint64())
 			}
@@ -733,7 +733,7 @@ var vote = func(v []int, sc *Scrutinizer, pid []byte, weight *big.Int) error {
 		ProcessID: pid,
 		Votes: indexertypes.NewEmptyVotes(
 			int(proc.VoteOpts.MaxCount), int(proc.VoteOpts.MaxValue)+1),
-		Weight:       new(big.Int).SetUint64(0),
+		Weight:       new(types.BigInt).SetUint64(0),
 		Signatures:   []types.HexBytes{},
 		VoteOpts:     proc.VoteOpts,
 		EnvelopeType: proc.Envelope,

--- a/vochain/scrutinizer/vote.go
+++ b/vochain/scrutinizer/vote.go
@@ -111,7 +111,7 @@ func (s *Scrutinizer) WalkEnvelopes(processId []byte, async bool,
 					log.Errorf("transaction is not an Envelope")
 					return
 				}
-				callback(envelope, txRef.Weight)
+				callback(envelope, txRef.Weight.ToInt())
 			}
 			if async {
 				go func() {
@@ -323,7 +323,7 @@ func (s *Scrutinizer) GetResultsWeight(processID []byte) (*big.Int, error) {
 	if err := s.db.FindOne(results, badgerhold.Where(badgerhold.Key).Eq(processID)); err != nil {
 		return nil, err
 	}
-	return results.Weight, nil
+	return results.Weight.ToInt(), nil
 }
 
 // unmarshalVote decodes the base64 payload to a VotePackage struct type.
@@ -377,7 +377,7 @@ func (s *Scrutinizer) addLiveVote(pid []byte, VotePackage []byte, weight *big.In
 		}
 	} else {
 		// If encrypted, just add the weight
-		results.Weight.Add(results.Weight, weight)
+		results.Weight.Add(results.Weight, (*types.BigInt)(weight))
 		results.EnvelopeHeight++
 	}
 	return nil
@@ -393,7 +393,7 @@ func (s *Scrutinizer) addVoteIndex(nullifier, pid []byte, blockHeight uint32,
 			Nullifier:    nullifier,
 			ProcessID:    pid,
 			Height:       blockHeight,
-			Weight:       new(big.Int).SetBytes(weight),
+			Weight:       new(types.BigInt).SetBytes(weight),
 			TxIndex:      txIndex,
 			CreationTime: time.Now(),
 		})
@@ -403,7 +403,7 @@ func (s *Scrutinizer) addVoteIndex(nullifier, pid []byte, blockHeight uint32,
 			Nullifier:    nullifier,
 			ProcessID:    pid,
 			Height:       blockHeight,
-			Weight:       new(big.Int).SetBytes(weight),
+			Weight:       new(types.BigInt).SetBytes(weight),
 			TxIndex:      txIndex,
 			CreationTime: time.Now(),
 		})
@@ -480,7 +480,7 @@ func (s *Scrutinizer) computeFinalResults(p *indexertypes.Process) (*indexertype
 	results := &indexertypes.Results{
 		Votes:        indexertypes.NewEmptyVotes(int(p.VoteOpts.MaxCount), int(p.VoteOpts.MaxValue)+1),
 		ProcessID:    p.ID,
-		Weight:       new(big.Int).SetUint64(0),
+		Weight:       new(types.BigInt).SetUint64(0),
 		Final:        true,
 		VoteOpts:     p.VoteOpts,
 		EnvelopeType: p.Envelope,


### PR DESCRIPTION
The JSON Marshaler for the standard type big.Int optputs an integer
number instead of an string (such as 123456789 instead of "123456789").
This behavior creates a problem when importing the JSON
data to a different implementation (i.e Javascript) since it forces to
read the field as an integer.

To fix this we introduce a new custom big.Int implementation which
Marshals always to a bigInt string.

Note that this fix is widely used by projects such as go-ethereum
(common/hexutil)

Signed-off-by: p4u <pau@dabax.net>