### PR TITLE
Add missing dump.Type to census publish

### DIFF
--- a/census/handler.go
+++ b/census/handler.go
@@ -320,6 +320,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 			log.Warnf("cannot dump census with root %x: %s", tr.Root(), err)
 			return resp
 		}
+		dump.Type = tr.Type()
 		dumpBytes, err := json.Marshal(dump)
 		if err != nil {
 			resp.SetError(err)


### PR DESCRIPTION
This branch is an attempt to hot-fix a bug found by @NateWilliams2 & spotted by @emmdim .

This branch adds the `dump.Type = tr.Type()` inside the `publish` case.
But, I'm not sure which is the expected behavior & connection between the `dump` & `publish` & `importDump`, as in the `publish` the dump specifies the type of the tree, but in the import the tree type is defined outside the scope, thus if the dump type is different than the existing one in that scope would not match and the import dump would not be correct.