### PR TITLE
Integrate Arbo-based StateDB in vochain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,11 +48,11 @@ require (
 	github.com/tendermint/tendermint v0.34.10
 	github.com/tendermint/tm-db v0.6.4
 	github.com/timshannon/badgerhold/v3 v3.0.0-20210415132401-e7c90fb5919f
-	github.com/vocdoni/arbo v0.0.0-20210831141531-de5914f453cf
+	github.com/vocdoni/arbo v0.0.0-20210909102959-f09b0b039255
 	github.com/vocdoni/go-external-ip v0.0.0-20210705122950-fae6195a1d44
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.18.1
-	go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b
+	go.vocdoni.io/proto v1.0.4-0.20210910085433-e7c056b7c23a
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -1969,6 +1969,8 @@ github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMI
 github.com/vocdoni/arbo v0.0.0-20210616072504-a8c7ea980892/go.mod h1:Pikn2YIz/Rt05HWs35QHdpx7IWk4E2G0KdnCX+KRsNs=
 github.com/vocdoni/arbo v0.0.0-20210831141531-de5914f453cf h1:8hZXnUdi3v6hsarvQ6Qv7b0+j8UaqBrfLlKvn6JpNSI=
 github.com/vocdoni/arbo v0.0.0-20210831141531-de5914f453cf/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
+github.com/vocdoni/arbo v0.0.0-20210909102959-f09b0b039255 h1:Gabst/0jIl3CgiywQWS5VpWsqaPuBwz0XAuMws5Pcyw=
+github.com/vocdoni/arbo v0.0.0-20210909102959-f09b0b039255/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
 github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f h1:z7CK3k1yIutKycPY8s2ZbtwUBKMy3xPcLMh12QukLRY=
 github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f/go.mod h1:BoN7UMTA/JcgmNPaoUQq6RwuixhgSrk5PmCMVMKLxpc=
 github.com/vocdoni/blind-ca v0.1.4/go.mod h1:4ouWDqlvXrrNS0Csf3hKA3cuDTmKh6nP7kSXF39nT4s=
@@ -2102,8 +2104,11 @@ go.vocdoni.io/dvote v1.0.4-0.20210806163627-9494efbc5382/go.mod h1:kl66EQmAjR252
 go.vocdoni.io/proto v0.1.7/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.8/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
-go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b h1:Xcc4GRtegTWKCwn2VKQTATrkmhy9f+Ju5teULJCRYg0=
 go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
+go.vocdoni.io/proto v1.0.4-0.20210909161946-f3158498ba88 h1:EJnuknmHjwPQL44d5TVOZJhzVA4oFzZT41etyaRervk=
+go.vocdoni.io/proto v1.0.4-0.20210909161946-f3158498ba88/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
+go.vocdoni.io/proto v1.0.4-0.20210910085433-e7c056b7c23a h1:7QimTKlkCY0O5KRFi0ejafFkLQze7zN0qOE/BuZosbE=
+go.vocdoni.io/proto v1.0.4-0.20210910085433-e7c056b7c23a/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20200411211856-f5505b9728dd h1:BNJlw5kRTzdmyfh5U8F93HA2OwkP7ZGwA51eJ/0wKOU=
 go4.org v0.0.0-20200411211856-f5505b9728dd/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=

--- a/test/statedb_test.go
+++ b/test/statedb_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
 	"github.com/tendermint/tendermint/privval"
 	models "go.vocdoni.io/proto/build/go/models"
 
@@ -19,46 +20,37 @@ func TestVochainState(t *testing.T) {
 	t.Parallel()
 
 	s, err := vochain.NewState(t.TempDir())
-	if err != nil {
-		t.Fatalf("cannot create vochain state (%s)", err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 
 	// This used to panic due to nil *ImmutableTree fields.
 	exists, err := s.EnvelopeExists(util.RandomBytes(32), util.RandomBytes(32), false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if exists {
-		t.Errorf("expected EnvelopeExists to return false")
-	}
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, exists, qt.Equals, false)
 
+	s.Tx.Add(vochain.ProcessesCfg.Key(), make([]byte, vochain.ProcessesCfg.HashFunc().Len()))
 	for i := 0; i < 10; i++ {
-		s.Store.Tree(vochain.AppTree).Add([]byte(fmt.Sprintf("%d", i)), []byte(fmt.Sprintf("number %d", i)))
-		s.Store.Tree(vochain.ProcessTree).Add([]byte(fmt.Sprintf("%d", i+1)), []byte(fmt.Sprintf("number %d", i+1)))
-		s.Store.Tree(vochain.VoteTree).Add([]byte(fmt.Sprintf("%d", i+2)), []byte(fmt.Sprintf("number %d", i+2)))
+		s.Tx.Add([]byte(fmt.Sprintf("%d", i)), []byte(fmt.Sprintf("number %d", i)))
+		s.Tx.DeepAdd([]byte(fmt.Sprintf("%d", i+1)),
+			[]byte(fmt.Sprintf("number %d", i+1)), vochain.ProcessesCfg)
 	}
 	s.Save()
 
-	ah := s.Store.Hash()
-	if ah == nil {
-		t.Error(ah)
-	}
+	_, err = s.Store.Hash()
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func TestAddOracle(t *testing.T) {
 	t.Parallel()
 	s := testcommon.NewVochainStateWithOracles(t)
-	if err := s.AddOracle(common.HexToAddress("414896B0BC763b8762456DB00F9c76EBd49979C4")); err != nil {
-		t.Error(err)
-	}
+	err := s.AddOracle(common.HexToAddress("414896B0BC763b8762456DB00F9c76EBd49979C4"))
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func TestRemoveOracle(t *testing.T) {
 	t.Parallel()
 	s := testcommon.NewVochainStateWithOracles(t)
-	if err := s.RemoveOracle(testcommon.OracleListHardcoded[0]); err != nil {
-		t.Error(err)
-	}
+	err := s.RemoveOracle(testcommon.OracleListHardcoded[0])
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func TestGetOracles(t *testing.T) {
@@ -66,14 +58,8 @@ func TestGetOracles(t *testing.T) {
 
 	s := testcommon.NewVochainStateWithOracles(t)
 	oracles, err := s.Oracles(false)
-	if err != nil {
-		t.Error(err)
-	}
-	for i, v := range testcommon.OracleListHardcoded {
-		if oracles[i] != v {
-			t.Error("oracle address does not match")
-		}
-	}
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, oracles, qt.ContentEquals, testcommon.OracleListHardcoded)
 }
 
 func TestAddValidator(t *testing.T) {
@@ -83,17 +69,14 @@ func TestAddValidator(t *testing.T) {
 	rint := rand.Int()
 	val := privval.GenFilePV(fmt.Sprintf("/tmp/vochainBenchmark%d", rint), fmt.Sprintf("/tmp/vochainBenchmark%d", rint))
 	pubk, err := val.GetPubKey()
-	if err != nil {
-		t.Error(err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	validator := &models.Validator{
 		Address: pubk.Address(),
 		PubKey:  pubk.Bytes(),
 		Power:   10,
 	}
-	if err := s.AddValidator(validator); err != nil {
-		t.Error(err)
-	}
+	err = s.AddValidator(validator)
+	qt.Assert(t, err, qt.IsNil)
 }
 
 /*
@@ -126,81 +109,68 @@ func TestAddProcess(t *testing.T) {
 	t.Parallel()
 
 	s := testcommon.NewVochainStateWithProcess(t)
-	if err := s.AddProcess(testcommon.ProcessHardcoded); err != nil {
-		t.Error(err)
-	}
+	err := s.AddProcess(testcommon.ProcessHardcoded)
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func TestGetProcess(t *testing.T) {
 	t.Parallel()
 
 	s := testcommon.NewVochainStateWithProcess(t)
-	if _, err := s.Process(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"), false); err != nil {
-		t.Error(err)
-	}
+	_, err := s.Process(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"), false)
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func TestCancelProcess(t *testing.T) {
 	t.Parallel()
 
 	s := testcommon.NewVochainStateWithProcess(t)
-	if err := s.CancelProcess(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105")); err != nil {
-		t.Error(err)
-	}
+	err := s.CancelProcess(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"))
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func TestAddVote(t *testing.T) {
 	t.Parallel()
 
 	s := testcommon.NewVochainStateWithProcess(t)
-	if err := s.AddVote(testcommon.VoteHardcoded()); err != nil {
-		t.Error(err)
-	}
+	err := s.AddVote(testcommon.NewVoteHardcoded())
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func TestGetEnvelope(t *testing.T) {
 	t.Parallel()
 
 	s := testcommon.NewVochainStateWithProcess(t)
-	if err := s.AddVote(testcommon.VoteHardcoded()); err != nil {
-		t.Error(err)
-	}
-	if _, err := s.Envelope(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
-		testutil.Hex2byte(t, "5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0"), false); err != nil {
-		t.Error(err)
-	}
+	err := s.AddVote(testcommon.NewVoteHardcoded())
+	qt.Assert(t, err, qt.IsNil)
+	_, err = s.Envelope(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
+		testutil.Hex2byte(t, "5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0"), false)
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func TestCountVotes(t *testing.T) {
 	t.Parallel()
 
 	s := testcommon.NewVochainStateWithProcess(t)
-	if err := s.AddVote(testcommon.VoteHardcoded()); err != nil {
-		t.Error(err)
-	}
-	if _, err := s.Envelope(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
-		testutil.Hex2byte(t, "5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0"), false); err != nil {
-		t.Error(err)
-	}
+	err := s.AddVote(testcommon.NewVoteHardcoded())
+	qt.Assert(t, err, qt.IsNil)
+	_, err = s.Envelope(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
+		testutil.Hex2byte(t, "5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0"), false)
+	qt.Assert(t, err, qt.IsNil)
 	c := s.CountVotes(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"), false)
-	if c != 1 {
-		t.Errorf("number of votes should be 1, received %d", c)
-	}
+	qt.Assert(t, c, qt.Equals, uint32(1))
 }
 
 func TestGetEnvelopeList(t *testing.T) {
 	t.Parallel()
 
 	s := testcommon.NewVochainStateWithProcess(t)
-	if err := s.AddVote(testcommon.VoteHardcoded()); err != nil {
-		t.Error(err)
-	}
-	if _, err := s.Envelope(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
-		testutil.Hex2byte(t, "5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0"), false); err != nil {
-		t.Error(err)
-	}
+	err := s.AddVote(testcommon.NewVoteHardcoded())
+	qt.Assert(t, err, qt.IsNil)
+	_, err = s.Envelope(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
+		testutil.Hex2byte(t, "5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0"), false)
+	qt.Assert(t, err, qt.IsNil)
 	nullifiers := s.EnvelopeList(testutil.Hex2byte(t, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"), 0, 1, false)
-	if string(nullifiers[0]) != string(testutil.Hex2byte(t, "5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0")) {
-		t.Errorf("bad nullifier recovered, expected: 5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0, got: %s", nullifiers[0])
-	}
+	qt.Assert(t, string(nullifiers[0]), qt.Equals,
+		string(testutil.Hex2byte(t, "5592f1c18e2a15953f355c34b247d751da307338c994000b9a65db1dc14cc6c0")))
 }

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -32,9 +32,9 @@ var (
 		common.HexToAddress("06d0d2c41f4560f8ffea1285f44ce0ffa2e19ef0"),
 	}
 
-	// VoteHardcoded needs to be a constructor, since multiple tests will
+	// NewVoteHardcoded needs to be a constructor, since multiple tests will
 	// modify its value. We need a different pointer for each test.
-	VoteHardcoded = func() *models.Vote {
+	NewVoteHardcoded = func() *models.Vote {
 		vp, _ := base64.StdEncoding.DecodeString("eyJ0eXBlIjoicG9sbC12b3RlIiwibm9uY2UiOiI1NTkyZjFjMThlMmExNTk1M2YzNTVjMzRiMjQ3ZDc1MWRhMzA3MzM4Yzk5NDAwMGI5YTY1ZGIxZGMxNGNjNmMwIiwidm90ZXMiOlsxLDIsMV19")
 		return &models.Vote{
 			ProcessId:   testutil.Hex2byte(nil, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
@@ -53,6 +53,11 @@ var (
 		Mode:         &models.ProcessMode{},
 		Status:       models.ProcessStatus_READY,
 		VoteOptions:  &models.ProcessVoteOptions{MaxCount: 16, MaxValue: 16},
+	}
+
+	StateDBProcessHardcoded = &models.StateDBProcess{
+		Process:   ProcessHardcoded,
+		VotesRoot: make([]byte, 32),
 	}
 
 	// privKey e0aa6db5a833531da4d259fb5df210bae481b276dc4c2ab6ab9771569375aed5 for address 06d0d2c41f4560f8ffea1285f44ce0ffa2e19ef0
@@ -151,11 +156,14 @@ func NewVochainStateWithProcess(tb testing.TB) *vochain.State {
 		tb.Fatal(err)
 	}
 	// add process
-	processBytes, err := proto.Marshal(ProcessHardcoded)
+	processBytes, err := proto.Marshal(StateDBProcessHardcoded)
 	if err != nil {
 		tb.Fatal(err)
 	}
-	if err = s.Store.Tree(vochain.ProcessTree).Add(testutil.Hex2byte(nil, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"), processBytes); err != nil {
+	if err = s.Tx.DeepSet(
+		testutil.Hex2byte(nil, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
+		processBytes,
+		vochain.ProcessesCfg); err != nil {
 		tb.Fatal(err)
 	}
 	return s

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -2,14 +2,34 @@ package vochain
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"go.vocdoni.io/dvote/log"
-	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
 )
 
+type Random struct {
+	rand *rand.Rand
+}
+
+func newRandom(seed int64) Random {
+	return Random{
+		rand: rand.New(rand.NewSource(seed)),
+	}
+}
+
+func (r *Random) RandomBytes(n int) []byte {
+	b := make([]byte, n)
+	_, err := r.rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
 func TestState(t *testing.T) {
+	rng := newRandom(0)
 	log.Init("info", "stdout")
 	s, err := NewState(t.TempDir())
 	if err != nil {
@@ -18,9 +38,9 @@ func TestState(t *testing.T) {
 
 	var pids [][]byte
 	for i := 0; i < 100; i++ {
-		pids = append(pids, util.RandomBytes(32))
+		pids = append(pids, rng.RandomBytes(32))
 		censusURI := "ipfs://foobar"
-		p := &models.Process{EntityId: util.RandomBytes(32), CensusURI: &censusURI, ProcessId: pids[i]}
+		p := &models.Process{EntityId: rng.RandomBytes(32), CensusURI: &censusURI, ProcessId: pids[i]}
 		if err := s.AddProcess(p); err != nil {
 			t.Fatal(err)
 		}
@@ -28,7 +48,7 @@ func TestState(t *testing.T) {
 		for j := 0; j < 10; j++ {
 			v := &models.Vote{
 				ProcessId:   pids[i],
-				Nullifier:   util.RandomBytes(32),
+				Nullifier:   rng.RandomBytes(32),
 				VotePackage: []byte(fmt.Sprintf("%d%d", i, j)),
 			}
 			if err := s.AddVote(v); err != nil {
@@ -46,7 +66,7 @@ func TestState(t *testing.T) {
 		t.Errorf("entityID is not correct")
 	}
 
-	_, err = s.Process(util.RandomBytes(32), false)
+	_, err = s.Process(rng.RandomBytes(32), false)
 	if err == nil {
 		t.Errorf("process must not exist")
 	}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -35,7 +35,7 @@ func AddTx(vtx *models.Tx, txBytes, signature []byte, state *State,
 		return v.Nullifier, nil
 	case *models.Tx_Admin:
 		if err := AdminTxCheck(vtx, txBytes, signature, state); err != nil {
-			return []byte{}, fmt.Errorf("adminTxChek: %w", err)
+			return []byte{}, fmt.Errorf("adminTxCheck: %w", err)
 		}
 		tx := vtx.GetAdmin()
 		if commit {

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -23,9 +23,7 @@ var (
 	ErrVoteDoesNotExist = fmt.Errorf("vote does not exist")
 	ErrProcessNotFound  = fmt.Errorf("process not found")
 	// keys; not constants because of []byte
-	headerKey    = []byte("header")
-	oracleKey    = []byte("oracle")
-	validatorKey = []byte("validator")
+	headerKey = []byte("header")
 )
 
 // PrefixDBCacheSize is the size of the cache for the MutableTree IAVL databases


### PR DESCRIPTION
Integrate Arbo-based StateDB in vochain

Replace the IAVL-based StateDB used to store the vochain state by the new
Arbo-based StateDB.  This change doesn't introduce new features.

Due to the change of the vochain state underlying structure, even if the same
data is stored in the StateDB, the calculated hash of the state will be
completely different and incompatible with the previous one.  This means that
this change is not compatible with a chain built with the old StateDB, and
requires a chain reset to work.

Change notes:
- In statedb, remove SubTreeSingleConfig type and SubTreeSingle method
  in favour of a single config type (renamed to TreeConfig) and method.
  Introduced a new type TreeNonSingleConfig that becomes a TreeConfig
  with the method WithKey, in order to keep different types for
  singleton trees configuration and non-singleton trees configuration.
  So now, we open a singleton tree like this:
  `mainTree.SubTree(OraclesCfg)` and a non-singleton tree like this:
  `processesTree.SubTree(CensusCfg.Key(pid))`.  This type unification
  allows creating a slice of trees configuration (no matter if they are
  singleton or non-singleton) to easily access nested subtrees.
- Added new methods to the TreeUpdate/TreeView in statedb to make it
  simpler to query nested trees: `DeepSubTree`, `DeepGet`, `DeepAdd` and
  `DeepSet`.
- Replace VoteID = processID + nullifier by hash(processID + nullifier).  The
  old VoteID was longer than 32 bytes, and that made it not friendly to be used
  as a key in Arbo.  By hashing we obtain a 32byte that suits an Arbo key.
- In VotesTree, replace storage format from (key:VoteID, value:VoteHash) to
  (key:VoteID, value:StateDBVote) where StateDBVote is a new protobuf model
  which contains { VoteHash, ProcessID, Nullifier }.  This is required because
  now the VoteID is a hash of processID and nullifier, and thus from the VoteID
  we can't recover the nullifier, and we need a way to obtain the nullifier of
  a stored vote.
- In ProcessesTree, replace storage format from (key: ProcessID, value:
  Process) to (key: ProcessID, value: StateDBProcess) where StateDBProcess is a
  new protobuf model which contains { Process, VotesRoot }.  This is required
  because now there is a VotesTree for each Processes stored in the StateDB.
  To query the VotesTree at diferent blocks we need to store it's root next to
  the Process.
- New hierarchy in the StateDB. In bold are trees.
    - Before:
        - 1 **AppTree**
            - 1 OracleList
            - 1 ValidatorList
            - 1 Header
        - 1 **ProcessTree**
            - N Processes indexed by ProcessID
        - 1 **VoteTree**
            - N Votes indexed by ProcessID + Nullifier
    - After:
        - 1 **MainTree**
            - 1 **OracleTree**
                - N Oracles indexed by address
            - 1 **ValidatorTree**
                - N Validators indexed by address
            - 1 Header
            - 1 **ProcessesTree**
                - N Processes indexed by ProcessID
                    - 1 **VotesTree**
                        - N Votes indexed by VoteID
