### PR TITLE
Fix block.Height appHash disparity

### DIFF
--- a/vochain/cache.go
+++ b/vochain/cache.go
@@ -5,6 +5,7 @@ import (
 
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/proto/build/go/models"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -34,13 +35,22 @@ func (v *State) CacheDel(id [32]byte) {
 	v.voteCache.Remove(id)
 }
 
-// CacheGet fetch an existing vote from the local cache
+// CacheGet fetch an existing vote from the local cache and returns a copy
 func (v *State) CacheGet(id [32]byte) *models.Vote {
 	record, ok := v.voteCache.Get(id)
 	if !ok || record == nil {
 		return nil
 	}
 	return record.(*models.Vote)
+}
+
+// CacheGetCopy fetch an existing vote from the local cache and returns a copy
+// which is thread-safe for writing.
+func (v *State) CacheGetCopy(id [32]byte) *models.Vote {
+	if vote := v.CacheGet(id); vote != nil {
+		return proto.Clone(vote).(*models.Vote)
+	}
+	return nil
 }
 
 // CacheHasNullifier fetch an existing vote from the local cache

--- a/vochain/census.go
+++ b/vochain/census.go
@@ -57,7 +57,7 @@ func RegisterKeyTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State)
 	if process == nil || process.EnvelopeType == nil || process.Mode == nil {
 		return fmt.Errorf("process %x malformed", tx.ProcessId)
 	}
-	if state.Height() >= process.StartBlock {
+	if state.CurrentHeight() >= process.StartBlock {
 		return fmt.Errorf("process %x already started", tx.ProcessId)
 	}
 	if process.Status != models.ProcessStatus_READY {

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/types"
@@ -163,7 +164,7 @@ func TestProcessSetStatusTransition(t *testing.T) {
 
 	// Set it to ENDED (should fail)
 	status = models.ProcessStatus_ENDED
-	t.Logf("height: %d", app.State.Header(false).Height)
+	t.Logf("height: %d", app.State.CurrentHeight())
 	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err == nil {
 		t.Fatal("ready to ended should not be valid if interruptible=false")
 	}
@@ -470,4 +471,18 @@ func testSetProcessCensus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 	}
 	app.Commit()
 	return nil
+}
+
+func TestCount(t *testing.T) {
+	app, err := NewBaseApplication(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err := app.State.CountProcesses(false)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, count, qt.Equals, uint64(0))
+
+	count, err = app.State.CountProcesses(true)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, count, qt.Equals, uint64(0))
 }

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -290,7 +290,7 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 	)
 
 	// Get the block time from the Header
-	currentBlockTime := time.Unix(s.App.State.Header(false).Timestamp, 0)
+	currentBlockTime := time.Unix(s.App.TimestampStartBlock(), 0)
 
 	// Add the entity to the indexer database
 	eid := p.GetEntityId()

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -517,7 +517,7 @@ func TestResults(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	err = sc.updateProcess(pid)
 	qt.Assert(t, err, qt.IsNil)
-	err = sc.setResultsHeight(pid, uint32(app.State.Header(false).GetHeight()))
+	err = sc.setResultsHeight(pid, app.State.CurrentHeight())
 	qt.Assert(t, err, qt.IsNil)
 	err = sc.ComputeResult(pid)
 	qt.Assert(t, err, qt.IsNil)

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
+	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/log"
 	models "go.vocdoni.io/proto/build/go/models"
 )
@@ -28,7 +29,23 @@ func (r *Random) RandomBytes(n int) []byte {
 	return b
 }
 
-func TestState(t *testing.T) {
+func TestStateReopen(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewState(dir)
+	qt.Assert(t, err, qt.IsNil)
+	hash1Before, err := s.Save()
+	qt.Assert(t, err, qt.IsNil)
+
+	s.db.Close()
+
+	s, err = NewState(dir)
+	qt.Assert(t, err, qt.IsNil)
+	hash1After, err := s.Store.Hash()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, hash1After, qt.DeepEquals, hash1Before)
+}
+
+func TestStateBasic(t *testing.T) {
 	rng := newRandom(0)
 	log.Init("info", "stdout")
 	s, err := NewState(t.TempDir())

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -24,6 +24,7 @@ var (
 	ErrProcessNotFound  = fmt.Errorf("process not found")
 	// keys; not constants because of []byte
 	headerKey = []byte("header")
+	heightKey = []byte("height")
 )
 
 // PrefixDBCacheSize is the size of the cache for the MutableTree IAVL databases

--- a/vochain/vochaininfo/vochaininfo.go
+++ b/vochain/vochaininfo/vochaininfo.go
@@ -163,7 +163,6 @@ func (vi *VochainInfo) Start(sleepSecs int64) {
 			vi.avg60 = a60
 			vi.avg360 = a360
 			vi.avg1440 = a1440
-			vi.vnode.State.RLock()
 			var err error
 			vi.processTreeSize, err = vi.vnode.State.CountProcesses(true)
 			if err != nil {
@@ -181,7 +180,6 @@ func (vi *VochainInfo) Start(sleepSecs int64) {
 			// 	vm = 0
 			// }
 			vi.voteCacheSize = vi.vnode.State.CacheSize()
-			vi.vnode.State.RUnlock()
 			vi.mempoolSize = vi.vnode.Node.Mempool().Size()
 			vi.lock.Unlock()
 


### PR DESCRIPTION
Don't store the block request header in the state.  Previously the block
request header was stored in the state.  I found this confusing because then
the state hash is updated at every block even if there are no transactions that
update the state, and only the height and timestamp were ever queried.

Add startBlockTimestamp in BaseApplication so that it can be consumed by the
scrutinizer (previously this was stored in the header in the state).

Store the last commited block height in the NoState of the StateDB, so that on
init we can query the height of the last stored height (required for Tendermint
Info method).  Also keep the current block in a variable in State.

Move State RWMutex into a wrapper with the Tx to make it explicit that
only the State.Tx requires locking.