### PR TITLE
vochain: remove commitment and reveal keys

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -187,7 +187,6 @@ type MetaResponse struct {
 	CensusKeys           [][]byte                         `json:"censusKeys,omitempty"`
 	CensusValues         []types.HexBytes                 `json:"censusValues,omitempty"`
 	CensusDump           []byte                           `json:"censusDump,omitempty"`
-	CommitmentKeys       []Key                            `json:"commitmentKeys,omitempty"`
 	Content              []byte                           `json:"content,omitempty"`
 	CreationTime         int64                            `json:"creationTime,omitempty"`
 	EncryptionPrivKeys   []Key                            `json:"encryptionPrivKeys,omitempty"`
@@ -216,7 +215,6 @@ type MetaResponse struct {
 	Registered           *bool                            `json:"registered,omitempty"`
 	Request              string                           `json:"request"`
 	Results              [][]string                       `json:"results,omitempty"`
-	RevealKeys           []Key                            `json:"revealKeys,omitempty"`
 	Root                 types.HexBytes                   `json:"root,omitempty"`
 	Siblings             types.HexBytes                   `json:"siblings,omitempty"`
 	Size                 *int64                           `json:"size,omitempty"`

--- a/client/api.go
+++ b/client/api.go
@@ -19,8 +19,6 @@ import (
 type pkeys struct {
 	pub  []api.Key
 	priv []api.Key
-	comm []api.Key
-	rev  []api.Key
 }
 
 func (c *Client) GetEnvelopeStatus(nullifier, pid []byte) (bool, error) {
@@ -148,8 +146,6 @@ func (c *Client) GetKeys(pid, eid []byte) (*pkeys, error) {
 	return &pkeys{
 		pub:  resp.EncryptionPublicKeys,
 		priv: resp.EncryptionPrivKeys,
-		comm: resp.CommitmentKeys,
-		rev:  resp.RevealKeys,
 	}, nil
 }
 

--- a/cmd/dvotecli/commands/process.go
+++ b/cmd/dvotecli/commands/process.go
@@ -161,17 +161,9 @@ func processKeys(cmd *cobra.Command, args []string) error {
 	for _, pubk := range resp.EncryptionPublicKeys {
 		fmt.Fprintf(buffer, "%v ", pubk.Key)
 	}
-	buffer.WriteString("\nCommitment Keys: ")
-	for _, cmk := range resp.CommitmentKeys {
-		fmt.Fprintf(buffer, "%v ", cmk.Key)
-	}
 	buffer.WriteString("\nEncryption Private Keys: ")
 	for _, pvk := range resp.EncryptionPrivKeys {
 		fmt.Fprintf(buffer, "%v ", pvk.Key)
-	}
-	buffer.WriteString("\nReveal Keys: ")
-	for _, rvk := range resp.RevealKeys {
-		fmt.Fprintf(buffer, "%v ", rvk.Key)
 	}
 	fmt.Print(buffer.String())
 	return err

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.18.1
-	go.vocdoni.io/proto v1.0.4-0.20210910152144-4f30a5b8664c
+	go.vocdoni.io/proto v1.0.4-0.20210922071331-d3f7a9536661
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
 	google.golang.org/protobuf v1.27.1

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.18.1
-	go.vocdoni.io/proto v1.0.4-0.20210922071331-d3f7a9536661
+	go.vocdoni.io/proto v1.0.4-0.20210922091620-af1d75fc6de2
 	golang.org/x/crypto v0.0.0-20210920023735-84f357641f63
 	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -2171,6 +2171,8 @@ go.vocdoni.io/proto v1.0.4-0.20210922065140-e9e4afd89df6 h1:7Pq5+iiFII95w11rjkBR
 go.vocdoni.io/proto v1.0.4-0.20210922065140-e9e4afd89df6/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go.vocdoni.io/proto v1.0.4-0.20210922071331-d3f7a9536661 h1:68ARxHP+67+rjiZhp3stzsfklXG0pIr/tE3apqC7R+4=
 go.vocdoni.io/proto v1.0.4-0.20210922071331-d3f7a9536661/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
+go.vocdoni.io/proto v1.0.4-0.20210922091620-af1d75fc6de2 h1:66K9hO/amf1ThJEtEZIT7b4lN7SIwk0kwJc3ScoUiMc=
+go.vocdoni.io/proto v1.0.4-0.20210922091620-af1d75fc6de2/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20200411211856-f5505b9728dd h1:BNJlw5kRTzdmyfh5U8F93HA2OwkP7ZGwA51eJ/0wKOU=
 go4.org v0.0.0-20200411211856-f5505b9728dd/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=

--- a/go.sum
+++ b/go.sum
@@ -2115,6 +2115,10 @@ go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJ
 go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
 go.vocdoni.io/proto v1.0.4-0.20210910152144-4f30a5b8664c h1:kM/ZBLJ7UQZqqu8INlFbaHDxAt4o7L1omJMgL4AJcJw=
 go.vocdoni.io/proto v1.0.4-0.20210910152144-4f30a5b8664c/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
+go.vocdoni.io/proto v1.0.4-0.20210922065140-e9e4afd89df6 h1:7Pq5+iiFII95w11rjkBRo/iGfvCBpFD1EHG4l6j9eT0=
+go.vocdoni.io/proto v1.0.4-0.20210922065140-e9e4afd89df6/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
+go.vocdoni.io/proto v1.0.4-0.20210922071331-d3f7a9536661 h1:68ARxHP+67+rjiZhp3stzsfklXG0pIr/tE3apqC7R+4=
+go.vocdoni.io/proto v1.0.4-0.20210922071331-d3f7a9536661/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20200411211856-f5505b9728dd h1:BNJlw5kRTzdmyfh5U8F93HA2OwkP7ZGwA51eJ/0wKOU=
 go4.org v0.0.0-20200411211856-f5505b9728dd/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=

--- a/router/voteCallbacks.go
+++ b/router/voteCallbacks.go
@@ -281,7 +281,7 @@ func (r *Router) getProcessKeys(request RouterRequest) {
 		return
 	}
 	var response api.MetaResponse
-	var pubs, privs, coms, revs []api.Key
+	var pubs, privs []api.Key
 	for idx, pubk := range process.EncryptionPublicKeys {
 		if len(pubk) > 0 {
 			pubs = append(pubs, api.Key{Idx: idx, Key: pubk})
@@ -292,20 +292,8 @@ func (r *Router) getProcessKeys(request RouterRequest) {
 			privs = append(privs, api.Key{Idx: idx, Key: privk})
 		}
 	}
-	for idx, comk := range process.CommitmentKeys {
-		if len(comk) > 0 {
-			coms = append(coms, api.Key{Idx: idx, Key: comk})
-		}
-	}
-	for idx, revk := range process.RevealKeys {
-		if len(revk) > 0 {
-			revs = append(revs, api.Key{Idx: idx, Key: revk})
-		}
-	}
 	response.EncryptionPublicKeys = pubs
 	response.EncryptionPrivKeys = privs
-	response.CommitmentKeys = coms
-	response.RevealKeys = revs
 	if err := request.Send(r.BuildReply(request, &response)); err != nil {
 		log.Warnf("error sending response: %s", err)
 	}

--- a/types/consts.go
+++ b/types/consts.go
@@ -131,7 +131,7 @@ const (
 
 	// KeyKeeper
 
-	// KeyKeeperMaxKeyIndex is the maxim number of allowed Encryption or Commitment keys
+	// KeyKeeperMaxKeyIndex is the maxim number of allowed encryption keys
 	KeyKeeperMaxKeyIndex = 16
 
 	// List of transition names

--- a/vochain/censusdownloader/censusdownloader.go
+++ b/vochain/censusdownloader/censusdownloader.go
@@ -79,11 +79,11 @@ func (c *CensusDownloader) OnProcess(pid, eid []byte, censusRoot, censusURI stri
 }
 
 // NOT USED but required for implementing the interface
-func (c *CensusDownloader) OnCancel(pid []byte, txindex int32)                       {}
-func (c *CensusDownloader) OnVote(v *models.Vote, txindex int32)                     {}
-func (c *CensusDownloader) OnNewTx(blockHeight uint32, txIndex int32)                {}
-func (c *CensusDownloader) OnProcessKeys(pid []byte, pub, com string, txindex int32) {}
-func (c *CensusDownloader) OnRevealKeys(pid []byte, priv, rev string, txindex int32) {}
+func (c *CensusDownloader) OnCancel(pid []byte, txindex int32)                  {}
+func (c *CensusDownloader) OnVote(v *models.Vote, txindex int32)                {}
+func (c *CensusDownloader) OnNewTx(blockHeight uint32, txIndex int32)           {}
+func (c *CensusDownloader) OnProcessKeys(pid []byte, pub string, txindex int32) {}
+func (c *CensusDownloader) OnRevealKeys(pid []byte, priv string, txindex int32) {}
 func (c *CensusDownloader) OnProcessStatusChange(pid []byte,
 	status models.ProcessStatus, txindex int32) {
 }

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -26,7 +26,6 @@ import (
 // keys are deterministic and can be re-created at any time.
 
 const (
-	commitmentKeySize = nacl.KeyLength
 	encryptionKeySize = nacl.KeyLength
 	dbPrefixProcess   = "p_"
 	dbPrefixBlock     = "b_"
@@ -43,16 +42,14 @@ type KeyKeeper struct {
 }
 
 type processKeys struct {
-	pubKey        []byte
-	privKey       []byte
-	revealKey     []byte
-	commitmentKey []byte
-	index         int8
+	pubKey  []byte
+	privKey []byte
+	index   int8
 }
 
 // Encode encodes processKeys to bytes
 func (pk *processKeys) Encode() []byte {
-	data := make([]byte, commitmentKeySize*2+encryptionKeySize*2+1)
+	data := make([]byte, +encryptionKeySize*2+1)
 	i := 0
 
 	copy(data, pk.pubKey)
@@ -61,18 +58,13 @@ func (pk *processKeys) Encode() []byte {
 	copy(data[i:], pk.privKey)
 	i += encryptionKeySize
 
-	copy(data[i:], pk.revealKey)
-	i += commitmentKeySize
-
-	copy(data[i:], pk.commitmentKey)
-
-	data[128] = byte(pk.index)
+	data[i] = byte(pk.index)
 	return data
 }
 
 // Decode decodes processKeys from data
 func (pk *processKeys) Decode(data []byte) error {
-	if len(data) < commitmentKeySize*2+encryptionKeySize*2+1 {
+	if len(data) < encryptionKeySize*2+1 {
 		return fmt.Errorf("cannot decode, data too small")
 	}
 	i := 0
@@ -82,12 +74,6 @@ func (pk *processKeys) Decode(data []byte) error {
 
 	pk.privKey = append([]byte(nil), data[i:i+encryptionKeySize]...)
 	i += encryptionKeySize
-
-	pk.revealKey = append([]byte(nil), data[i:i+commitmentKeySize]...)
-	i += commitmentKeySize
-
-	pk.commitmentKey = append([]byte(nil), data[i:i+commitmentKeySize]...)
-	i += commitmentKeySize
 
 	pk.index = int8(data[i])
 	return nil
@@ -210,7 +196,7 @@ func (k *KeyKeeper) OnProcess(pid, eid []byte, censusRoot, censusURI string, txi
 		return
 	}
 	// If keys already exist, do nothing (this happens on the start-up block replay)
-	if len(p.EncryptionPublicKeys[k.myIndex])+len(p.CommitmentKeys[k.myIndex]) > 0 {
+	if len(p.EncryptionPublicKeys[k.myIndex]) > 0 {
 		return
 	}
 	log.Debugf("generating key for process %x", pid)
@@ -285,12 +271,12 @@ func (k *KeyKeeper) OnProcessStatusChange(pid []byte, status models.ProcessStatu
 }
 
 // OnProcessKeys does nothing
-func (k *KeyKeeper) OnProcessKeys(pid []byte, pub, com string, txindex int32) {
+func (k *KeyKeeper) OnProcessKeys(pid []byte, pub string, txindex int32) {
 	// do nothing
 }
 
 // OnRevealKeys does nothing
-func (k *KeyKeeper) OnRevealKeys(pid []byte, priv, rev string, txindex int32) {
+func (k *KeyKeeper) OnRevealKeys(pid []byte, priv string, txindex int32) {
 	// do nothing
 }
 
@@ -315,17 +301,10 @@ func (k *KeyKeeper) generateKeys(pid []byte) (*processKeys, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate encryption key: (%s)", err)
 	}
-	// Reveal and commitment keys
-	ckb := ethereum.HashRaw(priv.Bytes())
-	ck := ckb[:commitmentKeySize]
-	ckhash := ethereum.HashRaw(ckb)[:commitmentKeySize]
-
 	pk := &processKeys{
-		privKey:       priv.Bytes(),
-		pubKey:        priv.Public().Bytes(),
-		revealKey:     ck,
-		commitmentKey: ckhash,
-		index:         k.myIndex,
+		privKey: priv.Bytes(),
+		pubKey:  priv.Public().Bytes(),
+		index:   k.myIndex,
 	}
 	return pk, nil
 }
@@ -442,7 +421,6 @@ func (k *KeyKeeper) publishKeys(pk *processKeys, pid string) error {
 		Nonce:               util.RandomBytes(32),
 		ProcessId:           []byte(pid),
 		EncryptionPublicKey: pk.pubKey,
-		CommitmentKey:       pk.commitmentKey,
 	}
 	if err := k.signAndSendTx(tx); err != nil {
 		return err
@@ -498,16 +476,12 @@ func (k *KeyKeeper) revealKeys(pid string) error {
 		Nonce:                util.RandomBytes(32),
 		ProcessId:            []byte(pid),
 		EncryptionPrivateKey: pk.privKey,
-		RevealKey:            pk.revealKey,
 	}
 	if err := k.signAndSendTx(tx); err != nil {
 		return err
 	}
 	if len(pk.privKey) > 0 {
 		log.Infof("revealing encryption key for process %x", pid)
-	}
-	if len(pk.revealKey) > 0 {
-		log.Infof("revealing commitment key for process %x", pid)
 	}
 
 	wTx := k.storage.WriteTx()

--- a/vochain/keykeeper/keykeeper_test.go
+++ b/vochain/keykeeper/keykeeper_test.go
@@ -13,15 +13,11 @@ import (
 func TestEncodeDecode(t *testing.T) {
 	priv1, err := nacl.Generate(rand.Reader)
 	qt.Assert(t, err, qt.IsNil)
-	priv2, err := nacl.Generate(rand.Reader)
-	qt.Assert(t, err, qt.IsNil)
 
 	pk := processKeys{
-		pubKey:        priv1.Public().Bytes(),
-		privKey:       priv1.Bytes(),
-		revealKey:     priv2.Public().Bytes(),
-		commitmentKey: priv2.Bytes(),
-		index:         5,
+		pubKey:  priv1.Public().Bytes(),
+		privKey: priv1.Bytes(),
+		index:   5,
 	}
 	data := pk.Encode()
 	t.Logf("encoded data: %x", data)

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -373,8 +373,6 @@ func NewProcessTxCheck(vtx *models.Tx, txBytes,
 		// We consider the zero value as nil for security
 		tx.Process.EncryptionPublicKeys = make([]string, types.KeyKeeperMaxKeyIndex)
 		tx.Process.EncryptionPrivateKeys = make([]string, types.KeyKeeperMaxKeyIndex)
-		tx.Process.CommitmentKeys = make([]string, types.KeyKeeperMaxKeyIndex)
-		tx.Process.RevealKeys = make([]string, types.KeyKeeperMaxKeyIndex)
 	}
 	return tx.Process, nil
 }

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -445,7 +445,7 @@ func (s *Scrutinizer) OnCancel(pid []byte, txIndex int32) {
 }
 
 // OnProcessKeys does nothing
-func (s *Scrutinizer) OnProcessKeys(pid []byte, pub, commit string, txIndex int32) {
+func (s *Scrutinizer) OnProcessKeys(pid []byte, pub string, txIndex int32) {
 	s.updateProcessPool = append(s.updateProcessPool, pid)
 }
 
@@ -464,7 +464,7 @@ func (s *Scrutinizer) OnProcessStatusChange(pid []byte, status models.ProcessSta
 
 // OnRevealKeys checks if all keys have been revealed and in such case add the
 // process to the results queue
-func (s *Scrutinizer) OnRevealKeys(pid []byte, priv, reveal string, txIndex int32) {
+func (s *Scrutinizer) OnRevealKeys(pid []byte, priv string, txIndex int32) {
 	p, err := s.App.State.Process(pid, false)
 	if err != nil {
 		log.Errorf("cannot fetch process %s from state: (%s)", pid, err)


### PR DESCRIPTION
The current zkSnarks circuit implemented does not use
reveal and commitment keys, so this commit removes them
from the Process data structure and from the keykeeper.

Signed-off-by: p4u <pau@dabax.net>