### PR TITLE
Add zk-artifacts DownloadVKFile function

### DIFF
--- a/crypto/zk/artifacts/artifacts_test.go
+++ b/crypto/zk/artifacts/artifacts_test.go
@@ -94,3 +94,64 @@ func TestDownloadCircuitFiles(t *testing.T) {
 	qt.Assert(t, errExpected, qt.Equals,
 		"expected hash: 2ca5070e6fb17b920c1f938903c39867a2561900aaa2de52ec2265d46d41eb12, computed hash: 2ba5070e6fb17b920c1f938903c39867a2561900aaa2de52ec2265d46d41eb12")
 }
+
+func TestDownloadVKFile(t *testing.T) {
+	// create a test server that serves test files
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	vkHash, err := hex.DecodeString("de3b651d4d47a956eb8e27cbc2e7d145e7677d68fddac275604dbc697690e751")
+	qt.Assert(t, err, qt.IsNil)
+
+	path := t.TempDir()
+	c := CircuitsConfig{
+		URL:          ts.URL,
+		CircuitsPath: "/zkcensusproof/test/1024/",
+		LocalDir:     path,
+		VKHash:       vkHash,
+	}
+
+	ctx := context.Background()
+
+	// 0. delete files if exist in tmp test path
+	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameVK))
+
+	// 1. Files don't exist yet, call DownloadVKFile, then
+	// check expected hashes
+	err = DownloadVKFile(ctx, c)
+	qt.Assert(t, err, qt.IsNil)
+
+	// 2. Remove the VK file and call DownloadVKFile, check
+	// expected hashes
+	err = os.Remove(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameVK))
+	qt.Assert(t, err, qt.IsNil)
+	err = DownloadVKFile(ctx, c)
+	qt.Assert(t, err, qt.IsNil)
+
+	// checkHashe without download, as was download in the last step (2)
+	err = checkHash(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameVK), c.VKHash)
+	qt.Assert(t, err, qt.IsNil)
+
+	// 3. Call again DownloadVKFile, expect no new download
+	// and check expected hashes.
+	// Stop the TestServer and call DownloadVKFile, should not
+	// give any error as the file already exist locally and match the
+	// expected hash
+	ts.Close()
+	err = DownloadVKFile(ctx, c)
+	qt.Assert(t, err, qt.IsNil)
+
+	// run again the TestServer for the next step
+	ts = newTestServer(t)
+	defer ts.Close()
+
+	// 4. Call DownloadVKFile, but this time change one of the
+	// expected hashes to not match.
+	// change the expected hash of witness.wasm
+	c.VKHash[0] += 1
+	err = DownloadVKFile(ctx, c)
+	qt.Assert(t, err, qt.IsNotNil)
+	errExpected := strings.Split(err.Error(), "verificationKey.json, ")[1]
+	qt.Assert(t, errExpected, qt.Equals,
+		"expected hash: df3b651d4d47a956eb8e27cbc2e7d145e7677d68fddac275604dbc697690e751, computed hash: de3b651d4d47a956eb8e27cbc2e7d145e7677d68fddac275604dbc697690e751")
+}


### PR DESCRIPTION
Add zk-artifacts DownloadVKFile function to download only the VK file
without the witness & zkey files.