### PR TITLE
Feature/batchtx

### DIFF
--- a/census/importqueue.go
+++ b/census/importqueue.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sync/atomic"
@@ -31,7 +32,7 @@ func (m *Manager) importTree(tree []byte, cid string) error {
 		return fmt.Errorf("no claims found on the retreived census")
 	}
 	tr, err := m.AddNamespace(cid, dump.Type, []string{})
-	if err == ErrNamespaceExist {
+	if errors.Is(err, ErrNamespaceExist) {
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("cannot create new census namespace: (%s)", err)

--- a/censustree/censustree.go
+++ b/censustree/censustree.go
@@ -33,8 +33,7 @@ const nLevels = 256
 
 // New returns a new Tree, if there already is a Tree in the
 // database, it will load it.
-func New(wTx db.WriteTx, opts Options) (
-	*Tree, error) {
+func New(wTx db.WriteTx, opts Options) (*Tree, error) {
 	var hashFunc arbo.HashFunction
 
 	switch opts.CensusType {
@@ -54,6 +53,7 @@ func New(wTx db.WriteTx, opts Options) (
 
 	t, err := tree.New(wTx, tree.Options{DB: database, MaxLevels: nLevels, HashFunc: hashFunc})
 	if err != nil {
+		database.Close()
 		return nil, err
 	}
 	return &Tree{Tree: t, censusType: opts.CensusType}, nil

--- a/censustreelegacy/arbotree/wrapper.go
+++ b/censustreelegacy/arbotree/wrapper.go
@@ -42,6 +42,7 @@ func NewTree(name, storageDir string, nLevels int, hashFunc arbo.HashFunction) (
 
 	mt, err := arbo.NewTree(database, nLevels, hashFunc)
 	if err != nil {
+		database.Close()
 		return nil, err
 	}
 	tree := &Tree{
@@ -80,6 +81,7 @@ func (t *Tree) Init(name, storageDir string) error {
 
 	mt, err := arbo.NewTree(database, 140, arbo.HashFunctionBlake2b)
 	if err != nil {
+		database.Close()
 		return err
 	}
 	t.Tree = mt

--- a/cmd/dvotecli/commands/json-client.go
+++ b/cmd/dvotecli/commands/json-client.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -54,7 +55,7 @@ func jsonInput(cmd *cobra.Command, args []string) error {
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		line, _, err := reader.ReadLine()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -176,7 +177,7 @@ func censusImport(host string, signer *ethereum.SignKeys) {
 	var pubk string
 	for {
 		line, _, err := reader.ReadLine()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/db/badgerdb/badger.go
+++ b/db/badgerdb/badger.go
@@ -1,6 +1,7 @@
 package badgerdb
 
 import (
+	"errors"
 	"os"
 
 	"github.com/dgraph-io/badger/v3"
@@ -53,12 +54,20 @@ func (tx WriteTx) Get(k []byte) ([]byte, error) {
 
 // Set implements the db.WriteTx.Set interface method
 func (tx WriteTx) Set(k, v []byte) error {
-	return tx.tx.Set(k, v)
+	if err := tx.tx.Set(k, v); errors.Is(err, badger.ErrTxnTooBig) {
+		return db.ErrTxnTooBig
+	} else {
+		return err
+	}
 }
 
 // Delete implements the db.WriteTx.Delete interface method
 func (tx WriteTx) Delete(k []byte) error {
-	return tx.tx.Delete(k)
+	if err := tx.tx.Delete(k); errors.Is(err, badger.ErrTxnTooBig) {
+		return db.ErrTxnTooBig
+	} else {
+		return err
+	}
 }
 
 // Commit implements the db.WriteTx.Commit interface method

--- a/db/badgerdb/badger.go
+++ b/db/badgerdb/badger.go
@@ -33,7 +33,7 @@ var _ db.WriteTx = (*WriteTx)(nil)
 // Get implements the db.ReadTx.Get interface method
 func (tx ReadTx) Get(k []byte) ([]byte, error) {
 	item, err := tx.tx.Get(k)
-	if err == badger.ErrKeyNotFound {
+	if errors.Is(err, badger.ErrKeyNotFound) {
 		return nil, db.ErrKeyNotFound
 	}
 	if err != nil {

--- a/db/badgerdb/batch_test.go
+++ b/db/badgerdb/batch_test.go
@@ -1,0 +1,42 @@
+package badgerdb
+
+import (
+	"encoding/binary"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
+)
+
+func TestBatch(t *testing.T) {
+	database, err := New(Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	const n = 1_000_000
+	wTx := database.WriteTx()
+	var key [4]byte
+	var value [4]byte
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint32(key[:], uint32(i))
+		binary.LittleEndian.PutUint32(value[:], uint32(i))
+		if err = wTx.Set(key[:], value[:]); err != nil {
+			break
+		}
+	}
+	// A WriteTx with too many writes fails because the Txn becomes too big
+	qt.Assert(t, err, qt.Equals, db.ErrTxnTooBig)
+	wTx.Discard()
+
+	batch := db.NewBatch(database)
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint32(key[:], uint32(i))
+		binary.LittleEndian.PutUint32(value[:], uint32(i))
+		if err = batch.Set(key[:], value[:]); err != nil {
+			break
+		}
+	}
+	// A Batch will commit automatically during writes if the Txn becomes
+	// too big, so we expect all the writes to work and no error here.
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, batch.Commit(), qt.IsNil)
+}

--- a/db/batch.go
+++ b/db/batch.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"errors"
+)
+
+// Batch wraps a WriteTx to automatically commit when it becomes too big,
+// causing a new internal WriteTx to be created.
+type Batch struct {
+	tx WriteTx
+	db Database
+}
+
+// check that Batch implements the ReadTx & WriteTx interfaces
+var _ ReadTx = (*Batch)(nil)
+var _ WriteTx = (*Batch)(nil)
+
+// NewBatch creates a new Batch from a Database
+func NewBatch(db Database) *Batch {
+	return &Batch{
+		tx: db.WriteTx(),
+		db: db,
+	}
+}
+
+// Get implements the WriteTx.Get interface method
+func (t *Batch) Get(key []byte) ([]byte, error) {
+	return t.tx.Get(key)
+}
+
+// Discard implements the ReadTx.Discard interface method.  Notice that this
+// method will only discard the writes of the last interal tx: if the tx
+// previously has become too big a commit will have been applied that can't be
+// discarded.
+func (t *Batch) Discard() {
+	t.tx.Discard()
+}
+
+// Set implements the WriteTx.Set interface method.  If during this
+// operation, the internal tx becomes too big, all the pending writes will be
+// committed and a new WriteTx will be created to continue with this and
+// future writes.
+func (t *Batch) Set(key []byte, value []byte) error {
+	if err := t.tx.Set(key, value); errors.Is(err, ErrTxnTooBig) {
+		if err := t.tx.Commit(); err != nil {
+			return err
+		}
+		t.tx = t.db.WriteTx()
+		return t.tx.Set(key, value)
+	} else {
+		return err
+	}
+}
+
+// Delete implements the WriteTx.Delete interface method.  If during this
+// operation, the internal tx becomes too big, all the pending writes will be
+// committed and a new WriteTx will be created to continue with this and
+// future writes.
+func (t *Batch) Delete(key []byte) error {
+	if err := t.tx.Delete(key); errors.Is(err, ErrTxnTooBig) {
+		if err := t.tx.Commit(); err != nil {
+			return err
+		}
+		t.tx = t.db.WriteTx()
+		return t.tx.Delete(key)
+	} else {
+		return err
+	}
+}
+
+// Commit implements the WriteTx.Commit interface method.  Notice that this
+// method also commits the wrapped WriteTx.  Notice that this
+// method will only commit the writes of the last interal tx: if the tx
+// previously has become too big a commit will have already been applied to the
+// previous tx transparently during a Set or Delete.
+func (t *Batch) Commit() error {
+	return t.tx.Commit()
+}

--- a/db/interface.go
+++ b/db/interface.go
@@ -8,6 +8,10 @@ import (
 // ErrKeysNotFound is used to indicate that a key does not exist in the db.
 var ErrKeyNotFound = fmt.Errorf("key not found")
 
+// ErrTxnTooBig is used to indicate that a WriteTx is too big and can't include
+// more writes.
+var ErrTxnTooBig = fmt.Errorf("Txn too big")
+
 // Database wraps all database operations. All methods are safe for concurrent
 // use.
 type Database interface {

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/tendermint/tendermint v0.34.13
 	github.com/tendermint/tm-db v0.6.4
 	github.com/timshannon/badgerhold/v3 v3.0.0-20210415132401-e7c90fb5919f
-	github.com/vocdoni/arbo v0.0.0-20210921154009-4227039df19f
+	github.com/vocdoni/arbo v0.0.0-20210927131431-d7c756341372
 	github.com/vocdoni/go-external-ip v0.0.0-20210705122950-fae6195a1d44
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -2029,6 +2029,8 @@ github.com/vocdoni/arbo v0.0.0-20210920213715-1f885e3ac1cf h1:0go2OtM6HJPZt7TINa
 github.com/vocdoni/arbo v0.0.0-20210920213715-1f885e3ac1cf/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
 github.com/vocdoni/arbo v0.0.0-20210921154009-4227039df19f h1:78yhWWKm+wxQTSfk+C4xGD5Rxv/+qQ0yM+vdQkH3E/0=
 github.com/vocdoni/arbo v0.0.0-20210921154009-4227039df19f/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
+github.com/vocdoni/arbo v0.0.0-20210927131431-d7c756341372 h1:kgd6g8uJmZe6ftaKC9WORlPqSddZYLUQ1uwhYMJu6Xo=
+github.com/vocdoni/arbo v0.0.0-20210927131431-d7c756341372/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
 github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f h1:z7CK3k1yIutKycPY8s2ZbtwUBKMy3xPcLMh12QukLRY=
 github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f/go.mod h1:BoN7UMTA/JcgmNPaoUQq6RwuixhgSrk5PmCMVMKLxpc=
 github.com/vocdoni/blind-ca v0.1.4/go.mod h1:4ouWDqlvXrrNS0Csf3hKA3cuDTmKh6nP7kSXF39nT4s=

--- a/multirpc/example/httpws/client/client.go
+++ b/multirpc/example/httpws/client/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -129,7 +130,7 @@ func main() {
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		line, _, err := reader.ReadLine()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/router/voteCallbacks.go
+++ b/router/voteCallbacks.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"go.vocdoni.io/dvote/api"
@@ -91,7 +92,7 @@ func (r *Router) getEnvelopeStatus(request RouterRequest) {
 	response.Registered = types.False
 	vr, err := r.Scrutinizer.GetEnvelopeReference(request.Nullifier)
 	if err != nil {
-		if err == scrutinizer.ErrNotFoundInDatabase {
+		if errors.Is(err, scrutinizer.ErrNotFoundInDatabase) {
 			if err := request.Send(r.BuildReply(request, &response)); err != nil {
 				log.Warnf("error sending response: %s", err)
 			}
@@ -366,7 +367,7 @@ func (r *Router) getResults(request RouterRequest) {
 		r.SendError(request, err.Error())
 		return
 	}
-	if err == scrutinizer.ErrNoResultsYet {
+	if errors.Is(err, scrutinizer.ErrNoResultsYet) {
 		response.Message = scrutinizer.ErrNoResultsYet.Error()
 		if err := request.Send(r.BuildReply(request, &response)); err != nil {
 			log.Warnf("error sending response: %s", err)

--- a/statedb/statedb.go
+++ b/statedb/statedb.go
@@ -228,7 +228,7 @@ func setVersionRoot(tx db.WriteTx, version uint32, root []byte) error {
 // level tx.
 func getVersion(tx db.ReadTx) (uint32, error) {
 	versionLE, err := subReadTx(tx, path.Join(subKeyMeta, pathVersion)).Get(keyCurVersion)
-	if err == db.ErrKeyNotFound {
+	if errors.Is(err, db.ErrKeyNotFound) {
 		return 0, nil
 	} else if err != nil {
 		return 0, err
@@ -378,7 +378,7 @@ func (s *StateDB) TreeView(root []byte) (*TreeView, error) {
 	defer txTree.Discard()
 	tree, err := tree.New(&readOnlyWriteTx{txTree},
 		tree.Options{DB: subDB(s.db, subKeyTree), MaxLevels: cfg.maxLevels, HashFunc: cfg.hashFunc})
-	if err == ErrReadOnly {
+	if errors.Is(err, ErrReadOnly) {
 		return nil, ErrEmptyTree
 	} else if err != nil {
 		return nil, err

--- a/statedb/treeview.go
+++ b/statedb/treeview.go
@@ -1,6 +1,7 @@
 package statedb
 
 import (
+	"errors"
 	"path"
 
 	"go.vocdoni.io/dvote/db"
@@ -149,7 +150,7 @@ func (v *TreeView) SubTree(cfg TreeConfig) (treeView TreeViewer, err error) {
 	defer txTree.Discard()
 	tree, err := tree.New(&readOnlyWriteTx{txTree},
 		tree.Options{DB: subDB(db, subKeyTree), MaxLevels: cfg.maxLevels, HashFunc: cfg.hashFunc})
-	if err == ErrReadOnly {
+	if errors.Is(err, ErrReadOnly) {
 		return nil, ErrEmptyTree
 	} else if err != nil {
 		return nil, err

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/vocdoni/arbo"
@@ -79,7 +80,7 @@ func (t *Tree) Set(wTx db.WriteTx, key, value []byte) error {
 		defer wTx.Discard()
 	}
 	err := t.tree.UpdateWithTx(wTx, key, value)
-	if err == arbo.ErrKeyNotFound {
+	if errors.Is(err, arbo.ErrKeyNotFound) {
 		// key does not exist, use Add
 		return t.Add(wTx, key, value)
 	}

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -1,6 +1,7 @@
 package keykeeper
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -359,7 +360,7 @@ func (k *KeyKeeper) checkRevealProcess(height uint32) {
 	defer wTx.Discard()
 
 	data, err := wTx.Get(pKey)
-	if err == db.ErrKeyNotFound {
+	if errors.Is(err, db.ErrKeyNotFound) {
 		return
 	}
 	if err != nil {
@@ -429,7 +430,7 @@ func (k *KeyKeeper) publishKeys(pk *processKeys, pid string) error {
 	defer wTx.Discard()
 
 	var err error
-	if _, err = wTx.Get(dbKey); err == db.ErrKeyNotFound {
+	if _, err = wTx.Get(dbKey); errors.Is(err, db.ErrKeyNotFound) {
 		// key does not exist yet, store it
 		data := pk.Encode()
 		if err = wTx.Set(dbKey, data); err != nil {

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -2,6 +2,7 @@ package vochain
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/vocdoni/arbo"
@@ -69,7 +70,7 @@ func (v *State) Process(pid []byte, isQuery bool) (*models.Process, error) {
 		defer v.Tx.RUnlock()
 	}
 	processBytes, err := v.mainTreeViewer(isQuery).DeepGet(pid, ProcessesCfg)
-	if err == arbo.ErrKeyNotFound {
+	if errors.Is(err, arbo.ErrKeyNotFound) {
 		return nil, ErrProcessNotFound
 	} else if err != nil {
 		return nil, err
@@ -115,7 +116,7 @@ func (v *State) updateProcess(p *models.Process, pid []byte) error {
 		return err
 	}
 	processBytes, err := processesTree.Get(pid)
-	if err == arbo.ErrKeyNotFound {
+	if errors.Is(err, arbo.ErrKeyNotFound) {
 		return ErrProcessNotFound
 	} else if err != nil {
 		return err

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -2,6 +2,7 @@ package scrutinizer
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -520,7 +521,7 @@ func (s *Scrutinizer) OnProcessResults(pid []byte, results *models.ProcessResult
 			if err == nil {
 				break
 			}
-			if err == ErrNoResultsYet {
+			if errors.Is(err, ErrNoResultsYet) {
 				time.Sleep(2 * time.Second)
 				retries--
 				continue

--- a/vochain/scrutinizer/vote.go
+++ b/vochain/scrutinizer/vote.go
@@ -2,6 +2,7 @@ package scrutinizer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -301,7 +302,7 @@ func (s *Scrutinizer) GetResults(processID []byte) (*indexertypes.Results, error
 	results := &indexertypes.Results{}
 	if err := s.db.FindOne(results, badgerhold.Where(badgerhold.Key).
 		Eq(processID)); err != nil {
-		if err == badgerhold.ErrNotFound {
+		if errors.Is(err, badgerhold.ErrNotFound) {
 			return nil, ErrNoResultsYet
 		}
 		return nil, err

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -634,14 +635,15 @@ func (v *State) Envelope(processID, nullifier []byte, isQuery bool) (_ []byte, e
 
 // EnvelopeExists returns true if the envelope identified with voteID exists
 func (v *State) EnvelopeExists(processID, nullifier []byte, isQuery bool) (bool, error) {
-	e, err := v.Envelope(processID, nullifier, isQuery)
-	if err != nil && err != ErrVoteDoesNotExist {
+	_, err := v.Envelope(processID, nullifier, isQuery)
+	if errors.Is(err, ErrProcessNotFound) {
+		return false, nil
+	} else if errors.Is(err, ErrVoteDoesNotExist) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
-	if err == ErrVoteDoesNotExist {
-		return false, nil
-	}
-	return e != nil, nil
+	return true, nil
 }
 
 // iterateVotes iterates fn over state tree entries with the processID prefix.

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -349,7 +349,7 @@ func (v *State) RemoveOracle(address common.Address) error {
 	if err != nil {
 		return err
 	}
-	if _, err := oracles.Get(address.Bytes()); err == arbo.ErrKeyNotFound {
+	if _, err := oracles.Get(address.Bytes()); errors.Is(err, arbo.ErrKeyNotFound) {
 		return fmt.Errorf("oracle not found: %w", err)
 	} else if err != nil {
 		return err
@@ -416,7 +416,7 @@ func (v *State) RemoveValidator(address []byte) error {
 	if err != nil {
 		return err
 	}
-	if _, err := validators.Get(address); err == arbo.ErrKeyNotFound {
+	if _, err := validators.Get(address); errors.Is(err, arbo.ErrKeyNotFound) {
 		return fmt.Errorf("validator not found: %w", err)
 	} else if err != nil {
 		return err
@@ -524,7 +524,7 @@ func (v *State) VoteCount(isQuery bool) (uint64, error) {
 	}
 	noState := v.mainTreeViewer(isQuery).NoState()
 	voteCountLE, err := noState.Get(voteCountKey)
-	if err == db.ErrKeyNotFound {
+	if errors.Is(err, db.ErrKeyNotFound) {
 		return 0, nil
 	} else if err != nil {
 		return 0, err
@@ -536,7 +536,7 @@ func (v *State) VoteCount(isQuery bool) (uint64, error) {
 func (v *State) voteCountInc() error {
 	noState := v.Tx.NoState()
 	voteCountLE, err := noState.Get(voteCountKey)
-	if err == db.ErrKeyNotFound {
+	if errors.Is(err, db.ErrKeyNotFound) {
 		voteCountLE = make([]byte, 8)
 	} else if err != nil {
 		return err
@@ -615,13 +615,13 @@ func (v *State) Envelope(processID, nullifier []byte, isQuery bool) (_ []byte, e
 	}
 	votesTree, err := v.mainTreeViewer(isQuery).DeepSubTree(
 		ProcessesCfg, VotesCfg.WithKey(processID))
-	if err == arbo.ErrKeyNotFound {
+	if errors.Is(err, arbo.ErrKeyNotFound) {
 		return nil, ErrProcessNotFound
 	} else if err != nil {
 		return nil, err
 	}
 	sdbVoteBytes, err := votesTree.Get(vid)
-	if err == arbo.ErrKeyNotFound {
+	if errors.Is(err, arbo.ErrKeyNotFound) {
 		return nil, ErrVoteDoesNotExist
 	} else if err != nil {
 		return nil, err
@@ -756,7 +756,7 @@ func (v *State) Rollback() {
 func (v *State) LastHeight() (uint32, error) {
 	noState := v.mainTreeView().NoState()
 	heightLE, err := noState.Get(heightKey)
-	if err == db.ErrKeyNotFound {
+	if errors.Is(err, db.ErrKeyNotFound) {
 		return 0, nil
 	} else if err != nil {
 		return 0, err


### PR DESCRIPTION
# Close Database on failure

# Batch transactions in the StateDB

Introduce db/batch.Batch: a wrapper over a db.WriteTx that implements
db.WriteTx.  The batch acts as a WriteTx but when it becomes too big, it
automatically commits and continues with a new internal db.WriteTx
transparently.

Use this Batch instead of a regular WriteTx in the statedb.TreeTx to
avoid hitting the db.WriteTx size limit when the block contains many
updates.  Since we are now writting to disk between StateDB versions,
when opening TreeUpdates we need to make sure we start always from the
last commited version, so we query the expected root and set it via
tree.SetRoot if necessary.

This should fix the observed error "Txn is too big to fit into one
request" seen in #280