### PR TITLE
Store all censuses in same Database

### DIFF
--- a/census/census_test.go
+++ b/census/census_test.go
@@ -1,10 +1,20 @@
 package census
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/proto/build/go/models"
 )
 
 func TestCompressor(t *testing.T) {
@@ -24,4 +34,131 @@ func TestCompressor(t *testing.T) {
 
 	// Decompressing should give us the original input back.
 	qt.Assert(t, comp.decompressBytes(compressed), qt.DeepEquals, input)
+}
+
+func TestMemoryUsage(t *testing.T) {
+	var cm Manager
+	qt.Assert(t, cm.Start(t.TempDir(), ""), qt.IsNil)
+	defer func() { qt.Assert(t, cm.Stop(), qt.IsNil) }()
+
+	const n = 16
+	var start, end runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&start)
+	for i := 0; i < n; i++ {
+		_, err := cm.LoadTree(fmt.Sprintf("%v", i), models.Census_ARBO_BLAKE2B)
+		qt.Assert(t, err, qt.IsNil)
+	}
+	runtime.ReadMemStats(&end)
+	_, _, loaded := cm.Count()
+	qt.Assert(t, loaded, qt.Equals, n)
+	alloc := end.Alloc - start.Alloc
+	// Assert that loading 16 censuses doesn't consume more than 1 GiB of memory
+	const maxAlloc = 1 * 1024 * 1024 * 1024
+	qt.Assert(t, alloc < maxAlloc, qt.Equals, true,
+		qt.Commentf("(got) %v MiB > (max) %v MiB", alloc/1024/1024, maxAlloc/1024/1024))
+}
+
+var nsConfigJSON1 = `
+{
+  "rootKey": "",
+  "namespaces": [
+    {
+      "type": 0,
+      "name": "dB5Cfb98c52a0a396F50087a882dCB10d26cB984/39f8da5676cadec08999ac5ddd72a2b13649c4438fe24a57329fb5229a09cdb9",
+      "keys": [
+        "0x04044abfd3f1cf573f4c9fb0eaf3bb1b1e1fd0f89dde12dce494ae69d7589feebfbe243efb8d2258902bea75ebcb470a3eb3e577300a896507047af91b90dfab5f"
+      ]
+    },
+    {
+      "type": 0,
+      "name": "44f90c48101a69aa5bcaea4a548585c5a2e853c988a12e720f74915d31c3c7a5",
+      "keys": null
+    }
+  ]
+}
+	`
+
+func TestOutdatedCensuses(t *testing.T) {
+	// Create a structure of 2 outdated census types, saved in namespaces.json
+	storageDir := t.TempDir()
+	time.Sleep(1 * time.Second)
+	nsConfig := filepath.Join(storageDir, "namespaces.json")
+	qt.Assert(t, ioutil.WriteFile(nsConfig, []byte(nsConfigJSON1), 0o600), qt.IsNil)
+
+	var namespaces Namespaces
+	qt.Assert(t, json.Unmarshal([]byte(nsConfigJSON1), &namespaces), qt.IsNil)
+	for _, v := range namespaces.Namespaces {
+		qt.Assert(t, os.MkdirAll(filepath.Join(storageDir, v.Name), 0o700), qt.IsNil)
+	}
+
+	// Init Manager, and expect the outdated censuses to be moved,
+	// namespaces.json to be backed up and cleaned
+	var cm Manager
+	qt.Assert(t, cm.Start(storageDir, ""), qt.IsNil)
+	defer func() { qt.Assert(t, cm.Stop(), qt.IsNil) }()
+
+	// Assert correct namespaces.json backup
+	matches, err := filepath.Glob(filepath.Join(storageDir, "namespaces.*.json"))
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, len(matches), qt.Equals, 1)
+
+	nsConfigBackupJSON, err := os.ReadFile(matches[0])
+	qt.Assert(t, err, qt.IsNil)
+	var namespacesBackup Namespaces
+	qt.Assert(t, json.Unmarshal([]byte(nsConfigBackupJSON), &namespacesBackup), qt.IsNil)
+	qt.Assert(t, namespacesBackup, qt.DeepEquals, namespaces)
+
+	// Assert correnct namespaces.json cleaned
+	nsConfigJSON, err := os.ReadFile(nsConfig)
+	qt.Assert(t, err, qt.IsNil)
+	var namespacesClean Namespaces
+	qt.Assert(t, json.Unmarshal([]byte(nsConfigJSON), &namespacesClean), qt.IsNil)
+	qt.Assert(t, namespacesClean, qt.DeepEquals, Namespaces{})
+
+	// Assert outdated censuses moved to outdated folder
+	matches, err = filepath.Glob(filepath.Join(storageDir, "outdated.*/v0"))
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, len(matches), qt.Equals, 1)
+	_, err = os.Stat(filepath.Join(matches[0], namespaces.Namespaces[0].Name))
+	qt.Assert(t, err, qt.IsNil)
+	_, err = os.Stat(filepath.Join(matches[0], namespaces.Namespaces[1].Name))
+	qt.Assert(t, err, qt.IsNil)
+}
+
+func TestManager(t *testing.T) {
+	storageDir := t.TempDir()
+	var cm Manager
+	qt.Assert(t, cm.Start(storageDir, ""), qt.IsNil)
+
+	// Add some censues with some keys
+	const numCensuses = 3
+	const numKeys = 4
+	keyValues := [numCensuses][numKeys][2][]byte{}
+	for i := 0; i < numCensuses; i++ {
+		tree, err := cm.AddNamespace(fmt.Sprintf("%v", i), models.Census_ARBO_BLAKE2B, []string{})
+		qt.Assert(t, err, qt.IsNil)
+		for j := 0; j < numKeys; j++ {
+			key := ethcrypto.Keccak256([]byte(fmt.Sprintf("key%v.%v", i, j)))
+			value := ethcrypto.Keccak256([]byte(fmt.Sprintf("value%v.%v", i, j)))
+			qt.Assert(t, tree.Add(key, value), qt.IsNil)
+			keyValues[i][j] = [2][]byte{key, value}
+		}
+	}
+
+	// Close and open again the Manager, and read back the censuses and keys
+	qt.Assert(t, cm.Stop(), qt.IsNil)
+	cm = Manager{}
+	qt.Assert(t, cm.Start(storageDir, ""), qt.IsNil)
+
+	for i := 0; i < numCensuses; i++ {
+		tree, err := cm.LoadTree(fmt.Sprintf("%v", i), models.Census_ARBO_BLAKE2B)
+		qt.Assert(t, err, qt.IsNil)
+		kvs := make([][2][]byte, 0)
+		tree.IterateLeaves(func(key, value []byte) bool {
+			kvs = append(kvs, [2][]byte{key, value})
+			return false
+		})
+		qt.Assert(t, kvs, qt.ContentEquals, keyValues[i][:])
+	}
 }

--- a/census/handler.go
+++ b/census/handler.go
@@ -112,7 +112,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 	// Methods without rootHash
 	switch r.Method {
 	case "getRoot":
-		resp.Root, err = tr.Root(nil)
+		resp.Root, err = tr.Root()
 		if err != nil {
 			resp.SetError(err.Error())
 			return resp
@@ -121,7 +121,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 
 	case "addClaimBulk":
 		if isAuth && validAuthPrefix {
-			invalidClaims, err := tr.AddBatch(nil, r.CensusKeys, r.CensusValues)
+			invalidClaims, err := tr.AddBatch(r.CensusKeys, r.CensusValues)
 			if err != nil {
 				resp.SetError(err.Error())
 				return resp
@@ -129,7 +129,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 			if len(invalidClaims) > 0 {
 				resp.InvalidClaims = invalidClaims
 			}
-			resp.Root, err = tr.Root(nil)
+			resp.Root, err = tr.Root()
 			if err != nil {
 				resp.SetError(err.Error())
 				return resp
@@ -152,12 +152,12 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 			//if !r.Digested {
 			// data = snarks.Poseidon.Hash(data)
 			//}
-			err := tr.Add(nil, data, r.CensusValue)
+			err := tr.Add(data, r.CensusValue)
 			if err != nil {
 				resp.SetError(err)
 				return resp
 			} else {
-				resp.Root, err = tr.Root(nil)
+				resp.Root, err = tr.Root()
 				if err != nil {
 					resp.SetError(err.Error())
 					return resp
@@ -173,6 +173,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 	case "importDump":
 		if isAuth && validAuthPrefix {
 			if len(r.CensusKeys) > 0 {
+				// FIXME: Can cause Txn too big
 				err := tr.ImportDump(r.CensusDump)
 				if err != nil {
 					log.Warnf("error importing dump: %s", err)
@@ -243,7 +244,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 		var err error
 		var root []byte
 		if len(r.RootHash) < 1 {
-			root, err = tr.Root(nil)
+			root, err = tr.Root()
 			if err != nil {
 				resp.SetError(err.Error())
 				return resp
@@ -284,7 +285,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 		//if !r.Digested {
 		//	data = snarks.Poseidon.Hash(data)
 		//}
-		leafV, siblings, err := tr.GenProof(nil, data)
+		leafV, siblings, err := tr.GenProof(data)
 		if err != nil {
 			resp.SetError(err)
 			return resp
@@ -297,7 +298,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 		return resp
 
 	case "getSize":
-		size, err := tr.Size(nil)
+		size, err := tr.Size()
 		if err != nil {
 			resp.SetError(err)
 			return resp
@@ -314,7 +315,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 		// dump the claim data and return it
 		var root []byte
 		if len(r.RootHash) < 1 {
-			root, err = tr.Root(nil)
+			root, err = tr.Root()
 			if err != nil {
 				resp.SetError(err.Error())
 				return resp
@@ -362,7 +363,7 @@ func (m *Manager) Handler(ctx context.Context, r *api.MetaRequest, isAuth bool,
 		}
 		var dump CensusDump
 
-		root, err := tr.Root(nil)
+		root, err := tr.Root()
 		if err != nil {
 			resp.SetError(err.Error())
 			return resp

--- a/censustree/censustree.go
+++ b/censustree/censustree.go
@@ -2,28 +2,33 @@ package censustree
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/vocdoni/arbo"
 	"go.vocdoni.io/dvote/db"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	"go.vocdoni.io/dvote/db/prefixeddb"
 	"go.vocdoni.io/dvote/tree"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
 // Tree implements the Merkle Tree used for census
+// Concurrent updates to the tree.Tree can lead to losing some of the updates,
+// so we don't expose the tree.Tree directly, and lock it in every method that
+// updates it.
 type Tree struct {
-	*tree.Tree
+	tree *tree.Tree
 
+	sync.Mutex
 	public     uint32
 	censusType models.Census_Type
 }
 
 type Options struct {
+	// ParentDB is the Database under which all censuses are stored, each
+	// with a different prefix.
+	ParentDB   db.Database
 	Name       string
-	StorageDir string
 	MaxLevels  int
 	CensusType models.Census_Type
 }
@@ -33,7 +38,7 @@ const nLevels = 256
 
 // New returns a new Tree, if there already is a Tree in the
 // database, it will load it.
-func New(wTx db.WriteTx, opts Options) (*Tree, error) {
+func New(opts Options) (*Tree, error) {
 	var hashFunc arbo.HashFunction
 
 	switch opts.CensusType {
@@ -45,18 +50,12 @@ func New(wTx db.WriteTx, opts Options) (*Tree, error) {
 		return nil, fmt.Errorf("unrecognized census type (%d)", opts.CensusType)
 	}
 
-	dbDir := filepath.Join(opts.StorageDir, "arbotree.db."+strings.TrimSpace(opts.Name))
-	database, err := badgerdb.New(badgerdb.Options{Path: dbDir})
+	db := prefixeddb.NewPrefixedDatabase(opts.ParentDB, []byte(opts.Name))
+	t, err := tree.New(nil, tree.Options{DB: db, MaxLevels: nLevels, HashFunc: hashFunc})
 	if err != nil {
 		return nil, err
 	}
-
-	t, err := tree.New(wTx, tree.Options{DB: database, MaxLevels: nLevels, HashFunc: hashFunc})
-	if err != nil {
-		database.Close()
-		return nil, err
-	}
-	return &Tree{Tree: t, censusType: opts.CensusType}, nil
+	return &Tree{tree: t, censusType: opts.CensusType}, nil
 }
 
 // Type returns the numeric identifier of the censustree implementation
@@ -67,12 +66,12 @@ func (t *Tree) Type() models.Census_Type {
 // FromRoot returns a new read-only Tree for the given root, that uses the same
 // underlying db.
 func (t *Tree) FromRoot(root []byte) (*Tree, error) {
-	treeFromRoot, err := t.Tree.FromRoot(root)
+	treeFromRoot, err := t.tree.FromRoot(root)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Tree{Tree: treeFromRoot, censusType: t.Type()}, nil
+	return &Tree{tree: treeFromRoot, censusType: t.Type()}, nil
 }
 
 // Publish makes a merkle tree available for queries.  Application layer should
@@ -81,12 +80,63 @@ func (t *Tree) Publish() {
 	atomic.StoreUint32(&t.public, 1)
 }
 
-// UnPublish makes a merkle tree not available for queries
+// UnPublish makes a merkle tree not available for queries.
 func (t *Tree) Unpublish() {
 	atomic.StoreUint32(&t.public, 0)
 }
 
-// IsPublic returns true if the tree is available
+// IsPublic returns true if the tree is available.
 func (t *Tree) IsPublic() bool {
 	return atomic.LoadUint32(&t.public) == 1
+}
+
+// Root wraps tree.Tree.Root.
+func (t *Tree) Root() ([]byte, error) {
+	return t.tree.Root(nil)
+}
+
+// Root wraps t.tree.VerifyProof.
+func (t *Tree) VerifyProof(key, value, proof, root []byte) (bool, error) {
+	return t.tree.VerifyProof(key, value, proof, root)
+}
+
+// GenProof wraps t.tree.GenProof.
+func (t *Tree) GenProof(key []byte) ([]byte, []byte, error) {
+	return t.tree.GenProof(nil, key)
+}
+
+// Size wraps t.tree.Size.
+func (t *Tree) Size() (uint64, error) {
+	return t.tree.Size(nil)
+}
+
+// Dump wraps t.tree.Dump.
+func (t *Tree) Dump() ([]byte, error) {
+	return t.tree.Dump()
+}
+
+// IterateLeaves wraps t.tree.IterateLeaves.
+func (t *Tree) IterateLeaves(callback func(key, value []byte) bool) error {
+	return t.tree.IterateLeaves(nil, callback)
+}
+
+// AddBatch wraps t.tree.AddBatch while acquiring the lock.
+func (t *Tree) AddBatch(keys, values [][]byte) ([]int, error) {
+	t.Lock()
+	defer t.Unlock()
+	return t.tree.AddBatch(nil, keys, values)
+}
+
+// Add wraps t.tree.Add while acquiring the lock.
+func (t *Tree) Add(key, value []byte) error {
+	t.Lock()
+	defer t.Unlock()
+	return t.tree.Add(nil, key, value)
+}
+
+// ImportDump wraps t.tree.ImportDump while acquiring the lock.
+func (t *Tree) ImportDump(b []byte) error {
+	t.Lock()
+	defer t.Unlock()
+	return t.tree.ImportDump(b)
 }

--- a/censustree/censustree_test.go
+++ b/censustree/censustree_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db/badgerdb"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
@@ -12,7 +13,11 @@ import (
 // added code in the CensusTree wrapper.
 
 func TestPublish(t *testing.T) {
-	censusTree, err := New(nil, Options{Name: "test", StorageDir: t.TempDir(), MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})
+	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	censusTree, err := New(Options{Name: "test", ParentDB: db, MaxLevels: 256,
+		CensusType: models.Census_ARBO_BLAKE2B})
 	qt.Assert(t, err, qt.IsNil)
 
 	qt.Assert(t, censusTree.IsPublic(), qt.IsFalse)

--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -193,6 +194,7 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 	}
 
 	// Add viper config path (now we know it)
+	globalCfg.DataDir = filepath.Clean(globalCfg.DataDir)
 	viper.AddConfigPath(globalCfg.DataDir)
 
 	// binding flags to viper
@@ -553,7 +555,8 @@ func main() {
 
 			// Start keykeeper service (if key index specified)
 			if globalCfg.VochainConfig.KeyKeeperIndex > 0 {
-				kk, err = keykeeper.NewKeyKeeper(path.Join(globalCfg.VochainConfig.DataDir, "/keykeeper"),
+				kk, err = keykeeper.NewKeyKeeper(
+					path.Join(globalCfg.VochainConfig.DataDir, "keykeeper"),
 					vnode,
 					signer,
 					globalCfg.VochainConfig.KeyKeeperIndex)

--- a/db/badgerdb/tx_test.go
+++ b/db/badgerdb/tx_test.go
@@ -1,0 +1,70 @@
+package badgerdb
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v3"
+	qt "github.com/frankban/quicktest"
+)
+
+var key = []byte{1}
+
+func inc(t *testing.T, m *sync.Mutex, db *BadgerDB) error {
+	wTx := db.WriteTx()
+	time.Sleep(100 * time.Millisecond)
+
+	m.Lock()
+	val, err := wTx.Get(key)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, wTx.Set(key, []byte{val[0] + 1}), qt.IsNil)
+	m.Unlock()
+
+	return wTx.Commit()
+}
+
+// TestConcurrentWriteTx validates the behaviour of badgerdb when multiple
+// write transactions modify the same key.
+func TestConcurrentWriteTx(t *testing.T) {
+	db, err := New(Options{Path: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wTx := db.WriteTx()
+	qt.Assert(t, wTx.Set(key, []byte{0}), qt.IsNil)
+	qt.Assert(t, wTx.Commit(), qt.IsNil)
+
+	var wg sync.WaitGroup
+	var m sync.Mutex
+	// A
+	var errA error
+	wg.Add(1)
+	go func() {
+		errA = inc(t, &m, db)
+		wg.Done()
+	}()
+
+	// B
+	var errB error
+	wg.Add(1)
+	go func() {
+		errB = inc(t, &m, db)
+		wg.Done()
+	}()
+
+	wg.Wait()
+	rTx := db.ReadTx()
+	defer rTx.Discard()
+	val, err := rTx.Get(key)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, val, qt.DeepEquals, []byte{1})
+
+	if errA == nil {
+		qt.Assert(t, errA, qt.IsNil)
+		qt.Assert(t, errB, qt.Equals, badger.ErrConflict)
+	} else {
+		qt.Assert(t, errA, qt.Equals, badger.ErrConflict)
+		qt.Assert(t, errB, qt.IsNil)
+	}
+}

--- a/db/interface.go
+++ b/db/interface.go
@@ -10,7 +10,7 @@ var ErrKeyNotFound = fmt.Errorf("key not found")
 
 // ErrTxnTooBig is used to indicate that a WriteTx is too big and can't include
 // more writes.
-var ErrTxnTooBig = fmt.Errorf("Txn too big")
+var ErrTxnTooBig = fmt.Errorf("txn too big")
 
 // Database wraps all database operations. All methods are safe for concurrent
 // use.

--- a/service/census.go
+++ b/service/census.go
@@ -19,7 +19,7 @@ func Census(datadir string, ma *metrics.Agent) (*census.Manager, error) {
 			return nil, err
 		}
 	}
-	if err := censusManager.Init(stdir, ""); err != nil {
+	if err := censusManager.Start(stdir, ""); err != nil {
 		return nil, err
 	}
 

--- a/test/testcommon/apis.go
+++ b/test/testcommon/apis.go
@@ -89,7 +89,7 @@ func (d *DvoteAPIServer) Start(tb testing.TB, apis ...string) {
 	// Create the Census Manager and enable it trough the router
 	var cm census.Manager
 	d.CensusDir = tb.TempDir()
-	if err := cm.Init(d.CensusDir, ""); err != nil {
+	if err := cm.Start(d.CensusDir, ""); err != nil {
 		tb.Fatal(err)
 	}
 

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -7,8 +7,10 @@ import (
 	"sync/atomic"
 	"testing"
 
+	qt "github.com/frankban/quicktest"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/censustree"
+	"go.vocdoni.io/dvote/db/badgerdb"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -40,9 +42,10 @@ func BenchmarkCheckTx(b *testing.B) {
 
 func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 	nvoters int, tmpDir string) (voters []*models.SignedTx) {
-	tr, err := censustree.New(nil,
-		censustree.Options{Name: util.RandomHex(12), StorageDir: tmpDir,
-			MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})
+	db, err := badgerdb.New(badgerdb.Options{Path: tmpDir})
+	qt.Assert(b, err, qt.IsNil)
+	tr, err := censustree.New(censustree.Options{Name: util.RandomHex(12), ParentDB: db,
+		MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -54,14 +57,14 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 	claims := []string{}
 	for _, k := range keys {
 		c := k.PublicKey()
-		if err := tr.Add(nil, c, nil); err != nil {
+		if err := tr.Add(c, nil); err != nil {
 			b.Error(err)
 		}
 		claims = append(claims, string(c))
 	}
 	censusURI := ipfsUrl
 	pid := util.RandomBytes(types.ProcessIDsize)
-	root, err := tr.Root(nil)
+	root, err := tr.Root()
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -83,7 +86,7 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 
 	var proof []byte
 	for i, s := range keys {
-		_, proof, err = tr.GenProof(nil, []byte(claims[i]))
+		_, proof, err = tr.GenProof([]byte(claims[i]))
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Previously the census manager used graviton to store the censues, and
there was a different graviton database for each census.  Now we have
moved to BadgerDB with Arbo; and BadgerDB has a significant memory usage
for each opened Database.  For this reason we switch to having a single
BadgerDB database where all censuses are stored (using Arbo) under
different prefixes.  This should solve the Out of Memory issue observed
in nodes with many censues.

Introduce the concept of census version.  We define censuses previous to
the update to Arbo + BadgerDB to be version 0, and the current
implementation of censuses to be version 1.  The vocdoni-node stores
and loads censuses indexed in the namespaces.json file.  Censuses with
version 0 (note that by using json.Unmarshal, entries in the
namespaces.json that don't have the version key will default to version
= 0) are incompatible with the current implementation and will be
removed from the namespaces.json file and their corresponding database
directories will be discarded.  For safety, if entries in namespace.json
are deleted, a backup will be made with the current time timestamp, and
the corresponding database directories will be moved to a folder for
outdated censues with the current time timestamp.

Add locking on update operations in the census Trees to avoid
inconsisntencies.  Without locking, in the best case a concurrent update
would fail, and in the worst case a concurrent update would overwrite a
previous update.

For update operations in the cenuses, use db.Batch instead of db.WriteTx
to avoid encountering "txn too big" errors, which could happen with big
censues during "AddBatch" or "ImportDump" methods.  We do this by
wrapping BadgerDB via a struct that returns a db.Batch for every WriteTx
requested.