### PR TITLE
Integrate zk-artifacts download on dvote-node init

### DIFF
--- a/crypto/zk/artifacts/artifacts_test.go
+++ b/crypto/zk/artifacts/artifacts_test.go
@@ -35,25 +35,25 @@ func TestDownloadCircuitFiles(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	zkeyHash, err := hex.DecodeString("279433966c3d258fa747121207b02baad715e12877473f9c2326da7f3a17597b")
 	qt.Assert(t, err, qt.IsNil)
-	vkHash, err := hex.DecodeString("de3b651d4d47a956eb8e27cbc2e7d145e7677d68fddac275604dbc697690e751")
+	vkHash, err := hex.DecodeString("3ec7355a7be53019b66563d02a1e2ce689e6dfac207a5f9ce503fb8ac915acf0")
 	qt.Assert(t, err, qt.IsNil)
 
 	path := t.TempDir()
-	c := CircuitsConfig{
-		URL:          ts.URL,
-		CircuitsPath: "/zkcensusproof/test/1024/",
-		LocalDir:     path,
-		WitnessHash:  witnessHash,
-		ZKeyHash:     zkeyHash,
-		VKHash:       vkHash,
+	c := CircuitConfig{
+		URL:         ts.URL,
+		CircuitPath: "/zkcensusproof/test/1024/",
+		LocalDir:    path,
+		WitnessHash: witnessHash,
+		ZKeyHash:    zkeyHash,
+		VKHash:      vkHash,
 	}
 
 	ctx := context.Background()
 
 	// 0. delete files if exist in tmp test path
-	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameWitness))
-	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameZKey))
-	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameVK))
+	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitPath, FilenameWitness))
+	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitPath, FilenameZKey))
+	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitPath, FilenameVK))
 
 	// 1. Files don't exist yet, call DownloadCircuitFiles, then check
 	// expected hashes
@@ -62,7 +62,7 @@ func TestDownloadCircuitFiles(t *testing.T) {
 
 	// 2. Remove one file and call DownloadCircuitFiles, check expected
 	// hashes
-	err = os.Remove(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameWitness))
+	err = os.Remove(filepath.Join(c.LocalDir, c.CircuitPath, FilenameWitness))
 	qt.Assert(t, err, qt.IsNil)
 	err = DownloadCircuitFiles(ctx, c)
 	qt.Assert(t, err, qt.IsNil)
@@ -95,26 +95,45 @@ func TestDownloadCircuitFiles(t *testing.T) {
 		"expected hash: 2ca5070e6fb17b920c1f938903c39867a2561900aaa2de52ec2265d46d41eb12, computed hash: 2ba5070e6fb17b920c1f938903c39867a2561900aaa2de52ec2265d46d41eb12")
 }
 
+func TestErrorDownloading(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	path := t.TempDir()
+	c := CircuitConfig{
+		URL:         ts.URL,
+		CircuitPath: "/zkcensusproof/test/1024/",
+		LocalDir:    path,
+	}
+	ctx := context.Background()
+	err := DownloadCircuitFiles(ctx, c)
+	qt.Assert(t, err, qt.IsNotNil)
+	// qt.Assert(t, strings.Contains(err.Error(), "error on download file"), qt.IsTrue)
+	qt.Assert(t, err, qt.ErrorMatches, "error on download file .* 404")
+}
+
 func TestDownloadVKFile(t *testing.T) {
 	// create a test server that serves test files
 	ts := newTestServer(t)
 	defer ts.Close()
 
-	vkHash, err := hex.DecodeString("de3b651d4d47a956eb8e27cbc2e7d145e7677d68fddac275604dbc697690e751")
+	vkHash, err := hex.DecodeString("3ec7355a7be53019b66563d02a1e2ce689e6dfac207a5f9ce503fb8ac915acf0")
 	qt.Assert(t, err, qt.IsNil)
 
 	path := t.TempDir()
-	c := CircuitsConfig{
-		URL:          ts.URL,
-		CircuitsPath: "/zkcensusproof/test/1024/",
-		LocalDir:     path,
-		VKHash:       vkHash,
+	c := CircuitConfig{
+		URL:         ts.URL,
+		CircuitPath: "/zkcensusproof/test/1024/",
+		LocalDir:    path,
+		VKHash:      vkHash,
 	}
 
 	ctx := context.Background()
 
 	// 0. delete files if exist in tmp test path
-	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameVK))
+	_ = os.Remove(filepath.Join(c.LocalDir, c.CircuitPath, FilenameVK))
 
 	// 1. Files don't exist yet, call DownloadVKFile, then
 	// check expected hashes
@@ -123,13 +142,13 @@ func TestDownloadVKFile(t *testing.T) {
 
 	// 2. Remove the VK file and call DownloadVKFile, check
 	// expected hashes
-	err = os.Remove(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameVK))
+	err = os.Remove(filepath.Join(c.LocalDir, c.CircuitPath, FilenameVK))
 	qt.Assert(t, err, qt.IsNil)
 	err = DownloadVKFile(ctx, c)
 	qt.Assert(t, err, qt.IsNil)
 
 	// checkHashe without download, as was download in the last step (2)
-	err = checkHash(filepath.Join(c.LocalDir, c.CircuitsPath, FilenameVK), c.VKHash)
+	err = checkHash(filepath.Join(c.LocalDir, c.CircuitPath, FilenameVK), c.VKHash)
 	qt.Assert(t, err, qt.IsNil)
 
 	// 3. Call again DownloadVKFile, expect no new download
@@ -151,7 +170,7 @@ func TestDownloadVKFile(t *testing.T) {
 	c.VKHash[0] += 1
 	err = DownloadVKFile(ctx, c)
 	qt.Assert(t, err, qt.IsNotNil)
-	errExpected := strings.Split(err.Error(), "verificationKey.json, ")[1]
+	errExpected := strings.Split(err.Error(), FilenameVK+", ")[1]
 	qt.Assert(t, errExpected, qt.Equals,
-		"expected hash: df3b651d4d47a956eb8e27cbc2e7d145e7677d68fddac275604dbc697690e751, computed hash: de3b651d4d47a956eb8e27cbc2e7d145e7677d68fddac275604dbc697690e751")
+		"expected hash: 3fc7355a7be53019b66563d02a1e2ce689e6dfac207a5f9ce503fb8ac915acf0, computed hash: 3ec7355a7be53019b66563d02a1e2ce689e6dfac207a5f9ce503fb8ac915acf0")
 }

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -45,8 +45,8 @@ type BaseApplication struct {
 	// abcitypes.RequestBeginBlock.Header.Time
 	startBlockTimestamp int64
 	chainId             string
-	// ZkVks contains the VerificationKey for each circuit parameters index
-	ZkVks []*snarkTypes.Vk
+	// ZkVKs contains the VerificationKey for each circuit parameters index
+	ZkVKs []*snarkTypes.Vk
 }
 
 var _ abcitypes.Application = (*BaseApplication)(nil)

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -1,9 +1,18 @@
 package vochain
 
+import (
+	"encoding/hex"
+	"strings"
+
+	"go.vocdoni.io/dvote/crypto/zk/artifacts"
+	"go.vocdoni.io/dvote/log"
+)
+
 type VochainGenesis struct {
-	SeedNodes         []string
-	Genesis           string
 	AutoUpdateGenesis bool
+	SeedNodes         []string
+	CircuitsConfig    []artifacts.CircuitConfig
+	Genesis           string
 }
 
 // Genesis is a map containing the defaut Genesis details
@@ -143,6 +152,14 @@ var Genesis = map[string]VochainGenesis{
 		AutoUpdateGenesis: true,
 		SeedNodes: []string{
 			"7440a5b086e16620ce7b13198479016aa2b07988@seed.dev.vocdoni.net:26656"},
+		CircuitsConfig: []artifacts.CircuitConfig{
+			{ // index: 0, size: 1024
+				URL:         "https://raw.githubusercontent.com/vocdoni/zk-circuits-artifacts/master/",
+				CircuitPath: "/zkcensusproof/dev/1024",
+				LocalDir:    "./circuits",
+				VKHash:      hexToBytes("0x3669e12ea939564b59b995b9067eab83c8ebb09f5a83ad4aa3d6d6f90c1b0fc4"),
+			},
+		},
 		Genesis: `
 {
    "genesis_time":"2021-09-23T20:43:28.668436552Z",
@@ -361,4 +378,15 @@ var Genesis = map[string]VochainGenesis{
 }
 `,
 	},
+}
+
+// hexToBytes parses a hex string and returns the byte array from it. Warning,
+// in case of error it will panic.
+func hexToBytes(s string) []byte {
+	s = strings.TrimPrefix(s, "0x")
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		log.Fatalf("Error decoding hex string %s: %s", s, err)
+	}
+	return b
 }

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -192,10 +192,10 @@ func (app *BaseApplication) VoteEnvelopeCheck(ve *models.VoteEnvelope, txBytes, 
 			return nil, err
 		}
 
-		if int(proofZkSNARK.CircuitParametersIndex) >= len(app.ZkVks) {
-			return nil, fmt.Errorf("invalid CircuitParametersIndex: %d", proofZkSNARK.CircuitParametersIndex)
+		if int(proofZkSNARK.CircuitParametersIndex) >= len(app.ZkVKs) {
+			return nil, fmt.Errorf("invalid CircuitParametersIndex: %d of %d", proofZkSNARK.CircuitParametersIndex, len(app.ZkVKs))
 		}
-		verificationKey := app.ZkVks[proofZkSNARK.CircuitParametersIndex]
+		verificationKey := app.ZkVKs[proofZkSNARK.CircuitParametersIndex]
 
 		// prepare the publicInputs that are defined by the process
 		censusRootBI := arbo.BytesToBigInt(process.CensusRoot)

--- a/vochain/transaction_test.go
+++ b/vochain/transaction_test.go
@@ -132,7 +132,7 @@ func TestVoteEnvelopeCheckCaseZkSNARK(t *testing.T) {
 	`
 	vk0, err := snarkParsers.ParseVk([]byte(vkJSON))
 	qt.Assert(t, err, qt.IsNil)
-	app.ZkVks = append(app.ZkVks, vk0)
+	app.ZkVKs = append(app.ZkVKs, vk0)
 
 	processId := arbo.BigIntToBytes(32, big.NewInt(10))
 	entityId := []byte("entityid-test")


### PR DESCRIPTION
Integrate zk-artifacts download on dvote-node init to download the
verification_key.json defined in the Vochain genesis, and load it in
memory for vochain usage.