### PR TITLE
Add missing Discard in State.Rollback

### DIFF
--- a/statedb/statedb.go
+++ b/statedb/statedb.go
@@ -375,7 +375,6 @@ func (s *StateDB) TreeView(root []byte) (*TreeView, error) {
 	}
 
 	txTree := subReadTx(tx, subKeyTree)
-	defer txTree.Discard()
 	tree, err := tree.New(&readOnlyWriteTx{txTree},
 		tree.Options{DB: subDB(s.db, subKeyTree), MaxLevels: cfg.maxLevels, HashFunc: cfg.hashFunc})
 	if errors.Is(err, ErrReadOnly) {

--- a/statedb/treeupdate.go
+++ b/statedb/treeupdate.go
@@ -132,11 +132,6 @@ func (u *TreeUpdate) SubTree(cfg TreeConfig) (treeUpdate *TreeUpdate, err error)
 		return nil, err
 	}
 	tx := subWriteTx(u.tx, path.Join(subKeySubTree, cfg.prefix))
-	defer func() {
-		if err != nil {
-			tx.Discard()
-		}
-	}()
 	txTree := subWriteTx(tx, subKeyTree)
 	tree, err := tree.New(txTree,
 		tree.Options{DB: nil, MaxLevels: cfg.maxLevels, HashFunc: cfg.hashFunc})

--- a/statedb/treeview.go
+++ b/statedb/treeview.go
@@ -147,7 +147,6 @@ func (v *TreeView) SubTree(cfg TreeConfig) (treeView TreeViewer, err error) {
 	tx := db.ReadTx()
 	defer tx.Discard()
 	txTree := subReadTx(tx, subKeyTree)
-	defer txTree.Discard()
 	tree, err := tree.New(&readOnlyWriteTx{txTree},
 		tree.Options{DB: subDB(db, subKeyTree), MaxLevels: cfg.maxLevels, HashFunc: cfg.hashFunc})
 	if errors.Is(err, ErrReadOnly) {

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -745,6 +745,7 @@ func (v *State) Rollback() {
 	}
 	v.Tx.Lock()
 	defer v.Tx.Unlock()
+	v.Tx.Discard()
 	var err error
 	if v.Tx.TreeTx, err = v.Store.BeginTx(); err != nil {
 		log.Fatalf("cannot begin statedb tx: %s", err)


### PR DESCRIPTION
Hopefully this is what's causing the memory leak from https://github.com/vocdoni/vocdoni-node/issues/287

Also, remove deferred discards in subTxs as they wrap a Tx that is managed in an upper layer and shouldn't be discarded nor commited as a subTx.