### PR TITLE
Fix height/AppHash mismatch in StateDB

### DIFF
--- a/statedb/statedb_test.go
+++ b/statedb/statedb_test.go
@@ -73,7 +73,7 @@ func TestStateDB(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, root1, qt.Not(qt.DeepEquals), emptyHash)
 
-	qt.Assert(t, mainTree.Commit(), qt.IsNil)
+	qt.Assert(t, mainTree.Commit(1), qt.IsNil)
 
 	// statedb.Root == mainTree.Root
 	rootStateDB, err := sdb.Hash()
@@ -132,7 +132,7 @@ func TestStateDB(t *testing.T) {
 	// Expect Commit with no changes to work, StateDB.Root is not changed
 	mainTree, err = sdb.BeginTx()
 	qt.Assert(t, err, qt.IsNil)
-	mainTree.Commit()
+	qt.Assert(t, mainTree.Commit(2), qt.IsNil)
 	version, err = sdb.Version()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, version, qt.Equals, uint32(2))
@@ -242,7 +242,7 @@ func TestSubTree(t *testing.T) {
 	qt.Assert(t, multiB.Add([]byte("key3"), []byte("value3")), qt.IsNil)
 	// treePrint(multiA.tree, multiA.txTree, "multiA")
 
-	qt.Assert(t, mainTree.Commit(), qt.IsNil)
+	qt.Assert(t, mainTree.Commit(1), qt.IsNil)
 
 	// dumpPrint(sdb.db)
 
@@ -340,7 +340,7 @@ func TestNoState(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, v1, qt.DeepEquals, []byte("value1"))
 
-	qt.Assert(t, mainTree.Commit(), qt.IsNil)
+	qt.Assert(t, mainTree.Commit(1), qt.IsNil)
 
 	// Expect the NoState values in each treeView.  Expect that roots
 	// haven't changed after Commit.
@@ -476,7 +476,7 @@ func TestBigUpdate(t *testing.T) {
 		binary.LittleEndian.PutUint32(value[:], uint32(i))
 		qt.Assert(t, mainTree.Add(key[:], value[:]), qt.IsNil)
 	}
-	qt.Assert(t, mainTree.Commit(), qt.IsNil)
+	qt.Assert(t, mainTree.Commit(1), qt.IsNil)
 }
 
 func TestBigUpdateDiscard(t *testing.T) {
@@ -513,7 +513,7 @@ func TestBigUpdateDiscard(t *testing.T) {
 	mainTree, err = sdb.BeginTx()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mainTree.Add(singleCfg.Key(), emptyHash), qt.IsNil)
-	qt.Assert(t, mainTree.Commit(), qt.IsNil)
+	qt.Assert(t, mainTree.Commit(1), qt.IsNil)
 
 	mainTree, err = sdb.BeginTx()
 	qt.Assert(t, err, qt.IsNil)

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -223,7 +223,7 @@ func (app *BaseApplication) Info(req abcitypes.RequestInfo) abcitypes.ResponseIn
 	log.Infof("tendermint Block protocol version: %d", req.BlockVersion)
 	lastHeight, err := app.State.LastHeight()
 	if err != nil {
-		log.Fatalf("cannot get Store.LastHeight: %v", err)
+		log.Fatalf("cannot get State.LastHeight: %v", err)
 	}
 	appHash, err := app.State.Store.Hash()
 	if err != nil {


### PR DESCRIPTION
Previously we were storing the new height in the StateDB at the
beginning of a block.  After commit
70d10e3f6dba1f187c1387309e5b534ba95e382f we no longer have atomic
updates for each block, so we could end with a crash in the middle of a
block, where the new height has been stored but the block has not been
completed.  After this crash, the height won't match the last state,
so the node won't be able to boot.

Fix this situation by removing the explicit storage of height in the
StateDB, and using the StateDB version as height (so we match each
commit version with the corresponding block height).  Since the StateDB
version is written last in a StateDB Commit, we should always have a
consistent state, where the stored height (StateDB version) always
matches the fully processed last block update.