### PR TITLE
allow configure key value database backend, use pebble by default

### DIFF
--- a/censustree/censustree_test.go
+++ b/censustree/censustree_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	"go.vocdoni.io/dvote/db/pebbledb"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
@@ -13,7 +13,7 @@ import (
 // added code in the CensusTree wrapper.
 
 func TestPublish(t *testing.T) {
-	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	db, err := pebbledb.New(pebbledb.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	censusTree, err := New(Options{Name: "test", ParentDB: db, MaxLevels: 256,

--- a/censustreelegacy/arbotree/wrapper.go
+++ b/censustreelegacy/arbotree/wrapper.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/vocdoni/arbo"
 	censustree "go.vocdoni.io/dvote/censustreelegacy"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	kv "go.vocdoni.io/dvote/db/pebbledb"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
@@ -35,7 +35,7 @@ var _ censustree.Tree = (*Tree)(nil)
 func NewTree(name, storageDir string, nLevels int, hashFunc arbo.HashFunction) (
 	censustree.Tree, error) {
 	dbDir := filepath.Join(storageDir, "arbotree.db."+strings.TrimSpace(name))
-	database, err := badgerdb.New(badgerdb.Options{Path: dbDir})
+	database, err := kv.New(kv.Options{Path: dbDir})
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (t *Tree) TypeString() string {
 // to choose the hash function to be used in the Tree.
 func (t *Tree) Init(name, storageDir string) error {
 	dbDir := filepath.Join(storageDir, "arbotree.db."+strings.TrimSpace(name))
-	database, err := badgerdb.New(badgerdb.Options{Path: dbDir})
+	database, err := kv.New(kv.Options{Path: dbDir})
 	if err != nil {
 		return err
 	}

--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -22,6 +22,7 @@ import (
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/data"
+	"go.vocdoni.io/dvote/db"
 	ethchain "go.vocdoni.io/dvote/ethereum"
 	"go.vocdoni.io/dvote/ethereum/ethevents"
 	"go.vocdoni.io/dvote/internal"
@@ -126,6 +127,8 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 		"external address:port to announce to other peers (automatically guessed if empty)")
 	globalCfg.VochainConfig.RPCListen = *flag.String("vochainRPCListen", "127.0.0.1:26657",
 		"rpc host and port to listen to for the voting chain")
+	globalCfg.VochainConfig.DBbackend = db.StorageType(*flag.Int("dbBackend", 0,
+		"database backend for storing the vochain state (0:pebble 1:badger2 2:badger3"))
 	globalCfg.VochainConfig.CreateGenesis = *flag.Bool("vochainCreateGenesis", false,
 		"create local/testing genesis file for the vochain")
 	globalCfg.VochainConfig.Genesis = *flag.String("vochainGenesis", "",
@@ -244,6 +247,7 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 	viper.BindPFlag("vochainConfig.RPCListen", flag.Lookup("vochainRPCListen"))
 	viper.BindPFlag("vochainConfig.LogLevel", flag.Lookup("vochainLogLevel"))
 	viper.BindPFlag("vochainConfig.LogLevelMemPool", flag.Lookup("vochainLogLevelMemPool"))
+	viper.BindPFlag("vochainConfig.DBbackend", flag.Lookup("dbBackend"))
 	viper.BindPFlag("vochainConfig.Peers", flag.Lookup("vochainPeers"))
 	viper.BindPFlag("vochainConfig.Seeds", flag.Lookup("vochainSeeds"))
 	viper.BindPFlag("vochainConfig.CreateGenesis", flag.Lookup("vochainCreateGenesis"))

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/types"
 )
 
@@ -182,6 +183,8 @@ type VochainCfg struct {
 	ProcessArchiveDataDir string
 	// Scrutinizer holds the configuration regarding the scrutinizer component
 	Scrutinizer ScrutinizerCfg
+	// DBbackend defines the type of key value backend
+	DBbackend db.StorageType
 }
 
 // ScrutinizerCfg handles the configuration options of the scrutinizer

--- a/db/badgerdbv2/badger.go
+++ b/db/badgerdbv2/badger.go
@@ -1,0 +1,169 @@
+package badgerdbv2
+
+import (
+	"errors"
+	"os"
+
+	badger "github.com/dgraph-io/badger/v2"
+	"go.vocdoni.io/dvote/db"
+)
+
+// MemTableSize defines the BadgerDB maximum size in bytes for memtable table.
+// The default is 64<<20 (64MB), this does not pre-allocate enough memory for
+// big Txs, that's why we use 128<<20.
+const MemTableSize = 128 << 20
+
+// ReadTx implements the interface db.ReadTx
+type ReadTx struct {
+	tx *badger.Txn
+}
+
+// check that ReadTx implements the db.ReadTx interface
+var _ db.ReadTx = (*ReadTx)(nil)
+
+// WriteTx implements the interface db.WriteTx
+type WriteTx struct {
+	tx *badger.Txn
+}
+
+// check that WriteTx implements the db.ReadTx & db.WriteTx interfaces
+var _ db.WriteTx = (*WriteTx)(nil)
+
+// Get implements the db.ReadTx.Get interface method
+func (tx ReadTx) Get(k []byte) ([]byte, error) {
+	item, err := tx.tx.Get(k)
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil, db.ErrKeyNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return item.ValueCopy(nil)
+}
+
+// Discard implements the db.ReadTx.Discard interface method
+func (tx ReadTx) Discard() {
+	tx.tx.Discard()
+}
+
+// Get implements the db.WriteTx.Get interface method
+func (tx WriteTx) Get(k []byte) ([]byte, error) {
+	return ReadTx(tx).Get(k)
+}
+
+// Set implements the db.WriteTx.Set interface method
+func (tx WriteTx) Set(k, v []byte) error {
+	if err := tx.tx.Set(k, v); errors.Is(err, badger.ErrTxnTooBig) {
+		return db.ErrTxnTooBig
+	} else {
+		return err
+	}
+}
+
+// Delete implements the db.WriteTx.Delete interface method
+func (tx WriteTx) Delete(k []byte) error {
+	if err := tx.tx.Delete(k); errors.Is(err, badger.ErrTxnTooBig) {
+		return db.ErrTxnTooBig
+	} else {
+		return err
+	}
+}
+
+// Commit implements the db.WriteTx.Commit interface method
+func (tx WriteTx) Commit() error {
+	return tx.tx.Commit()
+}
+
+// Discard implements the db.WriteTx.Discard interface method
+func (tx WriteTx) Discard() {
+	ReadTx(tx).Discard()
+}
+
+// BadgerDB implements db.Database interface
+type BadgerDB struct {
+	db *badger.DB
+}
+
+// check that BadgerDB implements the db.Database interface
+var _ db.Database = (*BadgerDB)(nil)
+
+// Options defines params for creating a new BadgerDB
+type Options struct {
+	Path string
+}
+
+// New returns a BadgerDB using the given Options, which implements the
+// db.Database interface
+func New(opts Options) (*BadgerDB, error) {
+	if err := os.MkdirAll(opts.Path, os.ModePerm); err != nil {
+		return nil, err
+	}
+	badgerOpts := badger.DefaultOptions(opts.Path).
+		WithLogger(nil).
+		// Do we want compression in the future?
+		// WithCompression(options.Snappy).
+		WithSyncWrites(false).
+		WithCompression(0).
+		WithBlockCacheSize(0).
+		WithNumCompactors(20).
+		WithNumMemtables(1).
+		WithBlockSize(16)
+
+	badgerOpts.MaxTableSize = MemTableSize
+	db, err := badger.Open(badgerOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BadgerDB{
+		db: db,
+	}, nil
+}
+
+// ReadTx returns a db.ReadTx
+func (db *BadgerDB) ReadTx() db.ReadTx {
+	return ReadTx{
+		tx: db.db.NewTransaction(false),
+	}
+}
+
+// WriteTx returns a db.WriteTx
+func (db *BadgerDB) WriteTx() db.WriteTx {
+	return WriteTx{
+		tx: db.db.NewTransaction(true),
+	}
+}
+
+// Close closes the BadgerDB
+func (db *BadgerDB) Close() error {
+	return db.db.Close()
+}
+
+// Iterate implements the db.Database.Iterate interface method
+func (db *BadgerDB) Iterate(prefix []byte, callback func(k, v []byte) bool) error {
+	return db.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		if prefix != nil {
+			opts.Prefix = prefix
+		}
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			item := it.Item()
+			stopIter := false
+			err := item.Value(func(v []byte) error {
+				if cont := callback(item.Key(), v); !cont {
+					stopIter = true
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			if stopIter {
+				break
+			}
+		}
+		return nil
+	})
+}

--- a/db/badgerdbv2/badger_test.go
+++ b/db/badgerdbv2/badger_test.go
@@ -1,4 +1,4 @@
-package badgerdb
+package badgerdbv2
 
 import (
 	"encoding/binary"

--- a/db/badgerdbv2/tx_test.go
+++ b/db/badgerdbv2/tx_test.go
@@ -1,0 +1,70 @@
+package badgerdbv2
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v2"
+	qt "github.com/frankban/quicktest"
+)
+
+var key = []byte{1}
+
+func inc(t *testing.T, m *sync.Mutex, db *BadgerDB) error {
+	wTx := db.WriteTx()
+	time.Sleep(100 * time.Millisecond)
+
+	m.Lock()
+	val, err := wTx.Get(key)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, wTx.Set(key, []byte{val[0] + 1}), qt.IsNil)
+	m.Unlock()
+
+	return wTx.Commit()
+}
+
+// TestConcurrentWriteTx validates the behaviour of badgerdb when multiple
+// write transactions modify the same key.
+func TestConcurrentWriteTx(t *testing.T) {
+	db, err := New(Options{Path: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wTx := db.WriteTx()
+	qt.Assert(t, wTx.Set(key, []byte{0}), qt.IsNil)
+	qt.Assert(t, wTx.Commit(), qt.IsNil)
+
+	var wg sync.WaitGroup
+	var m sync.Mutex
+	// A
+	var errA error
+	wg.Add(1)
+	go func() {
+		errA = inc(t, &m, db)
+		wg.Done()
+	}()
+
+	// B
+	var errB error
+	wg.Add(1)
+	go func() {
+		errB = inc(t, &m, db)
+		wg.Done()
+	}()
+
+	wg.Wait()
+	rTx := db.ReadTx()
+	defer rTx.Discard()
+	val, err := rTx.Get(key)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, val, qt.DeepEquals, []byte{1})
+
+	if errA == nil {
+		qt.Assert(t, errA, qt.IsNil)
+		qt.Assert(t, errB, qt.Equals, badger.ErrConflict)
+	} else {
+		qt.Assert(t, errA, qt.Equals, badger.ErrConflict)
+		qt.Assert(t, errB, qt.IsNil)
+	}
+}

--- a/db/badgerdbv3/badger.go
+++ b/db/badgerdbv3/badger.go
@@ -1,4 +1,4 @@
-package badgerdb
+package badgerdbv3
 
 import (
 	"errors"

--- a/db/badgerdbv3/badger_test.go
+++ b/db/badgerdbv3/badger_test.go
@@ -1,0 +1,57 @@
+package badgerdbv3
+
+import (
+	"encoding/binary"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
+	"go.vocdoni.io/dvote/db/internal/dbtest"
+)
+
+func TestWriteTx(t *testing.T) {
+	database, err := New(Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	dbtest.TestWriteTx(t, database)
+}
+
+func TestIterate(t *testing.T) {
+	database, err := New(Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	dbtest.TestIterate(t, database)
+}
+
+func TestBatch(t *testing.T) {
+	database, err := New(Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	const n = 1_000_000
+	wTx := database.WriteTx()
+	var key [4]byte
+	var value [4]byte
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint32(key[:], uint32(i))
+		binary.LittleEndian.PutUint32(value[:], uint32(i))
+		if err = wTx.Set(key[:], value[:]); err != nil {
+			break
+		}
+	}
+	// A WriteTx with too many writes fails because the Txn becomes too big
+	qt.Assert(t, err, qt.Equals, db.ErrTxnTooBig)
+	wTx.Discard()
+
+	batch := db.NewBatch(database)
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint32(key[:], uint32(i))
+		binary.LittleEndian.PutUint32(value[:], uint32(i))
+		if err = batch.Set(key[:], value[:]); err != nil {
+			break
+		}
+	}
+	// A Batch will commit automatically during writes if the Txn becomes
+	// too big, so we expect all the writes to work and no error here.
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, batch.Commit(), qt.IsNil)
+}

--- a/db/badgerdbv3/tx_test.go
+++ b/db/badgerdbv3/tx_test.go
@@ -1,4 +1,4 @@
-package badgerdb
+package badgerdbv3
 
 import (
 	"sync"

--- a/db/interface.go
+++ b/db/interface.go
@@ -5,6 +5,18 @@ import (
 	"io"
 )
 
+// StorageType defines the key value storage used as a backend database for the state
+type StorageType int
+
+const (
+	// StoragePebble defines pebbledb key value
+	StoragePebble StorageType = iota
+	// StorageBadgerv2 defines badgerdb v2 key value
+	StorageBadgerv2
+	// StorageBadgerv3 defines badgerdb v3 key value
+	StorageBadgerv3
+)
+
 // ErrKeysNotFound is used to indicate that a key does not exist in the db.
 var ErrKeyNotFound = fmt.Errorf("key not found")
 

--- a/db/prefixeddb/prefixeddb_test.go
+++ b/db/prefixeddb/prefixeddb_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	kv "go.vocdoni.io/dvote/db/pebbledb"
 )
 
 func TestPrefixed(t *testing.T) {
-	database, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	database, err := kv.New(kv.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	prefix1 := []byte("one")

--- a/statedb/statedb_test.go
+++ b/statedb/statedb_test.go
@@ -9,7 +9,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/arbo"
 	"go.vocdoni.io/dvote/db"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	kv "go.vocdoni.io/dvote/db/pebbledb"
 	"go.vocdoni.io/dvote/tree"
 )
 
@@ -376,7 +376,7 @@ func TestNoState(t *testing.T) {
 }
 
 func newTestStateDB(t *testing.T) *StateDB {
-	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	db, err := kv.New(kv.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 	sdb := NewStateDB(db)
 	return sdb
@@ -449,7 +449,7 @@ func treePrint(t *tree.Tree, tx db.ReadTx, name string) {
 }
 
 func TestTree(t *testing.T) {
-	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	db, err := kv.New(kv.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	tx := db.WriteTx()

--- a/test/statedb_test.go
+++ b/test/statedb_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tendermint/tendermint/privval"
 	models "go.vocdoni.io/proto/build/go/models"
 
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/util"
@@ -19,7 +20,7 @@ import (
 func TestVochainState(t *testing.T) {
 	t.Parallel()
 
-	s, err := vochain.NewState(t.TempDir())
+	s, err := vochain.NewState(t.TempDir(), db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 
 	// This used to panic due to nil *ImmutableTree fields.

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -14,6 +14,7 @@ import (
 
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
@@ -104,7 +105,7 @@ var (
 )
 
 func NewVochainStateWithOracles(tb testing.TB) *vochain.State {
-	s, err := vochain.NewState(tb.TempDir())
+	s, err := vochain.NewState(tb.TempDir(), db.StoragePebble)
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -117,7 +118,7 @@ func NewVochainStateWithOracles(tb testing.TB) *vochain.State {
 }
 
 func NewVochainStateWithValidators(tb testing.TB) *vochain.State {
-	s, err := vochain.NewState(tb.TempDir())
+	s, err := vochain.NewState(tb.TempDir(), db.StoragePebble)
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -151,7 +152,7 @@ func NewVochainStateWithValidators(tb testing.TB) *vochain.State {
 }
 
 func NewVochainStateWithProcess(tb testing.TB) *vochain.State {
-	s, err := vochain.NewState(tb.TempDir())
+	s, err := vochain.NewState(tb.TempDir(), db.StoragePebble)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -6,7 +6,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/arbo"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	kv "go.vocdoni.io/dvote/db/pebbledb"
 )
 
 // NOTE: most of the methods of Tree are just wrappers over
@@ -14,7 +14,7 @@ import (
 // there are tests that check the added code in the Tree wrapper
 
 func TestSet(t *testing.T) {
-	database, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	database, err := kv.New(kv.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	tree, err := New(nil, Options{DB: database, MaxLevels: 100, HashFunc: arbo.HashFunctionBlake2b})
@@ -62,7 +62,7 @@ func TestSet(t *testing.T) {
 }
 
 func TestGenProof(t *testing.T) {
-	database, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	database, err := kv.New(kv.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	tree, err := New(nil, Options{DB: database, MaxLevels: 100, HashFunc: arbo.HashFunctionBlake2b})
@@ -89,7 +89,7 @@ func TestGenProof(t *testing.T) {
 }
 
 func TestFromRoot(t *testing.T) {
-	database, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	database, err := kv.New(kv.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	tree, err := New(nil, Options{DB: database, MaxLevels: 100, HashFunc: arbo.HashFunctionBlake2b})

--- a/vochain/admintx_test.go
+++ b/vochain/admintx_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )
 
 func TestAddOracle(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +88,7 @@ func testAddOracle(t *testing.T,
 }
 
 func TestRemoveOracle(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.vocdoni.io/dvote/config"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/lru"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
@@ -54,8 +55,8 @@ var _ abcitypes.Application = (*BaseApplication)(nil)
 // NewBaseApplication creates a new BaseApplication given a name an a DB backend.
 // Node still needs to be initialized with SetNode
 // Callback functions still need to be initialized
-func NewBaseApplication(dbpath string) (*BaseApplication, error) {
-	state, err := NewState(dbpath)
+func NewBaseApplication(dbpath string, dbtype db.StorageType) (*BaseApplication, error) {
+	state, err := NewState(dbpath, dbtype)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create vochain state: (%s)", err)
 	}

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -10,7 +10,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/censustree"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	"go.vocdoni.io/dvote/db"
+	kv "go.vocdoni.io/dvote/db/pebbledb"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -22,7 +23,7 @@ const benchmarkVoters = 2000
 func BenchmarkCheckTx(b *testing.B) {
 	b.ReportAllocs()
 	tdir := b.TempDir()
-	app, err := NewBaseApplication(tdir)
+	app, err := NewBaseApplication(tdir, db.StoragePebble)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -42,7 +43,7 @@ func BenchmarkCheckTx(b *testing.B) {
 
 func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 	nvoters int, tmpDir string) (voters []*models.SignedTx) {
-	db, err := badgerdb.New(badgerdb.Options{Path: tmpDir})
+	db, err := kv.New(kv.Options{Path: tmpDir})
 	qt.Assert(b, err, qt.IsNil)
 	tr, err := censustree.New(censustree.Options{Name: util.RandomHex(12), ParentDB: db,
 		MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -9,7 +9,7 @@ import (
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/nacl"
 	"go.vocdoni.io/dvote/db"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	kv "go.vocdoni.io/dvote/db/pebbledb"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
@@ -94,7 +94,7 @@ func NewKeyKeeper(dbPath string, v *vochain.BaseApplication,
 		signer:  signer,
 	}
 	var err error
-	k.storage, err = badgerdb.New(badgerdb.Options{Path: dbPath})
+	k.storage, err = kv.New(kv.Options{Path: dbPath})
 	if err != nil {
 		return nil, err
 	}

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -8,6 +8,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -17,7 +18,7 @@ import (
 const ipfsUrl = "ipfs://123456789"
 
 func TestProcessSetStatusTransition(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +214,7 @@ func testSetProcessStatus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 }
 
 func TestProcessSetResultsTransition(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +341,7 @@ func testSetProcessResults(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 }
 
 func TestProcessSetCensusTransition(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +475,7 @@ func testSetProcessCensus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 }
 
 func TestCount(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/proof_erc20_test.go
+++ b/vochain/proof_erc20_test.go
@@ -8,6 +8,7 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -16,7 +17,7 @@ import (
 )
 
 func TestEthProof(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/proof_minime_test.go
+++ b/vochain/proof_minime_test.go
@@ -9,6 +9,7 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestMinimeProof(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -8,7 +8,8 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/censustree"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/db/badgerdb"
+	"go.vocdoni.io/dvote/db"
+	kv "go.vocdoni.io/dvote/db/pebbledb"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -17,12 +18,12 @@ import (
 )
 
 func TestMerkleTreeProof(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	db, err := kv.New(kv.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 	tr, err := censustree.New(censustree.Options{Name: "testchecktx", ParentDB: db,
 		MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})
@@ -179,7 +180,7 @@ func TestMerkleTreeProof(t *testing.T) {
 }
 
 func TestCAProof(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/scrutinizer/db_benchmark_test.go
+++ b/vochain/scrutinizer/db_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
@@ -28,7 +29,7 @@ func BenchmarkNewProcess(b *testing.B) {
 }
 
 func benchmarkIndexTx(b *testing.B) {
-	app, err := vochain.NewBaseApplication(b.TempDir())
+	app, err := vochain.NewBaseApplication(b.TempDir(), db.StoragePebble)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func benchmarkIndexTx(b *testing.B) {
 }
 
 func benchmarkNewProcess(b *testing.B) {
-	app, err := vochain.NewBaseApplication(b.TempDir())
+	app, err := vochain.NewBaseApplication(b.TempDir(), db.StoragePebble)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -11,6 +11,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/nacl"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -27,7 +28,7 @@ func TestEntityList(t *testing.T) {
 }
 
 func testEntityList(t *testing.T, entityCount int) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +78,7 @@ func testEntityList(t *testing.T, entityCount int) {
 }
 
 func TestEntitySearch(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +175,7 @@ func TestProcessList(t *testing.T) {
 }
 
 func testProcessList(t *testing.T, procsCount int) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +240,7 @@ func testProcessList(t *testing.T, procsCount int) {
 }
 
 func TestProcessSearch(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +359,7 @@ func TestProcessSearch(t *testing.T) {
 }
 
 func TestProcessListWithNamespaceAndStatus(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +428,7 @@ func TestProcessListWithNamespaceAndStatus(t *testing.T) {
 }
 
 func TestResults(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -559,7 +560,7 @@ func TestResults(t *testing.T) {
 }
 
 func TestLiveResults(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -635,7 +636,7 @@ func TestLiveResults(t *testing.T) {
 }
 
 func TestAddVote(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)
@@ -747,7 +748,7 @@ var vote = func(v []int, sc *Scrutinizer, pid []byte, weight *big.Int) error {
 
 func TestBallotProtocolRateProduct(t *testing.T) {
 	// Rate a product from 0 to 4
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)
@@ -786,7 +787,7 @@ func TestBallotProtocolRateProduct(t *testing.T) {
 
 func TestBallotProtocolQuadratic(t *testing.T) {
 	// Rate a product from 0 to 4
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)
@@ -839,7 +840,7 @@ func TestBallotProtocolQuadratic(t *testing.T) {
 func TestBallotProtocolMultiChoice(t *testing.T) {
 	// Choose your 3 favorite colours out of 5
 
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)
@@ -887,7 +888,7 @@ func TestBallotProtocolMultiChoice(t *testing.T) {
 }
 
 func TestCountVotes(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -956,7 +957,7 @@ func TestCountVotes(t *testing.T) {
 }
 
 func TestTxIndexer(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(t.TempDir(), db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -26,7 +26,7 @@ import (
 // NewVochain starts a node with an ABCI application
 func NewVochain(vochaincfg *config.VochainCfg, genesis []byte) *BaseApplication {
 	// creating new vochain app
-	app, err := NewBaseApplication(vochaincfg.DataDir + "/data")
+	app, err := NewBaseApplication(vochaincfg.DataDir+"/data", vochaincfg.DBbackend)
 	if err != nil {
 		log.Fatalf("cannot initialize vochain application: %s", err)
 	}

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/log"
 	models "go.vocdoni.io/proto/build/go/models"
 )
@@ -31,14 +32,14 @@ func (r *Random) RandomBytes(n int) []byte {
 
 func TestStateReopen(t *testing.T) {
 	dir := t.TempDir()
-	s, err := NewState(dir)
+	s, err := NewState(dir, db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 	hash1Before, err := s.Save()
 	qt.Assert(t, err, qt.IsNil)
 
 	s.db.Close()
 
-	s, err = NewState(dir)
+	s, err = NewState(dir, db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 	hash1After, err := s.Store.Hash()
 	qt.Assert(t, err, qt.IsNil)
@@ -48,7 +49,7 @@ func TestStateReopen(t *testing.T) {
 func TestStateBasic(t *testing.T) {
 	rng := newRandom(0)
 	log.Init("info", "stdout")
-	s, err := NewState(t.TempDir())
+	s, err := NewState(t.TempDir(), db.StoragePebble)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/transaction_test.go
+++ b/vochain/transaction_test.go
@@ -7,11 +7,12 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/arbo"
 	snarkParsers "github.com/vocdoni/go-snark/parsers"
+	"go.vocdoni.io/dvote/db"
 	models "go.vocdoni.io/proto/build/go/models"
 )
 
 func TestVoteEnvelopeCheckCaseZkSNARK(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(t.TempDir(), db.StoragePebble)
 	qt.Assert(t, err, qt.IsNil)
 
 	vkJSON := `


### PR DESCRIPTION
Current implementations: pebble (default), badger v2 and badger v3
New flag added "--dbBackend" for specifying backend to use with the Vochain state

Signed-off-by: p4u <pau@dabax.net>