### PR TITLE
Integrate pebbledb

### DIFF
--- a/census/census_test.go
+++ b/census/census_test.go
@@ -14,6 +14,7 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
@@ -38,7 +39,7 @@ func TestCompressor(t *testing.T) {
 
 func TestMemoryUsage(t *testing.T) {
 	var cm Manager
-	qt.Assert(t, cm.Start(t.TempDir(), ""), qt.IsNil)
+	qt.Assert(t, cm.Start(db.TypePebble, t.TempDir(), ""), qt.IsNil)
 	defer func() { qt.Assert(t, cm.Stop(), qt.IsNil) }()
 
 	const n = 16
@@ -95,7 +96,7 @@ func TestOutdatedCensuses(t *testing.T) {
 	// Init Manager, and expect the outdated censuses to be moved,
 	// namespaces.json to be backed up and cleaned
 	var cm Manager
-	qt.Assert(t, cm.Start(storageDir, ""), qt.IsNil)
+	qt.Assert(t, cm.Start(db.TypePebble, storageDir, ""), qt.IsNil)
 	defer func() { qt.Assert(t, cm.Stop(), qt.IsNil) }()
 
 	// Assert correct namespaces.json backup
@@ -129,7 +130,7 @@ func TestOutdatedCensuses(t *testing.T) {
 func TestManager(t *testing.T) {
 	storageDir := t.TempDir()
 	var cm Manager
-	qt.Assert(t, cm.Start(storageDir, ""), qt.IsNil)
+	qt.Assert(t, cm.Start(db.TypePebble, storageDir, ""), qt.IsNil)
 
 	// Add some censues with some keys
 	const numCensuses = 3
@@ -149,7 +150,7 @@ func TestManager(t *testing.T) {
 	// Close and open again the Manager, and read back the censuses and keys
 	qt.Assert(t, cm.Stop(), qt.IsNil)
 	cm = Manager{}
-	qt.Assert(t, cm.Start(storageDir, ""), qt.IsNil)
+	qt.Assert(t, cm.Start(db.TypePebble, storageDir, ""), qt.IsNil)
 
 	for i := 0; i < numCensuses; i++ {
 		tree, err := cm.LoadTree(fmt.Sprintf("%v", i), models.Census_ARBO_BLAKE2B)

--- a/censustree/censustree_test.go
+++ b/censustree/censustree_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/badgerdb"
 	"go.vocdoni.io/proto/build/go/models"
 )
@@ -13,7 +14,7 @@ import (
 // added code in the CensusTree wrapper.
 
 func TestPublish(t *testing.T) {
-	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	db, err := badgerdb.New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	censusTree, err := New(Options{Name: "test", ParentDB: db, MaxLevels: 256,

--- a/censustreelegacy/arbotree/wrapper.go
+++ b/censustreelegacy/arbotree/wrapper.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/vocdoni/arbo"
 	censustree "go.vocdoni.io/dvote/censustreelegacy"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/badgerdb"
 	"go.vocdoni.io/proto/build/go/models"
 )
@@ -35,7 +36,7 @@ var _ censustree.Tree = (*Tree)(nil)
 func NewTree(name, storageDir string, nLevels int, hashFunc arbo.HashFunction) (
 	censustree.Tree, error) {
 	dbDir := filepath.Join(storageDir, "arbotree.db."+strings.TrimSpace(name))
-	database, err := badgerdb.New(badgerdb.Options{Path: dbDir})
+	database, err := badgerdb.New(db.Options{Path: dbDir})
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +75,7 @@ func (t *Tree) TypeString() string {
 // to choose the hash function to be used in the Tree.
 func (t *Tree) Init(name, storageDir string) error {
 	dbDir := filepath.Join(storageDir, "arbotree.db."+strings.TrimSpace(name))
-	database, err := badgerdb.New(badgerdb.Options{Path: dbDir})
+	database, err := badgerdb.New(db.Options{Path: dbDir})
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/types"
 )
 
@@ -46,6 +47,19 @@ func (c *DvoteCfg) ValidMode() bool {
 	case types.ModeMiner:
 		break
 	case types.ModeEthAPIoracle:
+		break
+	default:
+		return false
+	}
+	return true
+}
+
+// ValidDBType checks if the configured dbType is valid
+func (c *VochainCfg) ValidDBType() bool {
+	switch c.DBType {
+	case db.TypePebble:
+		break
+	case db.TypeBadger:
 		break
 	default:
 		return false
@@ -139,6 +153,8 @@ type VochainCfg struct {
 	PublicAddr string
 	// DataDir directory where the Vochain related data (DB's and priv_validator_state.json) is stored
 	DataDir string
+	// DBType is the type of key-value db to be used
+	DBType string
 	// Genesis path where the genesis file is stored
 	Genesis string
 	// CreateGenesis if True a new genesis file is created

--- a/db/badgerdb/badger.go
+++ b/db/badgerdb/badger.go
@@ -87,14 +87,9 @@ type BadgerDB struct {
 // check that BadgerDB implements the db.Database interface
 var _ db.Database = (*BadgerDB)(nil)
 
-// Options defines params for creating a new BadgerDB
-type Options struct {
-	Path string
-}
-
 // New returns a BadgerDB using the given Options, which implements the
 // db.Database interface
-func New(opts Options) (*BadgerDB, error) {
+func New(opts db.Options) (*BadgerDB, error) {
 	if err := os.MkdirAll(opts.Path, os.ModePerm); err != nil {
 		return nil, err
 	}

--- a/db/badgerdb/badger_test.go
+++ b/db/badgerdb/badger_test.go
@@ -10,21 +10,21 @@ import (
 )
 
 func TestWriteTx(t *testing.T) {
-	database, err := New(Options{Path: t.TempDir()})
+	database, err := New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	dbtest.TestWriteTx(t, database)
 }
 
 func TestIterate(t *testing.T) {
-	database, err := New(Options{Path: t.TempDir()})
+	database, err := New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	dbtest.TestIterate(t, database)
 }
 
 func TestBatch(t *testing.T) {
-	database, err := New(Options{Path: t.TempDir()})
+	database, err := New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	const n = 1_000_000

--- a/db/badgerdb/tx_test.go
+++ b/db/badgerdb/tx_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
 )
 
 var key = []byte{1}
@@ -27,7 +28,7 @@ func inc(t *testing.T, m *sync.Mutex, db *BadgerDB) error {
 // TestConcurrentWriteTx validates the behaviour of badgerdb when multiple
 // write transactions modify the same key.
 func TestConcurrentWriteTx(t *testing.T) {
-	db, err := New(Options{Path: t.TempDir()})
+	db, err := New(db.Options{Path: t.TempDir()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/db/interface.go
+++ b/db/interface.go
@@ -5,12 +5,24 @@ import (
 	"io"
 )
 
+const (
+	// TypePebble defines the type of db that uses PebbleDB
+	TypePebble = "pebble"
+	// TypeBadger defines the type of db that uses BadgerDB
+	TypeBadger = "badger"
+)
+
 // ErrKeysNotFound is used to indicate that a key does not exist in the db.
 var ErrKeyNotFound = fmt.Errorf("key not found")
 
 // ErrTxnTooBig is used to indicate that a WriteTx is too big and can't include
 // more writes.
 var ErrTxnTooBig = fmt.Errorf("txn too big")
+
+// Options defines params for creating a new Database
+type Options struct {
+	Path string
+}
 
 // Database wraps all database operations. All methods are safe for concurrent
 // use.

--- a/db/metadb/metadb.go
+++ b/db/metadb/metadb.go
@@ -1,0 +1,30 @@
+package metadb
+
+import (
+	"fmt"
+
+	"go.vocdoni.io/dvote/db"
+	"go.vocdoni.io/dvote/db/badgerdb"
+	"go.vocdoni.io/dvote/db/pebbledb"
+)
+
+func New(typ, dir string) (db.Database, error) {
+	var database db.Database
+	var err error
+	opts := db.Options{Path: dir}
+	switch typ {
+	case db.TypePebble:
+		database, err = badgerdb.New(opts)
+		if err != nil {
+			return nil, err
+		}
+	case db.TypeBadger:
+		database, err = pebbledb.New(opts)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("invalid dbType: %q. Available types: %q, %q", typ, db.TypePebble, db.TypeBadger)
+	}
+	return database, nil
+}

--- a/db/pebbledb/pebledb.go
+++ b/db/pebbledb/pebledb.go
@@ -77,14 +77,9 @@ type PebbleDB struct {
 // check that PebbleDB implements the db.Database interface
 var _ db.Database = (*PebbleDB)(nil)
 
-// Options defines params for creating a new PebbleDB
-type Options struct {
-	Path string
-}
-
 // New returns a PebbleDB using the given Options, which implements the
 // db.Database interface
-func New(opts Options) (*PebbleDB, error) {
+func New(opts db.Options) (*PebbleDB, error) {
 	if err := os.MkdirAll(opts.Path, os.ModePerm); err != nil {
 		return nil, err
 	}

--- a/db/pebbledb/pebledb_test.go
+++ b/db/pebbledb/pebledb_test.go
@@ -4,18 +4,19 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/internal/dbtest"
 )
 
 func TestWriteTx(t *testing.T) {
-	database, err := New(Options{Path: t.TempDir()})
+	database, err := New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	dbtest.TestWriteTx(t, database)
 }
 
 func TestIterate(t *testing.T) {
-	database, err := New(Options{Path: t.TempDir()})
+	database, err := New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	dbtest.TestIterate(t, database)

--- a/db/prefixeddb/prefixeddb_test.go
+++ b/db/prefixeddb/prefixeddb_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/badgerdb"
 )
 
 func TestPrefixed(t *testing.T) {
-	database, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	database, err := badgerdb.New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	prefix1 := []byte("one")

--- a/service/census.go
+++ b/service/census.go
@@ -10,7 +10,7 @@ import (
 	"go.vocdoni.io/dvote/metrics"
 )
 
-func Census(datadir string, ma *metrics.Agent) (*census.Manager, error) {
+func Census(dbType, datadir string, ma *metrics.Agent) (*census.Manager, error) {
 	log.Info("creating census service")
 	var censusManager census.Manager
 	stdir := path.Join(datadir, "census")
@@ -19,7 +19,7 @@ func Census(datadir string, ma *metrics.Agent) (*census.Manager, error) {
 			return nil, err
 		}
 	}
-	if err := censusManager.Start(stdir, ""); err != nil {
+	if err := censusManager.Start(dbType, stdir, ""); err != nil {
 		return nil, err
 	}
 

--- a/service/vochain.go
+++ b/service/vochain.go
@@ -26,7 +26,7 @@ import (
 )
 
 func Vochain(vconfig *config.VochainCfg, waitForSync bool,
-	ma *metrics.Agent, cm *census.Manager, storage data.Storage) (
+	ma *metrics.Agent, cm *census.Manager, ipfsStorage data.Storage) (
 	*vochain.BaseApplication, *scrutinizer.Scrutinizer,
 	*vochaininfo.VochainInfo, error) {
 	log.Infof("creating vochain service for network %s", vconfig.Chain)
@@ -137,9 +137,9 @@ func Vochain(vconfig *config.VochainCfg, waitForSync bool,
 			err = fmt.Errorf("process archive needs indexer enabled")
 			return nil, nil, nil, err
 		}
-		ipfs, ok := storage.(*data.IPFSHandle)
+		ipfs, ok := ipfsStorage.(*data.IPFSHandle)
 		if !ok {
-			log.Warnf("storage is not IPFS, archive publishing disabled")
+			log.Warnf("ipfsStorage is not IPFS, archive publishing disabled")
 		}
 		log.Infof("starting process archiver on %s", vconfig.ProcessArchiveDataDir)
 		processarchive.NewProcessArchive(

--- a/statedb/statedb_test.go
+++ b/statedb/statedb_test.go
@@ -376,7 +376,7 @@ func TestNoState(t *testing.T) {
 }
 
 func newTestStateDB(t *testing.T) *StateDB {
-	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	db, err := badgerdb.New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 	sdb := NewStateDB(db)
 	return sdb
@@ -449,7 +449,7 @@ func treePrint(t *tree.Tree, tx db.ReadTx, name string) {
 }
 
 func TestTree(t *testing.T) {
-	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	db, err := badgerdb.New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	tx := db.WriteTx()

--- a/test/statedb_test.go
+++ b/test/statedb_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tendermint/tendermint/privval"
 	models "go.vocdoni.io/proto/build/go/models"
 
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/util"
@@ -19,7 +20,7 @@ import (
 func TestVochainState(t *testing.T) {
 	t.Parallel()
 
-	s, err := vochain.NewState(t.TempDir())
+	s, err := vochain.NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 
 	// This used to panic due to nil *ImmutableTree fields.

--- a/test/testcommon/apis.go
+++ b/test/testcommon/apis.go
@@ -9,6 +9,7 @@ import (
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/data"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/multirpc/transports"
 	"go.vocdoni.io/dvote/multirpc/transports/mhttp"
 	"go.vocdoni.io/dvote/router"
@@ -89,7 +90,7 @@ func (d *DvoteAPIServer) Start(tb testing.TB, apis ...string) {
 	// Create the Census Manager and enable it trough the router
 	var cm census.Manager
 	d.CensusDir = tb.TempDir()
-	if err := cm.Start(d.CensusDir, ""); err != nil {
+	if err := cm.Start(db.TypePebble, d.CensusDir, ""); err != nil {
 		tb.Fatal(err)
 	}
 

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -14,6 +14,7 @@ import (
 
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
@@ -104,7 +105,7 @@ var (
 )
 
 func NewVochainStateWithOracles(tb testing.TB) *vochain.State {
-	s, err := vochain.NewState(tb.TempDir())
+	s, err := vochain.NewState(db.TypePebble, tb.TempDir())
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -117,7 +118,7 @@ func NewVochainStateWithOracles(tb testing.TB) *vochain.State {
 }
 
 func NewVochainStateWithValidators(tb testing.TB) *vochain.State {
-	s, err := vochain.NewState(tb.TempDir())
+	s, err := vochain.NewState(db.TypePebble, tb.TempDir())
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -151,7 +152,7 @@ func NewVochainStateWithValidators(tb testing.TB) *vochain.State {
 }
 
 func NewVochainStateWithProcess(tb testing.TB) *vochain.State {
-	s, err := vochain.NewState(tb.TempDir())
+	s, err := vochain.NewState(db.TypePebble, tb.TempDir())
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -6,6 +6,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/arbo"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/badgerdb"
 )
 
@@ -14,7 +15,7 @@ import (
 // there are tests that check the added code in the Tree wrapper
 
 func TestSet(t *testing.T) {
-	database, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	database, err := badgerdb.New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	tree, err := New(nil, Options{DB: database, MaxLevels: 100, HashFunc: arbo.HashFunctionBlake2b})
@@ -62,7 +63,7 @@ func TestSet(t *testing.T) {
 }
 
 func TestGenProof(t *testing.T) {
-	database, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	database, err := badgerdb.New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	tree, err := New(nil, Options{DB: database, MaxLevels: 100, HashFunc: arbo.HashFunctionBlake2b})
@@ -89,7 +90,7 @@ func TestGenProof(t *testing.T) {
 }
 
 func TestFromRoot(t *testing.T) {
-	database, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	database, err := badgerdb.New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 
 	tree, err := New(nil, Options{DB: database, MaxLevels: 100, HashFunc: arbo.HashFunctionBlake2b})

--- a/vochain/admintx_test.go
+++ b/vochain/admintx_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )
 
 func TestAddOracle(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +88,7 @@ func testAddOracle(t *testing.T,
 }
 
 func TestRemoveOracle(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -54,8 +54,8 @@ var _ abcitypes.Application = (*BaseApplication)(nil)
 // NewBaseApplication creates a new BaseApplication given a name an a DB backend.
 // Node still needs to be initialized with SetNode
 // Callback functions still need to be initialized
-func NewBaseApplication(dbpath string) (*BaseApplication, error) {
-	state, err := NewState(dbpath)
+func NewBaseApplication(dbType, dbpath string) (*BaseApplication, error) {
+	state, err := NewState(dbType, dbpath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create vochain state: (%s)", err)
 	}

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -10,6 +10,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/censustree"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/badgerdb"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -22,7 +23,7 @@ const benchmarkVoters = 2000
 func BenchmarkCheckTx(b *testing.B) {
 	b.ReportAllocs()
 	tdir := b.TempDir()
-	app, err := NewBaseApplication(tdir)
+	app, err := NewBaseApplication(db.TypePebble, tdir)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -42,7 +43,7 @@ func BenchmarkCheckTx(b *testing.B) {
 
 func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 	nvoters int, tmpDir string) (voters []*models.SignedTx) {
-	db, err := badgerdb.New(badgerdb.Options{Path: tmpDir})
+	db, err := badgerdb.New(db.Options{Path: tmpDir})
 	qt.Assert(b, err, qt.IsNil)
 	tr, err := censustree.New(censustree.Options{Name: util.RandomHex(12), ParentDB: db,
 		MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -94,7 +94,7 @@ func NewKeyKeeper(dbPath string, v *vochain.BaseApplication,
 		signer:  signer,
 	}
 	var err error
-	k.storage, err = badgerdb.New(badgerdb.Options{Path: dbPath})
+	k.storage, err = badgerdb.New(db.Options{Path: dbPath})
 	if err != nil {
 		return nil, err
 	}

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -8,6 +8,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -17,7 +18,7 @@ import (
 const ipfsUrl = "ipfs://123456789"
 
 func TestProcessSetStatusTransition(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +214,7 @@ func testSetProcessStatus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 }
 
 func TestProcessSetResultsTransition(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +341,7 @@ func testSetProcessResults(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 }
 
 func TestProcessSetCensusTransition(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +475,7 @@ func testSetProcessCensus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 }
 
 func TestCount(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/proof_erc20_test.go
+++ b/vochain/proof_erc20_test.go
@@ -8,6 +8,7 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -16,7 +17,7 @@ import (
 )
 
 func TestEthProof(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/proof_minime_test.go
+++ b/vochain/proof_minime_test.go
@@ -9,6 +9,7 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestMinimeProof(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -8,6 +8,7 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/censustree"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/badgerdb"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
@@ -17,12 +18,12 @@ import (
 )
 
 func TestMerkleTreeProof(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	db, err := badgerdb.New(badgerdb.Options{Path: t.TempDir()})
+	db, err := badgerdb.New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)
 	tr, err := censustree.New(censustree.Options{Name: "testchecktx", ParentDB: db,
 		MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})
@@ -179,7 +180,7 @@ func TestMerkleTreeProof(t *testing.T) {
 }
 
 func TestCAProof(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/scrutinizer/db_benchmark_test.go
+++ b/vochain/scrutinizer/db_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
@@ -28,7 +29,7 @@ func BenchmarkNewProcess(b *testing.B) {
 }
 
 func benchmarkIndexTx(b *testing.B) {
-	app, err := vochain.NewBaseApplication(b.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, b.TempDir())
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func benchmarkIndexTx(b *testing.B) {
 }
 
 func benchmarkNewProcess(b *testing.B) {
-	app, err := vochain.NewBaseApplication(b.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, b.TempDir())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -11,6 +11,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/nacl"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -27,7 +28,7 @@ func TestEntityList(t *testing.T) {
 }
 
 func testEntityList(t *testing.T, entityCount int) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +78,7 @@ func testEntityList(t *testing.T, entityCount int) {
 }
 
 func TestEntitySearch(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +175,7 @@ func TestProcessList(t *testing.T) {
 }
 
 func testProcessList(t *testing.T, procsCount int) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +240,7 @@ func testProcessList(t *testing.T, procsCount int) {
 }
 
 func TestProcessSearch(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +359,7 @@ func TestProcessSearch(t *testing.T) {
 }
 
 func TestProcessListWithNamespaceAndStatus(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +428,7 @@ func TestProcessListWithNamespaceAndStatus(t *testing.T) {
 }
 
 func TestResults(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -559,7 +560,7 @@ func TestResults(t *testing.T) {
 }
 
 func TestLiveResults(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -635,7 +636,7 @@ func TestLiveResults(t *testing.T) {
 }
 
 func TestAddVote(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)
@@ -747,7 +748,7 @@ var vote = func(v []int, sc *Scrutinizer, pid []byte, weight *big.Int) error {
 
 func TestBallotProtocolRateProduct(t *testing.T) {
 	// Rate a product from 0 to 4
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)
@@ -786,7 +787,7 @@ func TestBallotProtocolRateProduct(t *testing.T) {
 
 func TestBallotProtocolQuadratic(t *testing.T) {
 	// Rate a product from 0 to 4
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)
@@ -839,7 +840,7 @@ func TestBallotProtocolQuadratic(t *testing.T) {
 func TestBallotProtocolMultiChoice(t *testing.T) {
 	// Choose your 3 favorite colours out of 5
 
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)
@@ -887,7 +888,7 @@ func TestBallotProtocolMultiChoice(t *testing.T) {
 }
 
 func TestCountVotes(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -956,7 +957,7 @@ func TestCountVotes(t *testing.T) {
 }
 
 func TestTxIndexer(t *testing.T) {
-	app, err := vochain.NewBaseApplication(t.TempDir())
+	app, err := vochain.NewBaseApplication(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 
 	sc, err := NewScrutinizer(t.TempDir(), app, true)

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -26,7 +26,7 @@ import (
 // NewVochain starts a node with an ABCI application
 func NewVochain(vochaincfg *config.VochainCfg, genesis []byte) *BaseApplication {
 	// creating new vochain app
-	app, err := NewBaseApplication(vochaincfg.DataDir + "/data")
+	app, err := NewBaseApplication(vochaincfg.DBType, vochaincfg.DataDir+"/data")
 	if err != nil {
 		log.Fatalf("cannot initialize vochain application: %s", err)
 	}

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/log"
 	models "go.vocdoni.io/proto/build/go/models"
 )
@@ -31,14 +32,14 @@ func (r *Random) RandomBytes(n int) []byte {
 
 func TestStateReopen(t *testing.T) {
 	dir := t.TempDir()
-	s, err := NewState(dir)
+	s, err := NewState(db.TypePebble, dir)
 	qt.Assert(t, err, qt.IsNil)
 	hash1Before, err := s.Save()
 	qt.Assert(t, err, qt.IsNil)
 
 	s.db.Close()
 
-	s, err = NewState(dir)
+	s, err = NewState(db.TypePebble, dir)
 	qt.Assert(t, err, qt.IsNil)
 	hash1After, err := s.Store.Hash()
 	qt.Assert(t, err, qt.IsNil)
@@ -48,7 +49,7 @@ func TestStateReopen(t *testing.T) {
 func TestStateBasic(t *testing.T) {
 	rng := newRandom(0)
 	log.Init("info", "stdout")
-	s, err := NewState(t.TempDir())
+	s, err := NewState(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/transaction_test.go
+++ b/vochain/transaction_test.go
@@ -7,11 +7,12 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/arbo"
 	snarkParsers "github.com/vocdoni/go-snark/parsers"
+	"go.vocdoni.io/dvote/db"
 	models "go.vocdoni.io/proto/build/go/models"
 )
 
 func TestVoteEnvelopeCheckCaseZkSNARK(t *testing.T) {
-	app, err := NewBaseApplication(t.TempDir())
+	app, err := NewBaseApplication(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 
 	vkJSON := `


### PR DESCRIPTION
Integrate pebbledb:
- Integrate pebbledb in the census & statedb
- Add flag to define which db implementation to use: PebbleDB or
BadgerDB

Currently the default db is pebble, but can be set to use badger by a flag. Maybe before merging this PR would be worth to test it with in the dev environment.