### PR TITLE
fix dualstack support of ExternalIP()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/ethereum/go-ethereum v1.10.8
 	github.com/frankban/quicktest v1.13.0
+	github.com/glendc/go-external-ip v0.1.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/cors v1.1.1
 	github.com/google/go-cmp v0.5.5
@@ -50,7 +51,6 @@ require (
 	github.com/tendermint/tm-db v0.6.4
 	github.com/timshannon/badgerhold/v3 v3.0.0-20210415132401-e7c90fb5919f
 	github.com/vocdoni/arbo v0.0.0-20210927131431-d7c756341372
-	github.com/vocdoni/go-external-ip v0.0.0-20210705122950-fae6195a1d44
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -461,6 +461,8 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/gin-gonic/gin v1.6.3 h1:ahKqKTFpO5KTPHxWZjEdPScmYaGtLo8Y4DMHoEsnp14=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
+github.com/glendc/go-external-ip v0.1.0 h1:iX3xQ2Q26atAmLTbd++nUce2P5ht5P4uD4V7caSY/xg=
+github.com/glendc/go-external-ip v0.1.0/go.mod h1:CNx312s2FLAJoWNdJWZ2Fpf5O4oLsMFwuYviHjS4uJE=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=
@@ -2096,7 +2098,6 @@ github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f h1:z7CK3k1yI
 github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f/go.mod h1:BoN7UMTA/JcgmNPaoUQq6RwuixhgSrk5PmCMVMKLxpc=
 github.com/vocdoni/blind-ca v0.1.4/go.mod h1:4ouWDqlvXrrNS0Csf3hKA3cuDTmKh6nP7kSXF39nT4s=
 github.com/vocdoni/eth-storage-proof v0.1.4-0.20201128112323-de7513ce5e25/go.mod h1:NLA1A55raZ1VNMmKulPUm+Lu9CVetCDVuDCYk5bSYrE=
-github.com/vocdoni/go-external-ip v0.0.0-20210705122950-fae6195a1d44 h1:OK5B1GPq2zPu2Z1sYaUcAmt3CpILABwYsvkK2raI1AQ=
 github.com/vocdoni/go-external-ip v0.0.0-20210705122950-fae6195a1d44/go.mod h1:o/kqzlz81Aq5/++p7zIRaaOiEUmCOiap7ulEAUeSQWI=
 github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319 h1:W8N7yfnWsVD3l2Sh0pTtXCDd4+LNh58lE427D1U9SVY=
 github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319/go.mod h1:A4ZJ8jq+ZbNvxrNUmScv2ghL34A6c6vw5Y1Oza2h7lo=

--- a/util/net.go
+++ b/util/net.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	externalip "github.com/vocdoni/go-external-ip"
+	externalip "github.com/glendc/go-external-ip"
 )
 
 // PublicIP returns the external/public IP of the host
@@ -16,7 +16,8 @@ import (
 // If a nil error is returned, the returned IP must be valid.
 func PublicIP() (net.IP, error) {
 	consensus := externalip.DefaultConsensus(nil, nil)
-	ip, err := consensus.ExternalIP(4)
+	consensus.UseIPProtocol(4)
+	ip, err := consensus.ExternalIP()
 	// if the IP isn't a valid ipv4, To4 will return nil
 	if ip = ip.To4(); ip == nil {
 		return nil, fmt.Errorf("public IP discovery failed: %v", err)


### PR DESCRIPTION
the current implementation of https://github.com/vocdoni/go-external-ip fork does not work as expected
(sometimes returns ipv4 when asked for ipv6, for example)