### PR TITLE
Add db.WriteTx.Apply method

### DIFF
--- a/db/badgerdb/badger_test.go
+++ b/db/badgerdb/badger_test.go
@@ -30,6 +30,13 @@ func TestConcurrentWriteTx(t *testing.T) {
 	dbtest.TestConcurrentWriteTx(t, database)
 }
 
+func TestWriteTxApply(t *testing.T) {
+	database, err := New(db.Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	dbtest.TestWriteTxApply(t, database)
+}
+
 func TestBatch(t *testing.T) {
 	database, err := New(db.Options{Path: t.TempDir()})
 	qt.Assert(t, err, qt.IsNil)

--- a/db/batch.go
+++ b/db/batch.go
@@ -56,6 +56,11 @@ func (t *Batch) Discard() {
 	t.tx.Discard()
 }
 
+// Apply implements the WriteTx.Apply interface method
+func (t *Batch) Apply(other WriteTx) (err error) {
+	return t.tx.Apply(other)
+}
+
 // Set implements the WriteTx.Set interface method.  If during this
 // operation, the internal tx becomes too big, all the pending writes will be
 // committed and a new WriteTx will be created to continue with this and

--- a/db/interface.go
+++ b/db/interface.go
@@ -67,6 +67,13 @@ type WriteTx interface {
 	Set(key []byte, value []byte) error
 	// Delete deletes a key and its value.
 	Delete(key []byte) error
+	// Apply applies the value-passed WriteTx into the given WriteTx,
+	// copying the key-values from the original WriteTx into the one from
+	// which the method is called.
+	// TODO Review once generics are ready: WriteTx is an interface, so
+	// Apply internally needs type assertions, revisit this once generics
+	// are ready.
+	Apply(WriteTx) error
 	// Commit commits the transaction into the db
 	Commit() error
 }

--- a/db/pebbledb/pebledb.go
+++ b/db/pebbledb/pebledb.go
@@ -67,6 +67,12 @@ func (tx WriteTx) Delete(k []byte) error {
 	return tx.batch.Delete(k, nil)
 }
 
+// Apply implements the db.WriteTx.Apply interface method
+func (tx WriteTx) Apply(other db.WriteTx) (err error) {
+	otherPebble := other.(WriteTx)
+	return tx.batch.Apply(otherPebble.batch, nil)
+}
+
 // Commit implements the db.WriteTx.Commit interface method
 func (tx WriteTx) Commit() error {
 	return tx.batch.Commit(nil)

--- a/db/prefixeddb/prefixeddb.go
+++ b/db/prefixeddb/prefixeddb.go
@@ -128,6 +128,11 @@ func (t *PrefixedWriteTx) Delete(key []byte) error {
 	return t.tx.Delete(prefixSlice(t.prefix, key))
 }
 
+// Apply implements the db.WriteTx.Apply interface method
+func (t *PrefixedWriteTx) Apply(other db.WriteTx) error {
+	return t.tx.Apply(other)
+}
+
 // Commit implements the db.WriteTx.Commit interface method.  Notice that this
 // method also commits the wrapped db.WriteTx.
 func (t *PrefixedWriteTx) Commit() error {

--- a/statedb/statedb.go
+++ b/statedb/statedb.go
@@ -367,7 +367,12 @@ func (t *readOnlyWriteTx) Delete(key []byte) error {
 	return ErrReadOnly
 }
 
-// Commit implements db.WriteTx.COmmit but returns nil always.
+// Apply implements db.WriteTx.Apply but returns error always.
+func (t *readOnlyWriteTx) Apply(w db.WriteTx) error {
+	return ErrReadOnly
+}
+
+// Commit implements db.WriteTx.Commit but returns nil always.
 func (t *readOnlyWriteTx) Commit() error {
 	return nil
 }


### PR DESCRIPTION
Apply applies the value-passed WriteTx into the given WriteTx,
copying the key-values from the original WriteTx into the one from
which the method is called.
For PebbleDB case, it uses the original Pebble `Apply` method. For the
BadgerDB case, as Badger does not offer this functionallity, our wrapper
uses reflect to access to the keys&values of the tx.

It is needed for arbo, in order to be able to work with a WriteTx from
different goroutines, where it would be done as: create a WriteTx for
each goroutine, use Apply to copy the content from the main WriteTx into
each goroutine WriteTx, proceed with the goroutines, and once completed,
use Apply to copy the content from each goroutine-WriteTx into the main
WriteTx.

~**Warning**:~
~PebbleDB has an `Apply` method, but BadgerDB hasn't. I've tried to do access to private values of the badgerdb Tx, in order to implement the `Apply` method for the badgerdb wrapper, running tests it seems to work, but does not seem a solid solution, and currently GoAnalyzer gives an error due `db/badgerdb/badger.go:84:23: call of reflect.ValueOf copies lock value: github.com/dgraph-io/badger/v3.Txn contains sync.Mutex`, as the `badger.Txn` internally has a mutex. I don't know if we could use a different approach or some different 'trick', @mvdan I would appreciate your opinion ^^~
**Update**: the BadgerDB tx 'Apply' has been done as stated in https://github.com/vocdoni/vocdoni-node/pull/319#issuecomment-949711467

Here can be found a use of the WriteTx.Apply in arbo when parallelizing while adding stuff in the tree (in the WriteTx): https://github.com/vocdoni/arbo/commit/8b2be1eb82849c438994e4ef732f9b41a473d534#diff-050830ac4334170e8d335e1b95519052a3461c5b57a4ca38a0531e35a8f3d388R307