### PR TITLE
Feature/processrollingapi

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
+	"go.vocdoni.io/dvote/crypto/zk/artifacts"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/vochain/scrutinizer/indexertypes"
 	"go.vocdoni.io/proto/build/go/models"
@@ -187,6 +188,7 @@ type MetaResponse struct {
 	CensusKeys           [][]byte                         `json:"censusKeys,omitempty"`
 	CensusValues         []types.HexBytes                 `json:"censusValues,omitempty"`
 	CensusDump           []byte                           `json:"censusDump,omitempty"`
+	CircuitConfig        *artifacts.CircuitConfig         `json:"circuitConfig,omitempty"`
 	Content              []byte                           `json:"content,omitempty"`
 	CreationTime         int64                            `json:"creationTime,omitempty"`
 	EncryptionPrivKeys   []Key                            `json:"encryptionPrivKeys,omitempty"`

--- a/client/api.go
+++ b/client/api.go
@@ -10,6 +10,7 @@ import (
 
 	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/zk/artifacts"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -147,6 +148,20 @@ func (c *Client) GetKeys(pid, eid []byte) (*pkeys, error) {
 		pub:  resp.EncryptionPublicKeys,
 		priv: resp.EncryptionPrivKeys,
 	}, nil
+}
+
+func (c *Client) GetCircuitConfig(pid, eid []byte) (*artifacts.CircuitConfig, error) {
+	var req api.MetaRequest
+	req.Method = "getCircuitConfig"
+	req.ProcessID = pid
+	resp, err := c.Request(req, nil)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Ok {
+		return nil, fmt.Errorf("cannot get circuitConfig for process %s: (%s)", pid, resp.Message)
+	}
+	return resp.CircuitConfig, nil
 }
 
 func (c *Client) TestResults(pid []byte, totalVotes int) ([][]string, error) {

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.18.1
-	go.vocdoni.io/proto v1.13.3-0.20211019215004-0ca7d4436553
+	go.vocdoni.io/proto v1.13.3-0.20211026121805-ac3d037a6139
 	golang.org/x/crypto v0.0.0-20210920023735-84f357641f63
 	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -2239,6 +2239,8 @@ go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJ
 go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
 go.vocdoni.io/proto v1.13.3-0.20211019215004-0ca7d4436553 h1:0aQHf6mdFEhP8x5ArPtwPwW9AiEXEZSK45GoHzlNrro=
 go.vocdoni.io/proto v1.13.3-0.20211019215004-0ca7d4436553/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
+go.vocdoni.io/proto v1.13.3-0.20211026121805-ac3d037a6139 h1:gUSpa7+K71nR1c0DF25HWYtn+3fcMEB0M0zzqpRBpyo=
+go.vocdoni.io/proto v1.13.3-0.20211026121805-ac3d037a6139/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20200411211856-f5505b9728dd h1:BNJlw5kRTzdmyfh5U8F93HA2OwkP7ZGwA51eJ/0wKOU=
 go4.org v0.0.0-20200411211856-f5505b9728dd/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=

--- a/router/apis.go
+++ b/router/apis.go
@@ -53,6 +53,7 @@ func (r *Router) EnableVoteAPI(vocapp *vochain.BaseApplication, vocInfo *vochain
 	r.RegisterPublic("getEnvelopeHeight", r.getEnvelopeHeight)
 	r.RegisterPublic("getBlockHeight", r.getBlockHeight)
 	r.RegisterPublic("getProcessKeys", r.getProcessKeys)
+	r.RegisterPublic("getProcessCircuitConfig", r.getProcessCircuitConfig)
 	r.RegisterPublic("getBlockStatus", r.getBlockStatus)
 	r.RegisterPublic("getOracleResults", r.getOracleResults)
 }

--- a/test/rollingcensus_test.go
+++ b/test/rollingcensus_test.go
@@ -33,7 +33,7 @@ func TestRollingCensus(t *testing.T) {
 	app.State.SetHeight(1)
 
 	censusURI := "ipfs://foobar"
-	maxRollingCensusSize := uint64(numKeys)
+	maxCensusSize := uint64(numKeys)
 	p := &models.Process{
 		EntityId:   rng.RandomBytes(32),
 		CensusURI:  &censusURI,
@@ -45,7 +45,7 @@ func TestRollingCensus(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{
 			Anonymous: true,
 		},
-		MaxRollingCensusSize: &maxRollingCensusSize,
+		MaxCensusSize: &maxCensusSize,
 	}
 	qt.Assert(t, app.State.AddProcess(p), qt.IsNil)
 

--- a/test/rollingcensus_test.go
+++ b/test/rollingcensus_test.go
@@ -25,6 +25,7 @@ func TestRollingCensus(t *testing.T) {
 
 	_ = censusdownloader.NewCensusDownloader(app, &cm, false)
 
+	const numKeys = 128
 	pid := rng.RandomBytes(32)
 
 	// Block 1
@@ -32,6 +33,7 @@ func TestRollingCensus(t *testing.T) {
 	app.State.SetHeight(1)
 
 	censusURI := "ipfs://foobar"
+	maxRollingCensusSize := uint64(numKeys)
 	p := &models.Process{
 		EntityId:   rng.RandomBytes(32),
 		CensusURI:  &censusURI,
@@ -43,6 +45,7 @@ func TestRollingCensus(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{
 			Anonymous: true,
 		},
+		MaxRollingCensusSize: &maxRollingCensusSize,
 	}
 	qt.Assert(t, app.State.AddProcess(p), qt.IsNil)
 
@@ -53,7 +56,6 @@ func TestRollingCensus(t *testing.T) {
 	app.State.Rollback()
 	app.State.SetHeight(2)
 
-	const numKeys = 128
 	keys := make([][]byte, numKeys)
 	for i := 0; i < numKeys; i++ {
 		keys[i] = rng.RandomInZKField()

--- a/vochain/census.go
+++ b/vochain/census.go
@@ -44,8 +44,8 @@ func (v *State) AddToRollingCensus(pid []byte, key []byte, weight *big.Int) erro
 	if err != nil {
 		return fmt.Errorf("cannot get ceneusLen: %w", err)
 	}
-	if censusLen >= *process.MaxRollingCensusSize {
-		return fmt.Errorf("maxRollingCensusSize already reached")
+	if censusLen >= *process.MaxCensusSize {
+		return fmt.Errorf("maxCensusSize already reached")
 	}
 	// Add key to census
 	index := [8]byte{}
@@ -181,13 +181,13 @@ func (v *State) RegisterKeyTxCheck(vtx *models.Tx, txBytes, signature []byte, st
 	if len(tx.NewKey) != 32 {
 		return fmt.Errorf("newKey wrong size")
 	}
-	// Verify that we are not over maxRollingCensusSize
+	// Verify that we are not over maxCensusSize
 	censusSize, err := v.GetRollingCensusSize(tx.ProcessId, false)
 	if err != nil {
 		return err
 	}
-	if censusSize >= *process.MaxRollingCensusSize {
-		return fmt.Errorf("maxRollingCensusSize already reached")
+	if censusSize >= *process.MaxCensusSize {
+		return fmt.Errorf("maxCensusSize already reached")
 	}
 
 	pubKey, err := ethereum.PubKeyFromSignature(txBytes, signature)

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -409,14 +409,14 @@ func (app *BaseApplication) NewProcessTxCheck(vtx *models.Tx, txBytes,
 			"with anonymous envelope type and viceversa")
 	}
 	if tx.Process.Mode.PreRegister &&
-		(tx.Process.MaxRollingCensusSize == nil || *tx.Process.MaxRollingCensusSize <= 0) {
+		(tx.Process.MaxCensusSize == nil || *tx.Process.MaxCensusSize <= 0) {
 		return nil, fmt.Errorf("pre-register mode requires setting " +
-			"maxRollingCensusSize to be > 0")
+			"maxCensusSize to be > 0")
 	}
 	if tx.Process.Mode.PreRegister && tx.Process.EnvelopeType.Anonymous {
 		circuits := Genesis[app.chainId].CircuitsConfig
-		if *tx.Process.MaxRollingCensusSize > uint64(circuits[len(circuits)-1].Parameters[0]) {
-			return nil, fmt.Errorf("maxRollingCensusSize for anonymous envelope "+
+		if *tx.Process.MaxCensusSize > uint64(circuits[len(circuits)-1].Parameters[0]) {
+			return nil, fmt.Errorf("maxCensusSize for anonymous envelope "+
 				"cannot be bigger than the parameter for the biggest circuit (%v)",
 				circuits[len(circuits)-1].Parameters[0])
 		}

--- a/vochain/scrutinizer/indexertypes/types.go
+++ b/vochain/scrutinizer/indexertypes/types.go
@@ -55,6 +55,8 @@ type Process struct {
 	FinalResults      bool                       `json:"finalResults"`
 	SourceBlockHeight uint64                     `json:"sourceBlockHeight"`
 	SourceNetworkId   string                     `badgerholdIndex:"SourceNetworkId" json:"sourceNetworkId"`
+	MaxCensusSize     uint64                     `json:"maxCensusSize"`
+	RollingCensusSize uint64                     `json:"rollingCensusSize"`
 }
 
 func (p Process) String() string {

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -353,6 +353,8 @@ func (s *Scrutinizer) newEmptyProcess(pid []byte) error {
 		SourceNetworkId:   p.SourceNetworkId.String(),
 		Metadata:          p.GetMetadata(),
 		EntityIndex:       entity.ProcessCount,
+		MaxCensusSize:     p.GetMaxCensusSize(),
+		RollingCensusSize: p.GetRollingCensusSize(),
 	}
 	log.Debugf("new indexer process %s", proc.String())
 	return s.queryWithRetries(func() error { return s.db.Insert(pid, proc) })
@@ -377,6 +379,7 @@ func (s *Scrutinizer) updateProcess(pid []byte) error {
 		update.PrivateKeys = p.EncryptionPrivateKeys
 		update.PublicKeys = p.EncryptionPublicKeys
 		update.Metadata = p.GetMetadata()
+		update.RollingCensusSize = p.GetRollingCensusSize()
 		// If the process is transacting to CANCELED, ensure results are not computed and remove
 		// them from the KV database.
 		if update.Status != int32(models.ProcessStatus_CANCELED) &&

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -563,7 +563,14 @@ func (s *Scrutinizer) OnProcessResults(pid []byte, results *models.ProcessResult
 }
 
 // NOT USED but required for implementing the vochain.EventListener interface
-func (s *Scrutinizer) OnProcessesStart(pids [][]byte) {}
+func (s *Scrutinizer) OnProcessesStart(pids [][]byte) {
+	// Update existing processes
+	for _, p := range pids {
+		if err := s.updateProcess(p); err != nil {
+			log.Errorf("OnProcessesStart: cannot update process %x: %v", p, err)
+		}
+	}
+}
 
 // GetFriendlyResults translates votes into a matrix of strings
 func GetFriendlyResults(votes [][]*types.BigInt) [][]string {

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -193,6 +193,7 @@ func TestOnProcessStart(t *testing.T) {
 	startBlock := uint32(4)
 	doBlock(1, func() {
 		censusURI := "ipfs://foobar"
+		maxRollingCensusSize := uint64(16)
 		p := &models.Process{
 			EntityId:   rng.RandomBytes(32),
 			CensusURI:  &censusURI,
@@ -204,6 +205,7 @@ func TestOnProcessStart(t *testing.T) {
 			EnvelopeType: &models.EnvelopeType{
 				Anonymous: true,
 			},
+			MaxRollingCensusSize: &maxRollingCensusSize,
 		}
 		qt.Assert(t, s.AddProcess(p), qt.IsNil)
 	})

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -193,7 +193,7 @@ func TestOnProcessStart(t *testing.T) {
 	startBlock := uint32(4)
 	doBlock(1, func() {
 		censusURI := "ipfs://foobar"
-		maxRollingCensusSize := uint64(16)
+		maxCensusSize := uint64(16)
 		p := &models.Process{
 			EntityId:   rng.RandomBytes(32),
 			CensusURI:  &censusURI,
@@ -205,7 +205,7 @@ func TestOnProcessStart(t *testing.T) {
 			EnvelopeType: &models.EnvelopeType{
 				Anonymous: true,
 			},
-			MaxRollingCensusSize: &maxRollingCensusSize,
+			MaxCensusSize: &maxCensusSize,
 		}
 		qt.Assert(t, s.AddProcess(p), qt.IsNil)
 	})

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -75,7 +75,7 @@ func (app *BaseApplication) AddTx(vtx *models.Tx, txBytes, signature []byte,
 		}
 
 	case *models.Tx_NewProcess:
-		if p, err := NewProcessTxCheck(vtx, txBytes, signature, app.State); err == nil {
+		if p, err := app.NewProcessTxCheck(vtx, txBytes, signature, app.State); err == nil {
 			if commit {
 				tx := vtx.GetNewProcess()
 				if tx.Process == nil {
@@ -115,7 +115,7 @@ func (app *BaseApplication) AddTx(vtx *models.Tx, txBytes, signature []byte,
 		}
 
 	case *models.Tx_RegisterKey:
-		if err := RegisterKeyTxCheck(vtx, txBytes, signature, app.State); err != nil {
+		if err := app.State.RegisterKeyTxCheck(vtx, txBytes, signature, app.State); err != nil {
 			return []byte{}, fmt.Errorf("registerKeyTx %w", err)
 		}
 		if commit {


### PR DESCRIPTION
See commit messages
```
Add MaxRollingCensusSize and RollingCensusSize to Scrutinizer

Add getCircuitConfig vote-api endpoint

    - Verify validity of models.Process.MaxRollingCensusSize value when
      adding a process
    - For each RegisterKey for a Rolling census, verify that we never
      superpass the process.MaxRollingCensusSize
    - When a process with rolling census starts, set the value of the census
      to process.RollingCensusSize
    - Add getCircuitConfig endpoint in vote-api which dynamically figures
      out the proper CircuitConfig to be used given the
      process.RollingCensusSize

State: Move OnProcessStart events to Save

    This removes the requirement for the event listeners to handle a
    possible Rollback of an OnProcessStart.

```

Depends on https://github.com/vocdoni/dvote-protobuf/pull/31
Resolve https://github.com/vocdoni/vocdoni-node/issues/327