### PR TITLE
add a new http router

### DIFF
--- a/httprouter/bearerstdapi/bearerstdapi.go
+++ b/httprouter/bearerstdapi/bearerstdapi.go
@@ -1,0 +1,93 @@
+package bearerstdapi
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"go.vocdoni.io/dvote/log"
+)
+
+const bearerPrefix = "Bearer "
+
+// BearerStandardAPI is a namespace handler for the httpRouter with Bearer authorization
+type BearerStandardAPI struct {
+	authTokens     sync.Map
+	adminToken     string
+	adminTokenLock sync.RWMutex
+}
+
+// BearerStandardAPIdata is the data type used by the BearerStandardAPI.
+// On handler functions Message.Data can be cast safely to this type.
+type BearerStandardAPIdata struct {
+	Data      []byte
+	AuthToken string
+}
+
+// NewBearerStandardAPI returns a BearerStandardAPI initialized type
+func NewBearerStandardAPI() *BearerStandardAPI {
+	return &BearerStandardAPI{}
+}
+
+// AuthorizeRequest is a function for the RouterNamespace interface.
+// On private handlers checks if the supplied bearer token have still request credits
+func (b *BearerStandardAPI) AuthorizeRequest(data interface{}, isAdmin bool) bool {
+
+	msg, ok := data.(*BearerStandardAPIdata)
+	if !ok {
+		log.Warnf("type is not bearerStandardApi")
+		return false
+	}
+	if isAdmin {
+		b.adminTokenLock.RLock()
+		defer b.adminTokenLock.RUnlock()
+		return msg.AuthToken == b.adminToken
+	}
+	remainingReqs, ok := b.authTokens.Load(msg.AuthToken)
+	if !ok || remainingReqs.(int64) < 1 {
+		return false
+	}
+	b.authTokens.Store(msg.AuthToken, remainingReqs.(int64)-1)
+	return true
+}
+
+// ProcessData is a function for the RouterNamespace interface.
+// The body of the http requests and the bearer auth token are readed.
+func (b *BearerStandardAPI) ProcessData(req *http.Request) (interface{}, error) {
+	respBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP connection closed: (%v)", err)
+	}
+	return &BearerStandardAPIdata{
+		Data:      respBody,
+		AuthToken: strings.TrimPrefix(req.Header.Get("Authorization"), bearerPrefix),
+	}, nil
+}
+
+// SetAdminToken sets the bearer admin token capable to execute admin handlers
+func (b *BearerStandardAPI) SetAdminToken(bearerToken string) {
+	b.adminTokenLock.Lock()
+	defer b.adminTokenLock.Unlock()
+	b.adminToken = bearerToken
+}
+
+// AddAuthToken adds a new bearer token capable to perform up to n requests
+func (b *BearerStandardAPI) AddAuthToken(bearerToken string, requests int64) {
+	b.authTokens.Store(bearerToken, requests)
+}
+
+// DelAuthToken removes a bearer token (will be not longer valid)
+func (b *BearerStandardAPI) DelAuthToken(bearerToken string) {
+	b.authTokens.Delete(bearerToken)
+}
+
+// GetAuthTokens returns the number of pending requests credits for a bearer token
+func (b *BearerStandardAPI) GetAuthTokens(bearerToken string) int64 {
+	ts, ok := b.authTokens.Load(bearerToken)
+	if !ok {
+		return 0
+	}
+	return ts.(int64)
+}

--- a/httprouter/bearerstdapi/bearerstdapi_test.go
+++ b/httprouter/bearerstdapi/bearerstdapi_test.go
@@ -1,0 +1,86 @@
+package bearerstdapi
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/httprouter"
+	"go.vocdoni.io/dvote/test/testcommon/testutil"
+)
+
+func TestRouterWithBearerStdAPI(t *testing.T) {
+	r := httprouter.HTTProuter{}
+	rng := testutil.NewRandom(124)
+	port := 23000 + rng.RandomIntn(1024)
+	url := fmt.Sprintf("http://127.0.0.1:%d", port)
+	err := r.Init("127.0.0.1", port)
+	qt.Check(t, err, qt.IsNil)
+
+	// Create a standard API handler
+	stdAPI := NewBearerStandardAPI()
+
+	// Add it under namespace "std"
+	r.AddNamespace("std", stdAPI)
+
+	// Add a public handler to serve requests on std namespace
+	r.AddPublicHandler("std", "/hello/*", "POST", func(msg httprouter.Message) {
+		t.Logf("Path: %v Received: %s\n", msg.Path, msg.Data.(*BearerStandardAPIdata).Data)
+		msg.Context.Send([]byte("hello public!"))
+	})
+
+	// Add an admin handler to serve requests on std namespace
+	r.AddAdminHandler("std", "/admin/*", "POST", func(msg httprouter.Message) {
+		t.Logf("Path: %v Received: %s\n", msg.Path, msg.Data.(*BearerStandardAPIdata).Data)
+		msg.Context.Send([]byte("hello admin!"))
+	})
+
+	// Add a private handler
+	r.AddPrivateHandler("std", "/private/*", "POST", func(msg httprouter.Message) {
+		t.Logf("Received: %s", msg.Data.(*BearerStandardAPIdata).Data)
+		msg.Context.Send([]byte("hello private!"))
+	})
+
+	// Set the bearer admin token
+	stdAPI.SetAdminToken("abcd")
+
+	// Create a token with access to 4 requests
+	stdAPI.AddAuthToken("1234", 2)
+
+	// Test public
+	resp := doRequest(t, url+"/hello/1234", "", "POST", []byte("hello"))
+	qt.Check(t, resp, qt.DeepEquals, []byte("hello public!\n"))
+
+	// Test private
+	resp = doRequest(t, url+"/private/ping", "1234", "POST", []byte("hello"))
+	qt.Check(t, resp, qt.DeepEquals, []byte("hello private!\n"))
+	resp = doRequest(t, url+"/private/ping", "1234", "POST", []byte("hello"))
+	qt.Check(t, resp, qt.DeepEquals, []byte("hello private!\n"))
+
+	// Token should be unauthorized now
+	resp = doRequest(t, url+"/private/ping", "1234", "POST", []byte("hello"))
+	qt.Check(t, resp, qt.DeepEquals, []byte("Not Authorized\n"))
+
+	// Test admin
+	resp = doRequest(t, url+"/admin/do", "abcd", "POST", []byte("hello"))
+	qt.Check(t, resp, qt.DeepEquals, []byte("hello admin!\n"))
+	resp = doRequest(t, url+"/admin/do", "abcde", "POST", []byte("hello"))
+	qt.Check(t, resp, qt.DeepEquals, []byte("Not Authorized\n"))
+
+}
+
+func doRequest(t *testing.T, url, authToken, method string, body []byte) []byte {
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	qt.Check(t, err, qt.IsNil)
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	qt.Check(t, err, qt.IsNil)
+	respBody, err := io.ReadAll(resp.Body)
+	qt.Check(t, err, qt.IsNil)
+	return respBody
+}

--- a/httprouter/httprouter.go
+++ b/httprouter/httprouter.go
@@ -1,0 +1,260 @@
+package httprouter
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/cors"
+	reuse "github.com/libp2p/go-reuseport"
+	"go.uber.org/zap"
+	"go.vocdoni.io/dvote/log"
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
+	"golang.org/x/net/http2"
+)
+
+const (
+	desiredSoMaxConn = 4096
+)
+
+// HTTProuter is a thread-safe multiplexer http(s) router using go-chi and autocert with a set of
+// preconfigured options. The router abstracts the HTTP layer and uses a custom Message type that
+// allows create handlers in a comfortable manner.
+// Allows multiple diferent kind of data processors by using the RouterNamespace interface. Each processor
+// is identified by a unique namespace string which must be specified when adding handlers.
+// Handlers can be Public, Private and Administrator. The proper checks must be implemented by the
+// RouterNamespace implementation.
+type HTTProuter struct {
+	Mux            *chi.Mux
+	TLSconfig      *tls.Config
+	TLSdomain      string
+	TLSdirCert     string
+	address        net.Addr
+	namespaces     map[string]RouterNamespace
+	namespacesLock sync.RWMutex
+}
+
+// RouterNamespace is the interface that a HTTProuter handler should follow in order
+// to become a valid namespace.
+type RouterNamespace interface {
+	AuthorizeRequest(data interface{}, isAdmin bool) (valid bool)
+	ProcessData(req *http.Request) (data interface{}, err error)
+}
+
+// RouterHandlerFn is the function signature for adding handlers to the HTTProuter.
+type RouterHandlerFn = func(msg Message)
+
+// Init initializes the router
+func (r *HTTProuter) Init(host string, port int) error {
+	r.namespaces = make(map[string]RouterNamespace, 32)
+	ln, err := reuse.Listen("tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	if err != nil {
+		return err
+	}
+
+	if n := somaxconn(); n < desiredSoMaxConn {
+		log.Warnf("operating system SOMAXCONN is smaller than recommended (%d). "+
+			"Consider increasing it: echo %d | sudo tee /proc/sys/net/core/somaxconn", n, desiredSoMaxConn)
+	}
+
+	r.Mux = chi.NewRouter()
+	r.Mux.Use(middleware.RealIP)
+	// If we want rich logging (e.g. with fields), we could implement our
+	// own version of DefaultLogFormatter.
+	r.Mux.Use(middleware.RequestLogger(&middleware.DefaultLogFormatter{
+		Logger:  stdLogger{log.Logger()},
+		NoColor: true,
+	}))
+	r.Mux.Use(middleware.Recoverer)
+	r.Mux.Use(middleware.Heartbeat("/ping"))
+	r.Mux.Use(middleware.ThrottleBacklog(5000, 40000, 30*time.Second))
+	r.Mux.Use(middleware.Timeout(30 * time.Second))
+	cors := cors.New(cors.Options{
+		AllowOriginFunc: func(r *http.Request, origin string) bool {
+			return true
+		}, // Kind of equivalent to AllowedOrigin: []string{"*"} but it returns the origin as allowed origin.
+		AllowedMethods:   []string{"GET", "POST", "PUT", "OPTIONS"},
+		AllowedHeaders:   []string{"Content-Type"},
+		AllowCredentials: true,
+		MaxAge:           300, // Maximum value not ignored by any of major browsers
+	})
+	r.Mux.Use(cors.Handler)
+
+	if len(r.TLSdomain) > 0 {
+		log.Infof("fetching letsencrypt TLS certificate for %s", r.TLSdomain)
+		s, m := r.generateTLScert(host, port)
+		s.ReadTimeout = 20 * time.Second
+		s.WriteTimeout = 15 * time.Second
+		s.IdleTimeout = 10 * time.Second
+		s.ReadHeaderTimeout = 5 * time.Second
+		s.Handler = r.Mux
+		if err := http2.ConfigureServer(s, nil); err != nil {
+			return err
+		}
+		go func() {
+			log.Info("starting go-chi https server")
+			log.Fatal(s.ServeTLS(ln, "", ""))
+		}()
+		certs, err := r.getCertificates(m)
+		if len(certs) == 0 || err != nil {
+			log.Warnf(`letsencrypt TLS certificate cannot be obtained. Maybe port 443 is not accessible or domain name is wrong.
+							You might want to redirect port 443 with iptables using the following command:
+							sudo iptables -t nat -I PREROUTING -p tcp --dport 443 -j REDIRECT --to-ports %d`, port)
+			return fmt.Errorf("cannot get letsencrypt TLS certificate: (%s)", err)
+		}
+		log.Infof("router ready at https://%s", ln.Addr())
+
+	} else {
+		log.Info("starting go-chi http server")
+		s := &http.Server{
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      10 * time.Second,
+			IdleTimeout:       10 * time.Second,
+			ReadHeaderTimeout: 3 * time.Second,
+			Handler:           r.Mux,
+		}
+		if err := http2.ConfigureServer(s, nil); err != nil {
+			return err
+		}
+		go func() {
+			log.Fatal(s.Serve(ln))
+		}()
+		log.Infof("router ready at http://%s", ln.Addr())
+	}
+	r.address = ln.Addr()
+	return nil
+
+}
+
+// AddNamespace creates a new namespace handled by the RouterNamespace implementation.
+func (r *HTTProuter) AddNamespace(id string, rns RouterNamespace) {
+	log.Infof("added namespace %s", id)
+	r.namespacesLock.Lock()
+	defer r.namespacesLock.Unlock()
+	r.namespaces[id] = rns
+}
+
+func (r *HTTProuter) getNamespace(id string) (RouterNamespace, bool) {
+	r.namespacesLock.RLock()
+	defer r.namespacesLock.RUnlock()
+	rns, ok := r.namespaces[id]
+	return rns, ok
+}
+
+// AddAdminHandler adds a handler function for the namespace, pattern and HTTPmethod.
+// The Admin requests are usually protected by some authorization mechanism.
+func (r *HTTProuter) AddAdminHandler(namespaceID, pattern, HTTPmethod string, handler RouterHandlerFn) {
+	log.Infof("added admin handler for namespace %s with pattern %s", namespaceID, pattern)
+	r.Mux.MethodFunc(HTTPmethod, pattern, r.routerHandler(namespaceID, false, true, handler))
+}
+
+// AddPrivateHandler adds a handler function for the namespace, pattern and HTTPmethod.
+// The Private requests are usually protected by some authorization mechanism, such as signature verification,
+// which must be handled by the namespace implementation.
+func (r *HTTProuter) AddPrivateHandler(namespaceID, pattern, HTTPmethod string, handler RouterHandlerFn) {
+	log.Infof("added private handler for namespace %s with pattern %s", namespaceID, pattern)
+	r.Mux.MethodFunc(HTTPmethod, pattern, r.routerHandler(namespaceID, true, false, handler))
+}
+
+// AddPublicHandler adds a handled function for the namespace, patter and HTTPmethod.
+// The public requests are not protected so all requests are allowed.
+func (r *HTTProuter) AddPublicHandler(namespaceID, pattern, HTTPmethod string, handler RouterHandlerFn) {
+	log.Infof("added public handler for namespace %s with pattern %s", namespaceID, pattern)
+	r.Mux.MethodFunc(HTTPmethod, pattern, r.routerHandler(namespaceID, false, false, handler))
+}
+
+func (r *HTTProuter) routerHandler(namespaceID string, private, admin bool,
+	handlerFunc RouterHandlerFn) func(w http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
+		defer req.Body.Close()
+
+		nsProcessor, ok := r.getNamespace(namespaceID)
+		if !ok {
+			log.Errorf("namespace %s is not defined", namespaceID)
+			return
+		}
+		data, err := nsProcessor.ProcessData(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if (private || admin) && !nsProcessor.AuthorizeRequest(data, admin) {
+			http.Error(w, "Not Authorized", http.StatusUnauthorized)
+			return
+		}
+		hc := &HTTPContext{Request: req, Writer: w, sent: make(chan struct{})}
+		msg := Message{
+			Data:      data,
+			TimeStamp: time.Now(),
+			Context:   hc,
+			Path:      strings.Split(req.URL.Path, "/")[1:],
+		}
+		go handlerFunc(msg)
+
+		// The contract is that every handled request must send a
+		// response, even when they fail or time out.
+		<-hc.sent
+	}
+}
+
+// generateTLScert generates a TLS certificated
+func (r *HTTProuter) generateTLScert(host string, port int) (*http.Server, *autocert.Manager) {
+	m := autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(r.TLSdomain),
+		Cache:      autocert.DirCache(r.TLSdirCert),
+	}
+	if r.TLSconfig == nil {
+		r.TLSconfig = &tls.Config{}
+	}
+	r.TLSconfig.GetCertificate = m.GetCertificate
+	serverConfig := &http.Server{
+		Addr:      net.JoinHostPort(host, fmt.Sprintf("%d", port)),
+		TLSConfig: r.TLSconfig,
+	}
+	serverConfig.TLSConfig.NextProtos = append(serverConfig.TLSConfig.NextProtos, acme.ALPNProto)
+
+	return serverConfig, &m
+}
+
+func (r *HTTProuter) getCertificates(m *autocert.Manager) ([][]byte, error) {
+	hello := &tls.ClientHelloInfo{
+		ServerName:   r.TLSdomain,
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
+	}
+	hello.CipherSuites = append(hello.CipherSuites, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305)
+
+	cert, err := m.GetCertificate(hello)
+	if err != nil {
+		return nil, err
+	}
+	return cert.Certificate, nil
+}
+
+func somaxconn() int {
+	content, err := os.ReadFile("/proc/sys/net/core/somaxconn")
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	n, err := strconv.Atoi(strings.Trim(string(content), "\n"))
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	return n
+}
+
+type stdLogger struct {
+	log *zap.SugaredLogger
+}
+
+func (l stdLogger) Print(v ...interface{}) { l.log.Debug(v...) }

--- a/httprouter/jsonrpcapi/encoding.go
+++ b/httprouter/jsonrpcapi/encoding.go
@@ -1,0 +1,42 @@
+package jsonrpcapi
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// HexBytes is a []byte which encodes as hexadecimal in json, as opposed to the
+// base64 default.
+type HexBytes []byte
+
+func (b HexBytes) MarshalJSON() ([]byte, error) {
+	enc := make([]byte, hex.EncodedLen(len(b))+2)
+	enc[0] = '"'
+	hex.Encode(enc[1:], b)
+	enc[len(enc)-1] = '"'
+	return enc, nil
+}
+
+func (b *HexBytes) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+		return fmt.Errorf("invalid JSON string: %q", data)
+	}
+	data = data[1 : len(data)-1]
+
+	// Strip a leading "0x" prefix, for backwards compatibility.
+	if len(data) >= 2 && data[0] == '0' && (data[1] == 'x' || data[1] == 'X') {
+		data = data[2:]
+	}
+
+	decLen := hex.DecodedLen(len(data))
+	if cap(*b) < decLen {
+		*b = make([]byte, decLen)
+	}
+	if _, err := hex.Decode(*b, data); err != nil {
+		return err
+	}
+	return nil
+}

--- a/httprouter/jsonrpcapi/jsonrpcapi.go
+++ b/httprouter/jsonrpcapi/jsonrpcapi.go
@@ -1,0 +1,186 @@
+package jsonrpcapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/httprouter"
+	"go.vocdoni.io/dvote/log"
+)
+
+// SignedJRPC is a httprouter handler to easily build a JSON rpc endpoint.
+//
+// The basic JSON structure for the RPC is predefined and follows the format:
+//
+// {
+//   "request": {
+//     "id":"randomID",
+//     "method":"methodName",
+//     "timestamp":"currentTS",
+//     <customFields...>
+//     },
+//   "signature":"0x...",
+//   "id":"sameID"}
+// }
+//
+// The handler manages automatically signatures, ids and timestamps.
+// The developer using SignedJRPC only needs to take care of the information within the request field (method and customFields).
+// The handler is prepared to accept several methods within the same URL path, such as http://localhost/jsonapi, so there
+// is no need to declare multiple URL paths (but its also allowed).
+type SignedJRPC struct {
+	signer    *ethereum.SignKeys
+	reqType   func() MessageAPI
+	methods   map[string]*registeredMethod
+	adminAddr *ethcommon.Address
+}
+
+// SignedJRPCdata is the data type used by SignedJRPC
+type SignedJRPCdata struct {
+	Method             string
+	Address            ethcommon.Address
+	SignaturePublicKey []byte
+	Private            bool
+	Message            MessageAPI
+}
+
+type registeredMethod struct {
+	public        bool
+	skipSignature bool
+}
+
+// NewSignedJRPC returns an initialized instance of the SignedJRPC type.
+// A signer is required in order to create signatures and authenticate clients.
+// A function returning an empty type implementing the custom MessageAPI should also be provided.
+func NewSignedJRPC(signer *ethereum.SignKeys, reqType func() MessageAPI) *SignedJRPC {
+	return &SignedJRPC{
+		methods: make(map[string]*registeredMethod, 128),
+		signer:  signer,
+		reqType: reqType,
+	}
+}
+
+// AuthorizeRequest implements the httprouter interface
+func (s *SignedJRPC) AuthorizeRequest(data interface{}, isAdmin bool) bool {
+	request, ok := data.(*SignedJRPCdata)
+	if !ok {
+		log.Warnf("type is not SignedJRPCdata")
+		return false
+	}
+	// If admin method, compare with the admin address
+	if isAdmin {
+		if s.adminAddr == nil {
+			log.Warnf("admin address not defined")
+			return false
+		}
+		return *s.adminAddr == request.Address
+	}
+	// If private method, check authentication
+	if request.Private {
+		return s.signer.Authorized[request.Address]
+	}
+	// If the method is registered as public, return true
+	return true
+}
+
+// ProcessData implements the httprouter interface
+func (s *SignedJRPC) ProcessData(req *http.Request) (interface{}, error) {
+	reqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP connection closed: (%v)", err)
+	}
+	return s.getRequest(reqBody)
+}
+
+// SendError builds a response message error and sends it using the provided http context.
+func (s *SignedJRPC) SendError(requestID string, errorMsg string, ctxt *httprouter.HTTPContext) error {
+	if ctxt == nil {
+		return fmt.Errorf("http context is nil")
+	}
+	msg := s.reqType()
+	msg.SetError(errorMsg)
+	data, err := BuildReply(s.signer, msg, requestID)
+	if err != nil {
+		return err
+	}
+	return ctxt.Send(data)
+}
+
+// AddAuthorizedAddress adds a new address to the list of authorized clients to perform private requests
+func (s *SignedJRPC) AddAuthorizedAddress(addr ethcommon.Address) {
+	s.signer.AddAuthKey(addr)
+}
+
+// SetAdminAddress sets the administrator address for admin private methods
+func (s *SignedJRPC) SetAdminAddress(addr ethcommon.Address) {
+	s.adminAddr = &addr
+}
+
+// RegisterMethod adds a new method to the SignedJRPC endpoint.
+// If private the method won't try to authenticate the user.
+// If skipSignature the method will not add or check any signature.
+func (s *SignedJRPC) RegisterMethod(method string, private, skipSignature bool) error {
+	if _, ok := s.methods[method]; ok {
+		return fmt.Errorf("duplicate method %s", method)
+	}
+	s.methods[method] = &registeredMethod{public: !private, skipSignature: skipSignature}
+	return nil
+}
+
+func (s *SignedJRPC) getRequest(payload []byte) (*SignedJRPCdata, error) {
+	// First unmarshal the outer layer, to obtain the request ID, the signed
+	// request, and the signature.
+	log.Debugf("got request: %s", payload)
+	if len(payload) < 22 { // 22 = min num characters json_tags+method+request
+		return nil, fmt.Errorf("empty payload")
+	}
+	reqOuter := &RequestMessage{}
+	if err := json.Unmarshal(payload, &reqOuter); err != nil {
+		return nil, err
+	}
+
+	request := new(SignedJRPCdata)
+	// Second unmarshal the request message to obtain the method
+	request.Message = s.reqType()
+	if err := json.Unmarshal(reqOuter.MessageAPI, request.Message); err != nil {
+		return request, err
+	}
+	request.Method = request.Message.GetMethod()
+	if request.Method == "" {
+		return request, fmt.Errorf("method is empty")
+	}
+
+	// The method must be registered
+	method, ok := s.methods[request.Method]
+	if !ok {
+		return request, fmt.Errorf("method not valid: (%s)", request.Method)
+	}
+
+	// Extract signature and address
+	if !method.skipSignature {
+		if len(reqOuter.Signature) != ethereum.SignatureLength {
+			return request, fmt.Errorf("no signature provided or invalid length")
+		}
+		var sigBytes []byte
+		if err := reqOuter.Signature.UnmarshalJSON(sigBytes); err != nil {
+			return request, fmt.Errorf("cannot unmarshal signature: %w {%s}", err, reqOuter.Signature)
+		}
+		var err error
+		if request.SignaturePublicKey, err = ethereum.PubKeyFromSignature(reqOuter.MessageAPI, reqOuter.Signature); err != nil {
+			return request, err
+		}
+
+		if len(request.SignaturePublicKey) != ethereum.PubKeyLengthBytes {
+			return request, fmt.Errorf("could not extract public key from signature")
+		}
+		if request.Address, err = ethereum.AddrFromPublicKey(request.SignaturePublicKey); err != nil {
+			return request, err
+		}
+		log.Debugf("recovered signer address: %s", request.Address.Hex())
+		request.Private = !method.public
+	}
+	return request, nil
+}

--- a/httprouter/jsonrpcapi/jsonrpcapi_test.go
+++ b/httprouter/jsonrpcapi/jsonrpcapi_test.go
@@ -1,0 +1,148 @@
+package jsonrpcapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/httprouter"
+	"go.vocdoni.io/dvote/test/testcommon/testutil"
+)
+
+func TestJSONRPCAPI(t *testing.T) {
+	r := httprouter.HTTProuter{}
+	rng := testutil.NewRandom(123)
+	port := 23000 + rng.RandomIntn(1024)
+	url := fmt.Sprintf("http://127.0.0.1:%d", port)
+	err := r.Init("127.0.0.1", port)
+	qt.Check(t, err, qt.IsNil)
+
+	// Create a standard API handler
+	signer := ethereum.NewSignKeys()
+	signer.Generate()
+	rpcAPI := NewSignedJRPC(signer, NewAPI)
+
+	// Add it under namespace "rpc"
+	r.AddNamespace("rpc", rpcAPI)
+
+	rpcAPI.RegisterMethod("add", false, false)
+	qt.Check(t, err, qt.IsNil)
+	rpcAPI.RegisterMethod("del", true, false)
+	qt.Check(t, err, qt.IsNil)
+
+	// Add a private handler to serve requests on rpc namespace
+	r.AddPrivateHandler("rpc", "/names", "POST", func(msg httprouter.Message) {
+		req := msg.Data.(*SignedJRPCdata)
+		apiMsg := req.Message.(*API)
+		resp := API{}
+		switch req.Method {
+		case "add":
+			if apiMsg.Name == "" || apiMsg.Age == 0 {
+				rpcAPI.SendError(req.Message.GetID(), "name or age missing", msg.Context)
+				break
+			}
+			resp.Ok = true
+			data, err := BuildReply(signer, &resp, req.Message.GetID())
+			qt.Check(t, err, qt.IsNil)
+			err = msg.Context.Send(data)
+			qt.Check(t, err, qt.IsNil)
+		case "del":
+			if apiMsg.Name == "" {
+				rpcAPI.SendError(req.Message.GetID(), "name missing", msg.Context)
+				break
+			}
+			resp.Ok = true
+			data, err := BuildReply(signer, &resp, req.Message.GetID())
+			qt.Check(t, err, qt.IsNil)
+			msg.Context.Send(data)
+			qt.Check(t, err, qt.IsNil)
+		default:
+			t.Fatal("method invalid")
+		}
+	})
+
+	// Crete a client signer
+	clientSigner := ethereum.SignKeys{}
+	clientSigner.Generate()
+
+	// Test add method
+	resp := doRequest(t, url+"/names", "POST", &clientSigner, &API{Method: "add", ID: "abc", Age: 21, Name: "John"})
+	qt.Check(t, string(resp), qt.Contains, `"ok":true`)
+
+	// Test an error
+	resp = doRequest(t, url+"/names", "POST", &clientSigner, &API{Method: "add", ID: "abc", Name: "John"})
+	qt.Check(t, string(resp), qt.Contains, `age missing`)
+
+	// Test a delete (authorized), should fail
+	resp = doRequest(t, url+"/names", "POST", &clientSigner, &API{Method: "del", ID: "bcd", Name: "John"})
+	qt.Check(t, resp, qt.DeepEquals, []byte("Not Authorized\n"))
+
+	// Add the client address key and test again (should work)
+	rpcAPI.AddAuthorizedAddress(clientSigner.Address())
+	resp = doRequest(t, url+"/names", "POST", &clientSigner, &API{Method: "del", ID: "feg", Name: "John"})
+	qt.Check(t, string(resp), qt.Contains, `"ok":true`)
+}
+
+func NewAPI() MessageAPI {
+	return &API{}
+}
+
+type API struct {
+	Method    string `json:"method,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Age       int    `json:"age,omitempty"`
+	ID        string `json:"id"`
+	Ok        bool   `json:"ok,omitempty"`
+	Error     string `json:"error,omitempty"`
+	Timestamp int32  `json:"timestamp"`
+}
+
+func (a *API) GetMethod() string {
+	return a.Method
+}
+
+func (a *API) SetID(id string) {
+	a.ID = id
+}
+
+func (a *API) SetError(errorMsg string) {
+	a.Error = errorMsg
+}
+
+func (a *API) GetID() string {
+	return a.ID
+}
+
+func (a *API) SetTimestamp(ts int32) {
+	a.Timestamp = ts
+}
+
+func doRequest(t *testing.T, url, method string, signer *ethereum.SignKeys, msg *API) []byte {
+	data, err := json.Marshal(msg)
+	qt.Check(t, err, qt.IsNil)
+	signature := []byte{}
+	if signer != nil {
+		signature, err = signer.Sign(data)
+		qt.Check(t, err, qt.IsNil)
+	}
+	msgReq := RequestMessage{
+		ID:         "123",
+		Signature:  signature,
+		MessageAPI: data,
+	}
+	body, err := json.Marshal(msgReq)
+	qt.Check(t, err, qt.IsNil)
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	qt.Check(t, err, qt.IsNil)
+	resp, err := http.DefaultClient.Do(req)
+	qt.Check(t, err, qt.IsNil)
+	respBody, err := io.ReadAll(resp.Body)
+	qt.Check(t, err, qt.IsNil)
+	return respBody
+}

--- a/httprouter/jsonrpcapi/message.go
+++ b/httprouter/jsonrpcapi/message.go
@@ -1,0 +1,62 @@
+package jsonrpcapi
+
+import (
+	"encoding/json"
+	"time"
+
+	"go.vocdoni.io/dvote/crypto"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/log"
+)
+
+// MessageAPI inteface defines the methods that the SignedJRPC custom message type must contain.
+type MessageAPI interface {
+	GetID() string
+	SetID(string)
+	SetTimestamp(int32)
+	SetError(string)
+	GetMethod() string
+}
+
+// RequestMessage is the envelope for the SignedJRPC message request
+type RequestMessage struct {
+	MessageAPI json.RawMessage `json:"request"`
+
+	ID        string   `json:"id"`
+	Signature HexBytes `json:"signature"`
+}
+
+// ResponseMessage is the envelope for the SignedJRPC message response
+type ResponseMessage struct {
+	MessageAPI json.RawMessage `json:"response"`
+
+	ID        string   `json:"id"`
+	Signature HexBytes `json:"signature"`
+}
+
+// BuildReply builds a response message (ID, Timestamp and Signature) and marshals it using JSON.
+// The output message is ready to send as reply to the client using reqMsg.Context.Send(data)
+func BuildReply(signer *ethereum.SignKeys, msg MessageAPI, requestID string) ([]byte, error) {
+	var err error
+	respRequest := &ResponseMessage{ID: requestID}
+	msg.SetID(requestID)
+	msg.SetTimestamp(int32(time.Now().Unix()))
+	respRequest.MessageAPI, err = crypto.SortedMarshalJSON(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	respRequest.Signature, err = signer.Sign(respRequest.MessageAPI)
+	if err != nil {
+		log.Error(err)
+		// continue without the signature
+	}
+
+	// We don't need to use crypto.SortedMarshalJSON here, since we don't sign these bytes.
+	respData, err := json.Marshal(respRequest)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("response: %s", respData)
+	return respData, nil
+}

--- a/httprouter/message.go
+++ b/httprouter/message.go
@@ -1,0 +1,51 @@
+package httprouter
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.vocdoni.io/dvote/log"
+)
+
+// Message is a wrapper for messages for a RouterNamespace implementation.
+// Data is set by the namespace and can be of any type (implementation details
+// should be check). In order to send a reply, Context.Send() should be called.
+type Message struct {
+	Data      interface{}
+	TimeStamp time.Time
+	Path      []string
+	Context   *HTTPContext
+}
+
+// HTTPContext is the Context for an HTTP request.
+type HTTPContext struct {
+	Writer  http.ResponseWriter
+	Request *http.Request
+
+	sent chan struct{}
+}
+
+// Send replies the request with the provided message.
+func (h *HTTPContext) Send(msg []byte) error {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("recovered http send panic: %v", r)
+		}
+	}()
+	defer close(h.sent)
+	defer h.Request.Body.Close()
+
+	if h.Request.Context().Err() != nil {
+		// The connection was closed, so don't try to write to it.
+		return fmt.Errorf("connection is closed")
+	}
+	h.Writer.Header().Set("Content-Length", fmt.Sprintf("%d", len(msg)+1))
+	h.Writer.Header().Set("Content-Type", "application/json")
+	if _, err := h.Writer.Write(msg); err != nil {
+		return err
+	}
+	// Ensure we end the response with a newline, to be nice.
+	_, err := h.Writer.Write([]byte("\n"))
+	return err
+}

--- a/test/testcommon/testutil/util.go
+++ b/test/testcommon/testutil/util.go
@@ -53,6 +53,10 @@ func (r *Random) RandomBytes(n int) []byte {
 	return b
 }
 
+func (r *Random) RandomIntn(n int) int {
+	return r.rand.Intn(n)
+}
+
 // RandomInSnarkField returns a random litte-endian encoded element in the
 // ZK SNARK field.
 func (r *Random) RandomInZKField() []byte {


### PR DESCRIPTION
This is an http router which reuses some code of the multirpc but
following a simpler approach. Supports not only JSON-RPC handlers but
any which implements the RouterNamespace inteface. So it will allow
creating the new API based on URL requests.

The existing router and multirpc should be replaced with this one.

Signed-off-by: p4u <pau@dabax.net>