### PR TITLE
Deprecate dumpPlain census handler

### DIFF
--- a/benchmark/api_benchmark_test.go
+++ b/benchmark/api_benchmark_test.go
@@ -139,16 +139,6 @@ func censusBench(b *testing.B, cl *client.Client, size int) {
 		return
 	}
 
-	// dumpPlain
-	/*	log.Infof("[%d] dump claims", rint)
-		req.CensusKey = []byte{}
-		req.CensusKeys = [][]byte{}
-		resp = doRequest("dumpPlain", signer)
-		if len(resp.CensusKeys) != len(claims) {
-			b.Fatalf("missing claims on dumpPlain, %d != %d", len(req.CensusKeys), len(claims))
-		}
-	*/
-
 	// GenProof valid
 	log.Infof("Generating proofs")
 	var siblings [][]byte

--- a/census/handler.go
+++ b/census/handler.go
@@ -269,7 +269,10 @@ func (m *Manager) Handler(ctx context.Context, r *api.APIrequest,
 		resp.Size = &sizeInt64
 		return resp, nil
 
-	case "dump", "dumpPlain":
+	case "dumpPlain":
+		return nil, fmt.Errorf("dumpPlain is deprecated, dump should be used instead")
+
+	case "dump":
 		if !validAuthPrefix {
 			return resp, fmt.Errorf("invalid authentication")
 		}
@@ -283,30 +286,14 @@ func (m *Manager) Handler(ctx context.Context, r *api.APIrequest,
 		} else {
 			root = r.RootHash
 		}
-		if r.Method == "dump" {
-			snapshot, err := tr.FromRoot(root)
-			if err != nil {
-				return nil, err
-			}
-			resp.CensusDump, err = snapshot.Dump()
-			if err != nil {
-				return nil, err
-			}
+		snapshot, err := tr.FromRoot(root)
+		if err != nil {
+			return nil, err
 		}
-		// else {
-		// 	TODO the method DumpPlain no longer exists, clarify
-		// 	the difference of usage between 'dump' & 'dumpPlain'.
-
-		// 	var vals [][]byte
-		// 	resp.CensusKeys, vals, err = tr.DumpPlain(root)
-		// 	for _, v := range vals {
-		// 	        resp.CensusValues = append(resp.CensusValues, types.HexBytes(v))
-		// 	}
-		// }
-		// if err != nil {
-		// 	resp.SetError(err)
-		// 	return resp
-		// }
+		resp.CensusDump, err = snapshot.Dump()
+		if err != nil {
+			return nil, err
+		}
 		return resp, nil
 
 	case "publish":

--- a/cmd/dvotecli/README.md
+++ b/cmd/dvotecli/README.md
@@ -46,7 +46,7 @@ This command will open an interactive input where you can request raw JSON comma
 ./dvotecli json-client --host https://gw2.vocdoni.net/dvote
 2020-12-23T10:46:55Z    INFO    commands/client.go:36   logger construction succeeded at level  and output stdout
 2020-12-23T10:46:55Z    INFO    commands/client.go:47   connecting to https://gw2.vocdoni.net/dvote
-{"method":"dumpPlain","censusId":"0x16c0feec71ab17f603bb8053802c745f77e75e65cd65e3b1bc92e8c6443be820"}
+{"method":"dump","censusId":"0x16c0feec71ab17f603bb8053802c745f77e75e65cd65e3b1bc92e8c6443be820"}
 ...
 {"method":"genProof","censusId":"0x16c0feec71ab17f603bb8053802c745f77e75e65cd65e3b1bc92e8c6443be820", "digested":true,"claimData":"IutkMaMqFvU+VSNd6DRQs/SHoBxPqPjHZc90/rE/HDw="}
 ...

--- a/rpcapi/handlers.go
+++ b/rpcapi/handlers.go
@@ -44,7 +44,6 @@ func (r *RPCAPI) EnableCensusAPI(cm *census.Manager) error {
 
 	r.RegisterPublic("getRoot", false, r.censusLocal)
 	r.RegisterPrivate("dump", r.censusLocal)
-	r.RegisterPrivate("dumpPlain", r.censusLocal)
 	r.RegisterPublic("getSize", false, r.censusLocal)
 	r.RegisterPublic("genProof", false, r.censusLocal)
 	r.RegisterPublic("checkProof", false, r.censusLocal)

--- a/test/census_test.go
+++ b/test/census_test.go
@@ -141,24 +141,6 @@ func TestCensus(t *testing.T) {
 	resp = doRequest("addClaimBulk", signer2)
 	qt.Assert(t, resp.Ok, qt.IsTrue)
 
-	// TODO WIP: the method DumpPlain no longer exists, clarify the
-	// difference of usage between 'dump' & 'dumpPlain'.
-	// dumpPlain
-	// req.CensusKey = []byte{}
-	// req.CensusKeys = [][]byte{}
-	// resp = doRequest("dumpPlain", signer2)
-	// qt.Assert(t, resp.Ok, qt.IsTrue)
-	// for _, c := range claims {
-	//         found := false
-	//         for _, c2 := range resp.CensusKeys {
-	//                 if bytes.Equal(c, c2) {
-	//                         found = true
-	//                         break
-	//                 }
-	//         }
-	//         qt.Assert(t, found, qt.IsTrue)
-	// }
-
 	// GenProof valid
 	req.RootHash = nil
 	req.CensusKey = claims[1]


### PR DESCRIPTION
Reasoning:
dumpPlain was used to return a json with an array of keys&values in
string hex encoding each one. While dump returns a byte array with the
keys&values in a much more efficient way, using arbo's Dump method.  So,
dumpPlain was doing the same that dump but in a much more inefficient
way, which affects the workload done by the backend for each request,
but also the size of data sent over the network.
With this change, the client can still download the keys&values from the
dump handler, and then parse them following the specified encoding.

This is the description of the dump byte array encoding:
```
dump exports all the Tree leafs in a byte array of length:
[ N * (2+len(k+v)) ]. Where N is the number of key-values, and for each k+v:
[ 1 byte | 1 byte | S bytes | len(v) bytes ]
[ len(k) | len(v) |   key   |     value    ]
Where S is the size of the output of the hash function used for the Tree.
```