### PR TITLE
re-enable hashing on census keys

### DIFF
--- a/censustree/censustree.go
+++ b/censustree/censustree.go
@@ -22,6 +22,7 @@ type Tree struct {
 	sync.Mutex
 	public     uint32
 	censusType models.Census_Type
+	hashFunc   func(...[]byte) ([]byte, error)
 }
 
 type Options struct {
@@ -55,12 +56,17 @@ func New(opts Options) (*Tree, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Tree{tree: t, censusType: opts.CensusType}, nil
+	return &Tree{tree: t, censusType: opts.CensusType, hashFunc: hashFunc.Hash}, nil
 }
 
 // Type returns the numeric identifier of the censustree implementation
 func (t *Tree) Type() models.Census_Type {
 	return t.censusType
+}
+
+// Hash executes the tree hash function for input data and returns its output
+func (t *Tree) Hash(data []byte) ([]byte, error) {
+	return t.hashFunc(data)
 }
 
 // FromRoot returns a new read-only Tree for the given root, that uses the same

--- a/test/census_test.go
+++ b/test/census_test.go
@@ -38,6 +38,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/arbo"
 
 	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/client"
@@ -133,7 +134,8 @@ func TestCensus(t *testing.T) {
 	req.Digested = false
 	keys := testcommon.CreateEthRandomKeysBatch(t, *censusSize)
 	for _, key := range keys {
-		claim := crypto.FromECDSAPub(&key.Public)
+		claim, err := arbo.HashFunctionBlake2b.Hash(crypto.FromECDSAPub(&key.Public))
+		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, claim, qt.Not(qt.HasLen), 0)
 		claims = append(claims, claim)
 	}

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -163,8 +163,8 @@ var Genesis = map[string]VochainGenesis{
 		},
 		Genesis: `
 {
-   "genesis_time":"2021-11-04T19:43:28.668436552Z",
-   "chain_id":"vocdoni-development-51",
+   "genesis_time":"2021-11-06T22:43:28.668436552Z",
+   "chain_id":"vocdoni-development-52",
    "consensus_params":{
       "block":{
          "max_bytes":"5120000",

--- a/vochain/proof.go
+++ b/vochain/proof.go
@@ -85,7 +85,11 @@ func VerifyProofOffChainTree(process *models.Process, proof *models.Proof,
 		default:
 			return false, nil, fmt.Errorf("not recognized ProofArbo type: %s", p.Type)
 		}
-		valid, err := tree.VerifyProof(hashFunc, key, []byte{}, p.Siblings, censusRoot)
+		hashedKey, err := hashFunc.Hash(key)
+		if err != nil {
+			return false, nil, err
+		}
+		valid, err := tree.VerifyProof(hashFunc, hashedKey, []byte{}, p.Siblings, censusRoot)
 		return valid, bigOne, err
 	default:
 		return false, nil, fmt.Errorf("unexpected proof.Payload type: %T",

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -28,7 +28,10 @@ func TestMerkleTreeProof(t *testing.T) {
 	keys := util.CreateEthRandomKeysBatch(1001)
 	proofs := []string{}
 	for _, k := range keys {
-		c := k.PublicKey()
+		c, err := tr.Hash(k.PublicKey())
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := tr.Add(c, nil); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
We need to hash the census keys in order to ensure the size
of the key fits into the hash function field.

Enable all hashings on censusManager if Digested=False

Signed-off-by: p4u <pau@dabax.net>