### PR TITLE
fix web3 connection sync routine if nethermind:

### DIFF
--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -27,13 +27,13 @@ echo "### Starting test suite ###"
 docker-compose build
 docker-compose up -d
 
-sleep 5
 echo "### Waiting for test suite to be ready ###"
 for i in {1..5}; do
 	docker-compose run test curl --fail http://gateway:9090/dvote \
 		-X POST \
 		-d '{"id": "req00'$RANDOM'", "request": {"method": "getInfo", "timestamp":'$(date +%s)'}}' && break || sleep 5
 done
+sleep 10 # extra wait to ensure all gateways API methods have been started
 
 testid="/tmp/.vochaintest$RANDOM"
 

--- a/rpcapi/handlers.go
+++ b/rpcapi/handlers.go
@@ -2,10 +2,10 @@ package rpcapi
 
 import (
 	"fmt"
-	"log"
 
 	"go.vocdoni.io/dvote/census"
 	"go.vocdoni.io/dvote/data"
+	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/dvote/vochain/scrutinizer"
 	"go.vocdoni.io/dvote/vochain/vochaininfo"
@@ -16,6 +16,7 @@ func (r *RPCAPI) EnableFileAPI(storage data.Storage) error {
 	if storage == nil {
 		return fmt.Errorf("storage cannot be nil for file API")
 	}
+	log.Infof("enabling file API")
 	r.storage = storage
 	r.APIs = append(r.APIs, "file")
 
@@ -36,6 +37,7 @@ func (r *RPCAPI) EnableCensusAPI(cm *census.Manager) error {
 	if cm == nil {
 		return fmt.Errorf("census manager cannot be nil for census API")
 	}
+	log.Infof("enabling census API")
 	r.APIs = append(r.APIs, "census")
 	r.census = cm
 	if cm.RemoteStorage == nil {
@@ -47,12 +49,14 @@ func (r *RPCAPI) EnableCensusAPI(cm *census.Manager) error {
 	r.RegisterPublic("getSize", false, r.censusLocal)
 	r.RegisterPublic("genProof", false, r.censusLocal)
 	r.RegisterPublic("checkProof", false, r.censusLocal)
-	r.RegisterPrivate("addCensus", r.censusLocal)
-	r.RegisterPrivate("addClaim", r.censusLocal)
-	r.RegisterPrivate("addClaimBulk", r.censusLocal)
-	r.RegisterPrivate("publish", r.censusLocal)
-	r.RegisterPrivate("importRemote", r.censusLocal)
-	r.RegisterPrivate("getCensusList", r.censusLocal)
+	if r.allowPrivate {
+		r.RegisterPrivate("addCensus", r.censusLocal)
+		r.RegisterPrivate("addClaim", r.censusLocal)
+		r.RegisterPrivate("addClaimBulk", r.censusLocal)
+		r.RegisterPrivate("publish", r.censusLocal)
+		r.RegisterPrivate("importRemote", r.censusLocal)
+		r.RegisterPrivate("getCensusList", r.censusLocal)
+	}
 
 	return nil
 }
@@ -62,6 +66,7 @@ func (r *RPCAPI) EnableVoteAPI(vocapp *vochain.BaseApplication, vocinfo *vochain
 	if (r.vocapp == nil && vocapp == nil) || (r.vocinfo == nil && vocinfo == nil) {
 		return fmt.Errorf("vocdoni APP or vocdoni Info are nil")
 	}
+	log.Infof("enabling vote API")
 	if r.vocapp == nil {
 		r.vocapp = vocapp
 	}
@@ -88,6 +93,7 @@ func (r *RPCAPI) EnableResultsAPI(vocapp *vochain.BaseApplication, scrutinizer *
 	if (r.vocapp == nil && vocapp == nil) || (r.scrutinizer == nil && scrutinizer == nil) {
 		return fmt.Errorf("vocdoni APP or scrutinizer are nil")
 	}
+	log.Infof("enabling results API")
 	if r.vocapp == nil {
 		r.vocapp = vocapp
 	}
@@ -115,6 +121,7 @@ func (r *RPCAPI) EnableIndexerAPI(vocapp *vochain.BaseApplication,
 		(r.vocinfo == nil && vocinfo == nil) {
 		return fmt.Errorf("vocdoni APP or scrutinizer are nil")
 	}
+	log.Infof("enabling indexer API")
 	if r.vocapp == nil {
 		r.vocapp = vocapp
 	}

--- a/rpcapi/handlers.go
+++ b/rpcapi/handlers.go
@@ -78,6 +78,7 @@ func (r *RPCAPI) EnableVoteAPI(vocapp *vochain.BaseApplication, vocinfo *vochain
 	r.RegisterPublic("getBlockStatus", false, r.getBlockStatus)
 	r.RegisterPublic("getOracleResults", false, r.getOracleResults)
 	r.RegisterPublic("getProcessCircuitConfig", false, r.getProcessCircuitConfig)
+	r.RegisterPublic("getProcessRollingCensusSize", false, r.getProcessRollingCensusSize)
 
 	return nil
 }

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -153,12 +153,23 @@ var Genesis = map[string]VochainGenesis{
 		SeedNodes: []string{
 			"7440a5b086e16620ce7b13198479016aa2b07988@seed.dev.vocdoni.net:26656"},
 		CircuitsConfig: []artifacts.CircuitConfig{
-			{ // index: 0, size: 1024
-				URL:         "https://raw.githubusercontent.com/vocdoni/zk-circuits-artifacts/master/",
-				CircuitPath: "/zkcensusproof/dev/1024",
-				Parameters:  []int64{1024},
+			{ // index: 0, size: 8
+				URL:         "https://raw.githubusercontent.com/vocdoni/zk-circuits-artifacts/master",
+				CircuitPath: "zkcensusproof/dev/8",
+				Parameters:  []int64{8},
 				LocalDir:    "./circuits",
-				VKHash:      hexToBytes("0x3669e12ea939564b59b995b9067eab83c8ebb09f5a83ad4aa3d6d6f90c1b0fc4"),
+				ZKeyHash:    hexToBytes("0x7d09a880e14e08143bb66a6f28e13b2707afabc79693ce1613f68083fd70ac31"),
+				WitnessHash: hexToBytes("0xd021d42d79d4e10b94a5785e1c1854ddb80d087cb58ad6bb29aa8b8d541d420d"),
+				VKHash:      hexToBytes("0xf4876aa550e33de1d1f552dc38fa89f6e87e553fd05179e693f82f661cd0c6a0"),
+			},
+			{ // index: 1, size: 16
+				URL:         "https://raw.githubusercontent.com/vocdoni/zk-circuits-artifacts/master",
+				CircuitPath: "zkcensusproof/dev/16",
+				Parameters:  []int64{16},
+				LocalDir:    "./circuits",
+				ZKeyHash:    hexToBytes("0x2d84f9ce275f35e10b6debde1c53d74264ebb401077aaaa2ac4970e3a06eba03"),
+				WitnessHash: hexToBytes("0xe55effa3d7ee28037a073f1096012ae75d97d949320bb0dfbc26ca553b818c70"),
+				VKHash:      hexToBytes("0x0d8af5c3cc443cfbaed59b6144b1edb959daacbae085a97f74cbafbe109de2fa"),
 			},
 		},
 		Genesis: `


### PR DESCRIPTION
Adapt the sync progress routine to work properly
when the connected web3 endpoint runs the Nethermind
codebase. The eth_syncing JSON RPC call returns 0x0
as block number.

Add an extra call (eth_blockNumber) in the Connect
method to check that the client can obtain at least the
block number from the connected web3 endpoint.