### PR TITLE
WIP: change some namings for consistency

### DIFF
--- a/crypto/zk/artifacts/artifacts.go
+++ b/crypto/zk/artifacts/artifacts.go
@@ -43,7 +43,7 @@ const (
 	// FilenameWitness defines the name of the file of the WitnessCalculator
 	FilenameWitness = "circuit.wasm"
 	// FilenameZKey defines the name of the file of the circom ZKey
-	FilenameZKey = "circuit_final.zkey"
+	FilenameZKey = "circuit.zkey"
 	// FilenameVK defines the name of the verification_key.json
 	FilenameVK = "verification_key.json"
 )
@@ -51,8 +51,8 @@ const (
 // CircuitConfig defines the configuration of the files to be downloaded
 type CircuitConfig struct {
 	// TODO: Replace by URI
-	// URL defines the URL from where to download the files
-	URL string `json:"url"`
+	// URI defines the URI from where to download the files
+	URI string `json:"uri"`
 	// CircuitPath defines the path from where the files are downloaded
 	CircuitPath string `json:"circuitPath"`
 	// Parameters used for the circuit build
@@ -112,7 +112,7 @@ func DownloadVKFile(ctx context.Context, c CircuitConfig) error {
 	if err := os.MkdirAll(filepath.Join(c.LocalDir, c.CircuitPath), os.ModePerm); err != nil {
 		return err
 	}
-	u, err := url.Parse(c.URL)
+	u, err := url.Parse(c.URI)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func DownloadVKFile(ctx context.Context, c CircuitConfig) error {
 	}
 	if err := checkHash(filepath.Join(c.LocalDir, c.CircuitPath, FilenameVK),
 		c.VKHash); err != nil {
-		return fmt.Errorf("error on download VerificationKey (VK) file from %s, %s", c.URL, err)
+		return fmt.Errorf("error on download VerificationKey (VK) file from %s, %s", c.URI, err)
 	}
 	log.Info("VK file downloaded correctly & match the expected hash")
 	return nil
@@ -176,7 +176,7 @@ func downloadFiles(ctx context.Context, c CircuitConfig) error {
 		return err
 	}
 
-	u, err := url.Parse(c.URL)
+	u, err := url.Parse(c.URI)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func downloadFiles(ctx context.Context, c CircuitConfig) error {
 		return err
 	}
 
-	u, err = url.Parse(c.URL)
+	u, err = url.Parse(c.URI)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func downloadFiles(ctx context.Context, c CircuitConfig) error {
 		return err
 	}
 
-	u, err = url.Parse(c.URL)
+	u, err = url.Parse(c.URI)
 	if err != nil {
 		return err
 	}
@@ -213,7 +213,7 @@ func downloadFiles(ctx context.Context, c CircuitConfig) error {
 	}
 
 	if err := checkHashes(c); err != nil {
-		return fmt.Errorf("error on download files from %s, %s", c.URL, err)
+		return fmt.Errorf("error on download files from %s, %s", c.URI, err)
 	}
 
 	log.Info("files downloaded correctly & match the expected hashes")

--- a/crypto/zk/artifacts/artifacts_test.go
+++ b/crypto/zk/artifacts/artifacts_test.go
@@ -33,14 +33,14 @@ func TestDownloadCircuitFiles(t *testing.T) {
 
 	witnessHash, err := hex.DecodeString("a812fddbb71ca2b5cc5a2326dad391c1f98c11fe2641927ec490fad7c5ef30ac")
 	qt.Assert(t, err, qt.IsNil)
-	zkeyHash, err := hex.DecodeString("e6827f50f2a44d5fa6c95b15893124af82ca154c0338295be8fa09fd9e8eb8ac")
+	zkeyHash, err := hex.DecodeString("279433966c3d258fa747121207b02baad715e12877473f9c2326da7f3a17597b")
 	qt.Assert(t, err, qt.IsNil)
 	vkHash, err := hex.DecodeString("3ec7355a7be53019b66563d02a1e2ce689e6dfac207a5f9ce503fb8ac915acf0")
 	qt.Assert(t, err, qt.IsNil)
 
 	path := t.TempDir()
 	c := CircuitConfig{
-		URL:         ts.URL,
+		URI:         ts.URL,
 		CircuitPath: "/zkcensusproof/test/1024/",
 		LocalDir:    path,
 		WitnessHash: witnessHash,
@@ -103,7 +103,7 @@ func TestErrorDownloading(t *testing.T) {
 
 	path := t.TempDir()
 	c := CircuitConfig{
-		URL:         ts.URL,
+		URI:         ts.URL,
 		CircuitPath: "/zkcensusproof/test/1024/",
 		LocalDir:    path,
 	}
@@ -124,7 +124,7 @@ func TestDownloadVKFile(t *testing.T) {
 
 	path := t.TempDir()
 	c := CircuitConfig{
-		URL:         ts.URL,
+		URI:         ts.URL,
 		CircuitPath: "/zkcensusproof/test/1024/",
 		LocalDir:    path,
 		VKHash:      vkHash,

--- a/dockerfiles/testsuite/js/gen-vote-snark.js
+++ b/dockerfiles/testsuite/js/gen-vote-snark.js
@@ -24,7 +24,7 @@ async function generateProof(inputs, artifactsPath, outPath) {
   await sleep(100);
 
   // proof
-  let { proof, publicSignals } = await snarkjs.groth16.prove(`${artifactsPath}/circuit_final.zkey`,
+  let { proof, publicSignals } = await snarkjs.groth16.prove(`${artifactsPath}/circuit.zkey`,
     `${outPath}/out.wtns`);
 
   // print proof

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -154,8 +154,8 @@ var Genesis = map[string]VochainGenesis{
 			"7440a5b086e16620ce7b13198479016aa2b07988@seed.dev.vocdoni.net:26656"},
 		CircuitsConfig: []artifacts.CircuitConfig{
 			{ // index: 0, size: 8
-				URL: "https://raw.githubusercontent.com/vocdoni/" +
-					"zk-circuits-artifacts/32a16e1c58dddebef6165a4fcf3a3c1f665a343f",
+				URI: "https://raw.githubusercontent.com/vocdoni/" +
+					"zk-circuits-artifacts/6afb7c22d856c8b727262b0a0ae8ab7ca534dd4e",
 				CircuitPath: "zkcensusproof/dev/8",
 				Parameters:  []int64{8},
 				LocalDir:    "./circuits",
@@ -164,8 +164,8 @@ var Genesis = map[string]VochainGenesis{
 				VKHash:      hexToBytes("0xf4876aa550e33de1d1f552dc38fa89f6e87e553fd05179e693f82f661cd0c6a0"),
 			},
 			{ // index: 1, size: 16
-				URL: "https://raw.githubusercontent.com/vocdoni/" +
-					"zk-circuits-artifacts/32a16e1c58dddebef6165a4fcf3a3c1f665a343f",
+				URI: "https://raw.githubusercontent.com/vocdoni/" +
+					"zk-circuits-artifacts/6afb7c22d856c8b727262b0a0ae8ab7ca534dd4e",
 				CircuitPath: "zkcensusproof/dev/16",
 				Parameters:  []int64{16},
 				LocalDir:    "./circuits",
@@ -174,8 +174,8 @@ var Genesis = map[string]VochainGenesis{
 				VKHash:      hexToBytes("0x0d8af5c3cc443cfbaed59b6144b1edb959daacbae085a97f74cbafbe109de2fa"),
 			},
 			{ // index: 2, size: 1024
-				URL: "https://raw.githubusercontent.com/vocdoni/" +
-					"zk-circuits-artifacts/32a16e1c58dddebef6165a4fcf3a3c1f665a343f",
+				URI: "https://raw.githubusercontent.com/vocdoni/" +
+					"zk-circuits-artifacts/6afb7c22d856c8b727262b0a0ae8ab7ca534dd4e",
 				CircuitPath: "zkcensusproof/dev/1024",
 				Parameters:  []int64{1024},
 				LocalDir:    "./circuits",


### PR DESCRIPTION
- rename the standard artifact zkey file from circuit_final.zkey to circuit.zkey
- rename circuitConfig field URL into uri for consistency with Content Hashed URI's

Partially address: #365 

Weighted Voting with zkSnarks IS NOT YET supported, commit f4e1dda12e6752aefeeba08ffcd0ebbe16e466cd temporary address the bug. cc: @brickpop 