### PR TITLE
vochain: allow weight == 1 on preRegister key Tx

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -527,7 +527,7 @@ func (c *Client) TestPreRegisterKeys(
 			Nonce:     util.RandomBytes(32),
 			ProcessId: pid,
 			NewKey:    zkCensusKey,
-			Weight:    big.NewInt(1).Bytes(),
+			Weight:    "1",
 		}
 		switch censusOrigin {
 		case models.CensusOrigin_OFF_CHAIN_TREE:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ replace github.com/timshannon/badgerhold/v3 => github.com/vocdoni/badgerhold/v3 
 
 require (
 	git.sr.ht/~sircmpwn/go-bare v0.0.0-20210406120253-ab86bc2846d9
+	github.com/766b/chi-prometheus v0.0.0-20180509160047-46ac2b31aa30
 	github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210323162413-ccaa6313370d
 	github.com/cockroachdb/pebble v0.0.0-20211004132338-b2eb88a71826
 	github.com/cosmos/iavl v0.15.3
@@ -56,7 +57,7 @@ require (
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.18.1
-	go.vocdoni.io/proto v1.13.3-0.20211114162531-c85a04c58730
+	go.vocdoni.io/proto v1.13.3-0.20211126083500-46ba146eff3f
 	golang.org/x/crypto v0.0.0-20210920023735-84f357641f63
 	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf
 	google.golang.org/protobuf v1.27.1
@@ -66,7 +67,6 @@ require (
 require (
 	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.3.0 // indirect
-	github.com/766b/chi-prometheus v0.0.0-20180509160047-46ac2b31aa30 // indirect
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect

--- a/go.sum
+++ b/go.sum
@@ -2096,8 +2096,6 @@ github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMI
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vocdoni/arbo v0.0.0-20210616072504-a8c7ea980892/go.mod h1:Pikn2YIz/Rt05HWs35QHdpx7IWk4E2G0KdnCX+KRsNs=
-github.com/vocdoni/arbo v0.0.0-20210927131431-d7c756341372 h1:kgd6g8uJmZe6ftaKC9WORlPqSddZYLUQ1uwhYMJu6Xo=
-github.com/vocdoni/arbo v0.0.0-20210927131431-d7c756341372/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
 github.com/vocdoni/arbo v0.0.0-20211011134549-3f7e76997421 h1:arYQr9xPfQyf+w2lwG9EGT2sRiKw0m8ih08z2WmevCI=
 github.com/vocdoni/arbo v0.0.0-20211011134549-3f7e76997421/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
 github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f h1:z7CK3k1yIutKycPY8s2ZbtwUBKMy3xPcLMh12QukLRY=
@@ -2242,16 +2240,8 @@ go.vocdoni.io/proto v0.1.7/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M
 go.vocdoni.io/proto v0.1.8/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
-go.vocdoni.io/proto v1.13.3-0.20211019215004-0ca7d4436553 h1:0aQHf6mdFEhP8x5ArPtwPwW9AiEXEZSK45GoHzlNrro=
-go.vocdoni.io/proto v1.13.3-0.20211019215004-0ca7d4436553/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
-go.vocdoni.io/proto v1.13.3-0.20211026121805-ac3d037a6139 h1:gUSpa7+K71nR1c0DF25HWYtn+3fcMEB0M0zzqpRBpyo=
-go.vocdoni.io/proto v1.13.3-0.20211026121805-ac3d037a6139/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
-go.vocdoni.io/proto v1.13.3-0.20211027093430-8170bfc7dc03 h1:SDnIqN/MDlePqwCfQEGkpgHIKASekDEU8u+rt+ho87Y=
-go.vocdoni.io/proto v1.13.3-0.20211027093430-8170bfc7dc03/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
-go.vocdoni.io/proto v1.13.3-0.20211111204422-dac54577ad68 h1:JE1nTnu4s3rnSVDImbDTT9H/nYhmLV5pyuLAGNLOwN8=
-go.vocdoni.io/proto v1.13.3-0.20211111204422-dac54577ad68/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
-go.vocdoni.io/proto v1.13.3-0.20211114162531-c85a04c58730 h1:CgTuDulomypbXvAC4Gj/AgDGQDtltt0+nAC34ruO8yI=
-go.vocdoni.io/proto v1.13.3-0.20211114162531-c85a04c58730/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
+go.vocdoni.io/proto v1.13.3-0.20211126083500-46ba146eff3f h1:YtqKk93BnLla8sBqYNMQAZAkv5Yqniwlr/ilzUVCP9Q=
+go.vocdoni.io/proto v1.13.3-0.20211126083500-46ba146eff3f/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20200411211856-f5505b9728dd h1:BNJlw5kRTzdmyfh5U8F93HA2OwkP7ZGwA51eJ/0wKOU=
 go4.org v0.0.0-20200411211856-f5505b9728dd/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -16,7 +16,7 @@ import (
 
 var emptyVotesRoot = make([]byte, VotesCfg.HashFunc().Len())
 var emptyCensusRoot = make([]byte, CensusCfg.HashFunc().Len())
-var emptyNullifiersRoot = make([]byte, NullifiersCfg.HashFunc().Len())
+var emptyPreRegisterNullifiersRoot = make([]byte, PreRegisterNullifiersCfg.HashFunc().Len())
 
 // AddProcess adds a new process to the vochain.  Adding a process with a
 // ProcessId that already exists will return an error.
@@ -25,7 +25,7 @@ func (v *State) AddProcess(p *models.Process) error {
 	anonymous := p.EnvelopeType != nil && p.EnvelopeType.Anonymous
 	if preRegister {
 		p.RollingCensusRoot = emptyCensusRoot
-		p.NullifiersRoot = emptyNullifiersRoot
+		p.NullifiersRoot = emptyPreRegisterNullifiersRoot
 	}
 
 	newProcessBytes, err := proto.Marshal(
@@ -51,7 +51,7 @@ func (v *State) AddProcess(p *models.Process) error {
 				return err
 			}
 			if _, err = v.Tx.DeepSubTree(ProcessesCfg,
-				NullifiersCfg.WithKey(p.ProcessId)); err != nil {
+				PreRegisterNullifiersCfg.WithKey(p.ProcessId)); err != nil {
 				return err
 			}
 		}

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -81,9 +81,9 @@ func processSetCensusRoot(value []byte, root []byte) ([]byte, error) {
 	return newValue, nil
 }
 
-// processGetNullifiersRoot is the GetRootFn function to get the nullifiers
+// processGetPreRegisterNullifiersRoot is the GetRootFn function to get the nullifiers
 // root of a process leaf.
-func processGetNullifiersRoot(value []byte) ([]byte, error) {
+func processGetPreRegisterNullifiersRoot(value []byte) ([]byte, error) {
 	var sdbProc models.StateDBProcess
 	if err := proto.Unmarshal(value, &sdbProc); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal StateDBProcess: %w", err)
@@ -95,9 +95,9 @@ func processGetNullifiersRoot(value []byte) ([]byte, error) {
 	return sdbProc.Process.NullifiersRoot, nil
 }
 
-// processSetNullifiersRoot is the SetRootFn function to set the nullifiers
+// processSetPreRegisterNullifiersRoot is the SetRootFn function to set the nullifiers
 // root of a process leaf.
-func processSetNullifiersRoot(value []byte, root []byte) ([]byte, error) {
+func processSetPreRegisterNullifiersRoot(value []byte, root []byte) ([]byte, error) {
 	var sdbProc models.StateDBProcess
 	if err := proto.Unmarshal(value, &sdbProc); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal StateDBProcess: %w", err)
@@ -198,16 +198,16 @@ var (
 		ParentLeafGetRoot: processGetCensusRoot,
 		ParentLeafSetRoot: processSetCensusRoot,
 	})
-	// NullifiersCfg is the Nullifiers subTree (found under a
+	// PreRegisterNullifiersCfg is the Nullifiers subTree (found under a
 	// Process leaf) configuration when the process supports anonymous
 	// voting with rolling census.  This tree contains the pre-census
 	// nullifiers that have pre-registered.
-	NullifiersCfg = statedb.NewTreeNonSingletonConfig(statedb.TreeParams{
+	PreRegisterNullifiersCfg = statedb.NewTreeNonSingletonConfig(statedb.TreeParams{
 		HashFunc:          arbo.HashFunctionSha256,
-		KindID:            "nulli",
+		KindID:            "prNul",
 		MaxLevels:         256,
-		ParentLeafGetRoot: processGetNullifiersRoot,
-		ParentLeafSetRoot: processSetNullifiersRoot,
+		ParentLeafGetRoot: processGetPreRegisterNullifiersRoot,
+		ParentLeafSetRoot: processSetPreRegisterNullifiersRoot,
 	})
 
 	// VotesCfg is the Votes subTree (found under a Process leaf) configuration.

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -122,7 +122,11 @@ func (app *BaseApplication) AddTx(vtx *models.Tx, txBytes, signature []byte,
 		}
 		if commit {
 			tx := vtx.GetRegisterKey()
-			return []byte{}, app.State.AddToRollingCensus(tx.ProcessId, tx.NewKey, new(big.Int).SetBytes(tx.Weight))
+			weight, ok := new(big.Int).SetString(tx.Weight, 10)
+			if !ok {
+				return []byte{}, fmt.Errorf("cannot parse weight %s", weight)
+			}
+			return []byte{}, app.State.AddToRollingCensus(tx.ProcessId, tx.NewKey, weight)
 		}
 
 	default:


### PR DESCRIPTION
tx.Weight is now a big number string

Only tx.Weight=1 is allowed until full weighted voting support
is added to vochain

Signed-off-by: p4u <pau@dabax.net>