### PR TITLE
vochain: use persistent state in IsOracle()

### DIFF
--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -26,6 +26,9 @@ func TestProcessSetStatusTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	app.State.SetHeight(1)
+	app.State.Save()
+
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl
 	pid := util.RandomBytes(types.ProcessIDsize)
@@ -219,6 +222,9 @@ func TestProcessSetResultsTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	app.State.SetHeight(1)
+	app.State.Save()
+
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl
 	pid := util.RandomBytes(types.ProcessIDsize)
@@ -342,6 +348,9 @@ func TestProcessSetCensusTransition(t *testing.T) {
 	if err := app.State.AddOracle(common.HexToAddress(oracle.AddressString())); err != nil {
 		t.Fatal(err)
 	}
+
+	app.State.SetHeight(1)
+	app.State.Save()
 
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -467,7 +467,7 @@ func (v *State) Oracles(isQuery bool) ([]common.Address, error) {
 
 // IsOracle returns true if the address is a valid oracle
 func (v *State) IsOracle(addr common.Address) (bool, error) {
-	oracles, err := v.Oracles(false)
+	oracles, err := v.Oracles(true)
 	if err != nil || len(oracles) == 0 {
 		return false, fmt.Errorf("cannot check authorization against a nil or empty oracle list")
 	}


### PR DESCRIPTION
With the `isQuery(false)` State method the oracle list is obtained from the volatile state and it must be fetched from the persistent one.