### PR TITLE
revert fix isOracle:

### DIFF
--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -26,9 +26,6 @@ func TestProcessSetStatusTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app.State.SetHeight(1)
-	app.State.Save()
-
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl
 	pid := util.RandomBytes(types.ProcessIDsize)
@@ -222,9 +219,6 @@ func TestProcessSetResultsTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app.State.SetHeight(1)
-	app.State.Save()
-
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl
 	pid := util.RandomBytes(types.ProcessIDsize)
@@ -348,9 +342,6 @@ func TestProcessSetCensusTransition(t *testing.T) {
 	if err := app.State.AddOracle(common.HexToAddress(oracle.AddressString())); err != nil {
 		t.Fatal(err)
 	}
-
-	app.State.SetHeight(1)
-	app.State.Save()
 
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -467,7 +467,7 @@ func (v *State) Oracles(isQuery bool) ([]common.Address, error) {
 
 // IsOracle returns true if the address is a valid oracle
 func (v *State) IsOracle(addr common.Address) (bool, error) {
-	oracles, err := v.Oracles(true)
+	oracles, err := v.Oracles(false)
 	if err != nil || len(oracles) == 0 {
 		return false, fmt.Errorf("cannot check authorization against a nil or empty oracle list")
 	}


### PR DESCRIPTION
In the same block is accepted the following behavior:
    - tx.1 AddOracle
    - tx.2 NewProcess
    - tx.3 RemoveOracle
So there is no need for the state to be persistent for accepting
process creation by the newly added oracle.