### PR TITLE
Fix bug in block time estimation

### DIFF
--- a/vochain/vochaininfo/vochaininfo.go
+++ b/vochain/vochaininfo/vochaininfo.go
@@ -76,7 +76,7 @@ func (vi *VochainInfo) HeightTime(height int64) time.Time {
 				return int64(times[i])
 			}
 		}
-		return 10 // fallback
+		return 10000 // fallback
 	}
 
 	t := int64(0)

--- a/vochain/vochaininfo/vochaininfo.go
+++ b/vochain/vochaininfo/vochaininfo.go
@@ -71,7 +71,7 @@ func (vi *VochainInfo) HeightTime(height int64) time.Time {
 	}
 
 	getMaxTimeFrom := func(i int) int64 {
-		for ; i <= 0; i-- {
+		for ; i >= 0; i-- {
 			if times[i] != 0 {
 				return int64(times[i])
 			}


### PR DESCRIPTION
There is a bug in the loop invariant here that causes the default blockTime value (10) to be returned always. This fixed the loop invariant.

I'm also changing the fallback value to be 10000, or 10 seconds.

(not sure if this code is even used, but I caught this when copying/modifying it for block time estimation in the vaas-api component)