### PR TITLE
api: send HTTP 400 for errors

### DIFF
--- a/httprouter/bearerstdapi/bearerstdapi.go
+++ b/httprouter/bearerstdapi/bearerstdapi.go
@@ -23,8 +23,10 @@ const (
 	// MethodAccessTypeAdmin for admin requests
 	MethodAccessTypeAdmin = "admin"
 
-	namespace    = "bearerStd"
-	bearerPrefix = "Bearer "
+	namespace         = "bearerStd"
+	bearerPrefix      = "Bearer "
+	HTTPstatusCodeOK  = 200
+	HTTPstatusCodeErr = 400
 )
 
 // BearerStandardAPI is a namespace handler for the httpRouter with Bearer authorization
@@ -128,12 +130,12 @@ func (b *BearerStandardAPI) RegisterMethod(pattern, HTTPmethod string,
 	routerHandler := func(msg httprouter.Message) {
 		bsaMsg := msg.Data.(*BearerStandardAPIdata)
 		if err := handler(bsaMsg, msg.Context); err != nil {
-			data, err := json.Marshal(&ErrorMsg{Error: err.Error()})
-			if err != nil {
-				log.Warn(err)
+			data, err2 := json.Marshal(&ErrorMsg{Error: err.Error()})
+			if err2 != nil {
+				log.Warn(err2)
 				return
 			}
-			if err := msg.Context.Send(data); err != nil {
+			if err := msg.Context.Send(data, HTTPstatusCodeErr); err != nil {
 				log.Warn(err)
 			}
 		}

--- a/httprouter/bearerstdapi/bearerstdapi_test.go
+++ b/httprouter/bearerstdapi/bearerstdapi_test.go
@@ -27,25 +27,25 @@ func TestRouterWithBearerStdAPI(t *testing.T) {
 	// Add a public handler to serve requests on std namespace
 	stdAPI.RegisterMethod("/hello/*", "POST", MethodAccessTypePublic,
 		func(msg *BearerStandardAPIdata, ctx *httprouter.HTTPContext) error {
-			return ctx.Send([]byte("hello public!"))
+			return ctx.Send([]byte("hello public!"), 200)
 		})
 
 	// Add an admin handler to serve requests on std namespace
 	stdAPI.RegisterMethod("/admin/*", "POST", MethodAccessTypeAdmin,
 		func(msg *BearerStandardAPIdata, ctx *httprouter.HTTPContext) error {
-			return ctx.Send([]byte("hello admin!"))
+			return ctx.Send([]byte("hello admin!"), 200)
 		})
 
 	// Add a private handler
 	stdAPI.RegisterMethod("/private/{name}", "POST", MethodAccessTypePrivate,
 		func(msg *BearerStandardAPIdata, ctx *httprouter.HTTPContext) error {
-			return ctx.Send([]byte(fmt.Sprintf("hello %s!", ctx.URLParam("name"))))
+			return ctx.Send([]byte(fmt.Sprintf("hello %s!", ctx.URLParam("name"))), 200)
 		})
 
 	// Add a quota handler
 	stdAPI.RegisterMethod("/quota/{name}", "POST", MethodAccessTypeQuota,
 		func(msg *BearerStandardAPIdata, ctx *httprouter.HTTPContext) error {
-			return ctx.Send([]byte(fmt.Sprintf("hello %s!", ctx.URLParam("name"))))
+			return ctx.Send([]byte(fmt.Sprintf("hello %s!", ctx.URLParam("name"))), 200)
 		})
 
 	// Set the bearer admin token

--- a/httprouter/jsonrpcapi/jsonrpcapi.go
+++ b/httprouter/jsonrpcapi/jsonrpcapi.go
@@ -135,7 +135,7 @@ func (s *SignedJRPC) SendError(requestID string, errorMsg string, ctxt *httprout
 	if err != nil {
 		return err
 	}
-	return ctxt.Send(data)
+	return ctxt.Send(data, 200)
 }
 
 func (s *SignedJRPC) returnError(errorMsg, requestID string) error {

--- a/httprouter/jsonrpcapi/jsonrpcapi_test.go
+++ b/httprouter/jsonrpcapi/jsonrpcapi_test.go
@@ -50,7 +50,7 @@ func TestJSONRPCAPI(t *testing.T) {
 			resp.Ok = true
 			data, err := BuildReply(signer, &resp, req.ID)
 			qt.Check(t, err, qt.IsNil)
-			err = msg.Context.Send(data)
+			err = msg.Context.Send(data, 200)
 			qt.Check(t, err, qt.IsNil)
 		case "del":
 			if apiMsg.Name == "" {
@@ -60,7 +60,7 @@ func TestJSONRPCAPI(t *testing.T) {
 			resp.Ok = true
 			data, err := BuildReply(signer, &resp, req.ID)
 			qt.Check(t, err, qt.IsNil)
-			msg.Context.Send(data)
+			msg.Context.Send(data, 200)
 			qt.Check(t, err, qt.IsNil)
 		default:
 			t.Fatal("method invalid")

--- a/rpcapi/api.go
+++ b/rpcapi/api.go
@@ -121,7 +121,7 @@ func (a *RPCAPI) route(msg httprouter.Message) {
 		log.Errorf("cannot build reply for method %s: %v", apiMsg.GetMethod(), err)
 		return
 	}
-	if err := msg.Context.Send(data); err != nil {
+	if err := msg.Context.Send(data, 200); err != nil {
 		log.Warnf("cannot send api response: %v", err)
 	}
 }

--- a/urlapi/handlers.go
+++ b/urlapi/handlers.go
@@ -81,7 +81,7 @@ func (u *URLAPI) entityProcessHandler(msg *bearerstdapi.BearerStandardAPIdata, c
 	if err != nil {
 		return fmt.Errorf("error marshaling JSON: %w", err)
 	}
-	if err = ctx.Send(data); err != nil {
+	if err = ctx.Send(data, bearerstdapi.HTTPstatusCodeOK); err != nil {
 		log.Warn(err)
 	}
 	return nil
@@ -119,7 +119,7 @@ func (u *URLAPI) processHandler(msg *bearerstdapi.BearerStandardAPIdata, ctx *ht
 	if err != nil {
 		return fmt.Errorf("error marshaling JSON: %w", err)
 	}
-	if err = ctx.Send(data); err != nil {
+	if err = ctx.Send(data, bearerstdapi.HTTPstatusCodeOK); err != nil {
 		log.Warn(err)
 	}
 	return nil


### PR DESCRIPTION
And allow API handlers to set the error code on each message

Signed-off-by: p4u <pau@dabax.net>