### PR TITLE
VPROT-125 TransactionCosts{} represents the tx cost settings in the genesis file

### DIFF
--- a/util/helpers.go
+++ b/util/helpers.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 
@@ -65,4 +67,13 @@ func CreateEthRandomKeysBatch(n int) []*ethereum.SignKeys {
 		}
 	}
 	return s
+}
+
+// Uint64ToBytes converts a uint to a little-endian byte array
+func Uint64ToBytes(x uint64) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.LittleEndian, x); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -286,7 +286,16 @@ var Genesis = map[string]VochainGenesis{
          "0xb926be24A9ca606B515a835E91298C7cF0f2846f",
          "0x2f4ed2773dcf7ad0ec15eb84ec896f4eebe0e08a"
       ],
-      "treasurer": "0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d"
+      "treasurer": "0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d",
+      "tx_cost": {
+         "Tx_SetProcess": 100,
+         "Tx_RegisterKey": 100,
+         "Tx_NewProcess": 100,
+         "Tx_SendTokens": 100,
+         "Tx_SetAccountInfo": 100,
+         "Tx_SetAccountDelegate": 100,
+         "Tx_CollectFaucet": 100
+       }
    }
 }
 `,

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -67,26 +67,27 @@ type QueryData struct {
 // ________________________ TRANSACTION COSTS __________________________
 // TransactionCosts describes how much each operation should cost
 type TransactionCosts struct {
-	SetProcess            uint64 `json:"Tx_SetProcess" state:"c_setProcess"`
-	RegisterKey           uint64 `json:"Tx_RegisterKey" state:"c_registerKey"`
-	NewProcess            uint64 `json:"Tx_NewProcess" state:"c_newProcess"`
-	SendTokens            uint64 `json:"Tx_SendTokens" state:"c_sendTokens"`
-	SetAccountInfo        uint64 `json:"Tx_SetAccountInfo" state:"c_setAccountInfo"`
-	AddDelegateForAccount uint64 `json:"Tx_AddDelegateForAccount" state:"c_addDelegateForAccount"`
-	DelDelegateForAccount uint64 `json:"Tx_DelDelegateForAccount" state:"c_delDelegateForAccount"`
-	CollectFaucet         uint64 `json:"Tx_CollectFaucet" state:"c_collectFaucet"`
+	SetProcess            uint64 `json:"Tx_SetProcess"`
+	RegisterKey           uint64 `json:"Tx_RegisterKey"`
+	NewProcess            uint64 `json:"Tx_NewProcess"`
+	SendTokens            uint64 `json:"Tx_SendTokens"`
+	SetAccountInfo        uint64 `json:"Tx_SetAccountInfo"`
+	AddDelegateForAccount uint64 `json:"Tx_AddDelegateForAccount"`
+	DelDelegateForAccount uint64 `json:"Tx_DelDelegateForAccount"`
+	CollectFaucet         uint64 `json:"Tx_CollectFaucet"`
 }
 
 // StructAsBytes returns the contents of TransactionCosts as a map. Its purpose
 // is to keep knowledge of TransactionCosts' fields within itself, so the
 // function using it only needs to iterate over the key-values.
-func (t *TransactionCosts) StructAsBytes() (b map[string][]byte, err error) {
-	b = make(map[string][]byte)
+func (t *TransactionCosts) StructAsBytes() (map[string][]byte, error) {
+	b := make(map[string][]byte)
 
 	tType := reflect.TypeOf(*t)
 	tValue := reflect.ValueOf(*t)
 	for i := 0; i < tType.NumField(); i++ {
-		key := tType.Field(i).Tag.Get("state")
+		key := TransactionCostsFieldToStateKey(tType.Field(i).Name)
+
 		value := tValue.Field(i).Uint()
 		valueBytes, err := util.Uint64ToBytes(value)
 		if err != nil {
@@ -94,7 +95,15 @@ func (t *TransactionCosts) StructAsBytes() (b map[string][]byte, err error) {
 		}
 		b[key] = valueBytes
 	}
-	return
+	return b, nil
+}
+
+// TransactionCostsFieldToStateKey transforms "SetProcess" to "c_setProcess" for all of
+// TransactionCosts' fields
+func TransactionCostsFieldToStateKey(key string) string {
+	a := []rune(key)
+	a[0] = unicode.ToLower(a[0])
+	return strings.Join([]string{costPrefix, string(a)}, "")
 }
 
 // TransactionCostsFieldFromStateKey transforms "c_setProcess" to "SetProcess" for all of

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -18,6 +18,7 @@ const (
 	voteCacheSize           = 50000
 	NewProcessCost          = 0
 	SetProcessCost          = 0
+	costPrefix              = "c_"
 )
 
 var (
@@ -101,10 +102,10 @@ func (t *TransactionCosts) StructAsBytes() (b map[string][]byte, err error) {
 // TransactionCostsFieldFromStateKey transforms "c_setProcess" to "SetProcess" for all of
 // TransactionCosts' fields
 func TransactionCostsFieldFromStateKey(key string) (string, error) {
-	if key[0:2] != "c_" {
-		return "", fmt.Errorf("state keys must start with 'c_', got %s", key)
+	if key[0:2] != costPrefix {
+		return "", fmt.Errorf("state keys must start with '%s', got %s", costPrefix, key)
 	}
-	name := strings.TrimLeft(key, "c_")
+	name := strings.TrimLeft(key, costPrefix)
 
 	// strings.Title will misbehave when there are punctuation marks in the
 	// string. To clean the input up, we ensure there are only alphabetical

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -59,6 +59,19 @@ type QueryData struct {
 	ProcessType string `json:"type,omitempty"`
 }
 
+// ________________________ TRANSACTION COSTS __________________________
+// TransactionCosts describes how much each operation should cost
+type TransactionCosts struct {
+	SetProcess            uint64 `json:"Tx_SetProcess"`
+	RegisterKey           uint64 `json:"Tx_RegisterKey"`
+	NewProcess            uint64 `json:"Tx_NewProcess"`
+	SendTokens            uint64 `json:"Tx_SendTokens"`
+	SetAccountInfo        uint64 `json:"Tx_SetAccountInfo"`
+	AddDelegateForAccount uint64 `json:"Tx_AddDelegateForAccount"`
+	DelDelegateForAccount uint64 `json:"Tx_DelDelegateForAccount"`
+	CollectFaucet         uint64 `json:"Tx_CollectFaucet"`
+}
+
 // ________________________ GENESIS APP STATE ________________________
 
 // GenesisAppState application state in genesis
@@ -66,6 +79,7 @@ type GenesisAppState struct {
 	Validators []GenesisValidator `json:"validators"`
 	Oracles    []string           `json:"oracles"`
 	Treasurer  string             `json:"treasurer"`
+	TxCost     TransactionCosts   `json:"tx_cost"`
 }
 
 // The rest of these genesis app state types are copied from

--- a/vochain/types_test.go
+++ b/vochain/types_test.go
@@ -1,0 +1,34 @@
+package vochain
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestTransactionCostsStructAsBytes(t *testing.T) {
+	txCosts := TransactionCosts{
+		SetProcess:            10,
+		RegisterKey:           10,
+		NewProcess:            10,
+		SendTokens:            10,
+		SetAccountInfo:        10,
+		AddDelegateForAccount: 10,
+		DelDelegateForAccount: 10,
+		CollectFaucet:         10,
+	}
+	txCostsBytes, err := txCosts.StructAsBytes()
+	qt.Assert(t, err, qt.IsNil)
+
+	expected := map[string][]byte{
+		"c_addDelegateForAccount": {10, 0, 0, 0, 0, 0, 0, 0},
+		"c_collectFaucet":         {10, 0, 0, 0, 0, 0, 0, 0},
+		"c_delDelegateForAccount": {10, 0, 0, 0, 0, 0, 0, 0},
+		"c_newProcess":            {10, 0, 0, 0, 0, 0, 0, 0},
+		"c_registerKey":           {10, 0, 0, 0, 0, 0, 0, 0},
+		"c_sendTokens":            {10, 0, 0, 0, 0, 0, 0, 0},
+		"c_setAccountInfo":        {10, 0, 0, 0, 0, 0, 0, 0},
+		"c_setProcess":            {10, 0, 0, 0, 0, 0, 0, 0},
+	}
+	qt.Assert(t, txCostsBytes, qt.DeepEquals, expected)
+}

--- a/vochain/types_test.go
+++ b/vochain/types_test.go
@@ -42,4 +42,7 @@ func TestTransactionCostsFieldFromStateKey(t *testing.T) {
 
 	_, err = TransactionCostsFieldFromStateKey("c_fictionalField")
 	qt.Assert(t, err, qt.IsNotNil)
+
+	_, err = TransactionCostsFieldFromStateKey("c_")
+	qt.Assert(t, err, qt.ErrorMatches, "state key must have a length greater than .*")
 }

--- a/vochain/types_test.go
+++ b/vochain/types_test.go
@@ -1,6 +1,7 @@
 package vochain
 
 import (
+	"fmt"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -31,4 +32,14 @@ func TestTransactionCostsStructAsBytes(t *testing.T) {
 		"c_setProcess":            {10, 0, 0, 0, 0, 0, 0, 0},
 	}
 	qt.Assert(t, txCostsBytes, qt.DeepEquals, expected)
+}
+
+func TestTransactionCostsFieldFromStateKey(t *testing.T) {
+	fieldName, err := TransactionCostsFieldFromStateKey("c_setProcess")
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, fieldName, qt.Equals, "SetProcess")
+	fmt.Println("Fieldname", fieldName)
+
+	_, err = TransactionCostsFieldFromStateKey("c_fictionalField")
+	qt.Assert(t, err, qt.IsNotNil)
 }


### PR DESCRIPTION
Plus a (not yet used) helper function `TransactionCostsFieldFromStateKey` which should be useful when coding the state updating methods.