### PR TITLE
Don't require processID for getEnvelopeStatus

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -50,7 +50,6 @@ func (c *Client) GetProcessInfo(pid []byte) (*indexertypes.Process, error) {
 func (c *Client) GetEnvelopeStatus(nullifier, pid []byte) (bool, error) {
 	var req api.APIrequest
 	req.Method = "getEnvelopeStatus"
-	req.ProcessID = pid
 	req.Nullifier = nullifier
 	resp, err := c.Request(req, nil)
 	if err != nil {

--- a/rpcapi/votehandlers.go
+++ b/rpcapi/votehandlers.go
@@ -64,11 +64,6 @@ func (a *RPCAPI) submitEnvelope(request *api.APIrequest) (*api.APIresponse, erro
 }
 
 func (r *RPCAPI) getEnvelopeStatus(request *api.APIrequest) (*api.APIresponse, error) {
-	// check pid
-	if len(request.ProcessID) != types.ProcessIDsize {
-		return nil, fmt.Errorf("cannot get envelope status: (malformed processId)")
-
-	}
 	// check nullifier
 	if len(request.Nullifier) != types.VoteNullifierSize {
 		return nil, fmt.Errorf("cannot get envelope status: (malformed nullifier)")


### PR DESCRIPTION
There's no need for the processID in the getEnvelopeStatus call