### PR TITLE
Decode resp message on submitRawTx errors

### DIFF
--- a/rpcapi/votehandlers.go
+++ b/rpcapi/votehandlers.go
@@ -25,11 +25,11 @@ func (r *RPCAPI) submitRawTx(request *api.APIrequest) (*api.APIresponse, error) 
 		return nil, fmt.Errorf("no reply from vochain")
 	}
 	if res.Code != 0 {
-		return nil, fmt.Errorf("%s", res.Data)
+		return nil, fmt.Errorf("%s", string(res.Data))
 	}
 	log.Debugf("broadcasting tx hash:%s", res.Hash)
 	// return nullifier or other info
-	return &api.APIresponse{Payload: fmt.Sprintf("%x", res.Data)}, nil
+	return &api.APIresponse{Payload: fmt.Sprintf("%s", string(res.Data))}, nil
 }
 
 func (a *RPCAPI) submitEnvelope(request *api.APIrequest) (*api.APIresponse, error) {

--- a/rpcapi/votehandlers.go
+++ b/rpcapi/votehandlers.go
@@ -29,7 +29,7 @@ func (r *RPCAPI) submitRawTx(request *api.APIrequest) (*api.APIresponse, error) 
 	}
 	log.Debugf("broadcasting tx hash:%s", res.Hash)
 	// return nullifier or other info
-	return &api.APIresponse{Payload: fmt.Sprintf("%s", string(res.Data))}, nil
+	return &api.APIresponse{Payload: fmt.Sprintf("%x", res.Data)}, nil
 }
 
 func (a *RPCAPI) submitEnvelope(request *api.APIrequest) (*api.APIresponse, error) {


### PR DESCRIPTION
Fixes an issue where messages returned by submitRawTx API methods are encoded in hex