### PR TITLE
Added `OFF_CHAIN_TREE_WEIGHTED` census origin in `verifyProof`

### DIFF
--- a/vochain/proof.go
+++ b/vochain/proof.go
@@ -41,7 +41,7 @@ func VerifyProof(process *models.Process, proof *models.Proof,
 	// check census origin and compute vote digest identifier
 	var verifyProof VerifyProofFunc
 	switch process.CensusOrigin {
-	case models.CensusOrigin_OFF_CHAIN_TREE:
+	case models.CensusOrigin_OFF_CHAIN_TREE, models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED:
 		verifyProof = VerifyProofOffChainTree
 	case models.CensusOrigin_OFF_CHAIN_CA:
 		verifyProof = VerifyProofOffChainCSP


### PR DESCRIPTION
This is an extension of the fix: https://github.com/vocdoni/vocdoni-node/commit/21b51e75f941cc6146258edb2ec2a0ee67bf0f69