### PR TITLE
Upgrade to last arbo version (addBatchInDisk)

### DIFF
--- a/censustreelegacy/arbotree/wrapper.go
+++ b/censustreelegacy/arbotree/wrapper.go
@@ -41,7 +41,13 @@ func NewTree(name, storageDir string, nLevels int, hashFunc arbo.HashFunction) (
 		return nil, err
 	}
 
-	mt, err := arbo.NewTree(database, nLevels, hashFunc)
+	arboConfig := arbo.Config{
+		Database:     database,
+		MaxLevels:    nLevels,
+		HashFunction: hashFunc,
+		// ThresholdNLeafs: not specified, use the default
+	}
+	mt, err := arbo.NewTree(arboConfig)
 	if err != nil {
 		database.Close()
 		return nil, err
@@ -80,7 +86,13 @@ func (t *Tree) Init(name, storageDir string) error {
 		return err
 	}
 
-	mt, err := arbo.NewTree(database, 140, arbo.HashFunctionBlake2b)
+	arboConfig := arbo.Config{
+		Database:     database,
+		MaxLevels:    140,
+		HashFunction: arbo.HashFunctionBlake2b,
+		// ThresholdNLeafs: not specified, use the default
+	}
+	mt, err := arbo.NewTree(arboConfig)
 	if err != nil {
 		database.Close()
 		return err

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/tendermint/tendermint v0.34.13
 	github.com/tendermint/tm-db v0.6.4
 	github.com/timshannon/badgerhold/v3 v3.0.0-20210415132401-e7c90fb5919f
-	github.com/vocdoni/arbo v0.0.0-20211011134549-3f7e76997421
+	github.com/vocdoni/arbo v0.0.0-20211217085703-d56ab859f109
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -2123,8 +2123,9 @@ github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMI
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vocdoni/arbo v0.0.0-20210616072504-a8c7ea980892/go.mod h1:Pikn2YIz/Rt05HWs35QHdpx7IWk4E2G0KdnCX+KRsNs=
-github.com/vocdoni/arbo v0.0.0-20211011134549-3f7e76997421 h1:arYQr9xPfQyf+w2lwG9EGT2sRiKw0m8ih08z2WmevCI=
-github.com/vocdoni/arbo v0.0.0-20211011134549-3f7e76997421/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
+github.com/vocdoni/arbo v0.0.0-20210927131431-d7c756341372/go.mod h1:qJqeB/91mJfvNHaJf04iyLpCZoroqrrjOrQFlDUn0ko=
+github.com/vocdoni/arbo v0.0.0-20211217085703-d56ab859f109 h1:jBbX7NQ5ism7BEfxHe0FzKgGU4sKaFgfi70YOx+68BQ=
+github.com/vocdoni/arbo v0.0.0-20211217085703-d56ab859f109/go.mod h1:6Z6HJMTIDGHnP4pGJpKMqUGPWShwKvBp2BwVV5b6PoQ=
 github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f h1:z7CK3k1yIutKycPY8s2ZbtwUBKMy3xPcLMh12QukLRY=
 github.com/vocdoni/badgerhold/v3 v3.0.0-20210514115050-2d704df3456f/go.mod h1:BoN7UMTA/JcgmNPaoUQq6RwuixhgSrk5PmCMVMKLxpc=
 github.com/vocdoni/blind-ca v0.1.4/go.mod h1:4ouWDqlvXrrNS0Csf3hKA3cuDTmKh6nP7kSXF39nT4s=
@@ -2264,6 +2265,7 @@ go.vocdoni.io/dvote v0.6.1-0.20210130094936-75dbb92de3f0/go.mod h1:NJyERGs2LmEvl
 go.vocdoni.io/dvote v0.6.1-0.20210206210936-a0407e833753/go.mod h1:HhMMtdnkLI3ujk+zcL1frzFg5S7SbvxWtis7RZTq1dA=
 go.vocdoni.io/dvote v1.0.0/go.mod h1:C9wjSWCzy33Bl2sNiF/2ie/oxcERR3uRD2G2c/NDeH0=
 go.vocdoni.io/dvote v1.0.4-0.20210806163627-9494efbc5382/go.mod h1:kl66EQmAjR252HCRQL756bZQnuvcXZZ3HuaABItf+0E=
+go.vocdoni.io/dvote v1.0.4-0.20211025120558-83c64f440044/go.mod h1:t2O6ExMry8na9bqrYiGH4AZ5ukXYAolUnIFGntmS63c=
 go.vocdoni.io/proto v0.1.7/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.8/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
@@ -2447,6 +2449,7 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20210716203947-853a461950ff/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -33,7 +33,13 @@ func New(wTx db.WriteTx, opts Options) (*Tree, error) {
 		wTx = opts.DB.WriteTx()
 		defer wTx.Discard()
 	}
-	tree, err := arbo.NewTreeWithTx(wTx, opts.DB, opts.MaxLevels, opts.HashFunc)
+	arboConfig := arbo.Config{
+		Database:     opts.DB,
+		MaxLevels:    opts.MaxLevels,
+		HashFunction: opts.HashFunc,
+		// ThresholdNLeafs: not specified, use the default
+	}
+	tree, err := arbo.NewTreeWithTx(wTx, arboConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Last arbo's version includes a `ThresholdNLeafs` parameter that is used
    for the `AddBatch` & `AddBatchWithTx` methods, to determine waether to load
    the tree in memory and work there, or to directly work in disk. Both
    approaches parallelize by CPUs. More details:
    https://github.com/vocdoni/arbo/pull/26#issue-1060579815 and
    https://github.com/vocdoni/arbo/blob/d56ab859f109acd5b7a72211e295d687eded7262/tree.go#L49.

This parameter is configurable on tree initialization, if not defined it
uses `arbo.DefaultThresholdNLeafs`, this commit uses the default value,
but if needed in future iterations we can tune it.

With this update, arbo usage should consume much less memory, and memory
peaks from its `arbo.AddBatch` usage should be reduced.