### PR TITLE
Upgrade to last go-blindsecp256k1 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace github.com/timshannon/badgerhold/v3 => github.com/vocdoni/badgerhold/v3 
 require (
 	git.sr.ht/~sircmpwn/go-bare v0.0.0-20210406120253-ab86bc2846d9
 	github.com/766b/chi-prometheus v0.0.0-20180509160047-46ac2b31aa30
-	github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210323162413-ccaa6313370d
+	github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211204171003-644e7408753f
 	github.com/cockroachdb/pebble v0.0.0-20211004132338-b2eb88a71826
 	github.com/cosmos/iavl v0.15.3
 	github.com/deroproject/graviton v0.0.0-20201218180342-ab474f4c94d2

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210203222605-876755a714c3/go.mod h1:10oM1DQMpukFfSzNsjSQG2rE6UjoGsXT4iIxWIiVbu0=
 github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210323162413-ccaa6313370d h1:QRip5Otx+8mDr77Z3AtTi3aq5cksZHyvDarzOo/vj7g=
 github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210323162413-ccaa6313370d/go.mod h1:10oM1DQMpukFfSzNsjSQG2rE6UjoGsXT4iIxWIiVbu0=
+github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211204171003-644e7408753f h1:+9bA9YJEr8gb+F4rsJ2EYIyaB/3+nKcuOiUStTAf1Pg=
+github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211204171003-644e7408753f/go.mod h1:n598ze+TUwDUQ2mbbiKgitcH6UNJlVYX6sLc08iI1nM=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/vochain/proof.go
+++ b/vochain/proof.go
@@ -158,7 +158,7 @@ func VerifyProofOffChainCSP(process *models.Process, proof *models.Proof,
 		if err != nil {
 			return false, nil, fmt.Errorf("cannot compute blind CSP public key: %w", err)
 		}
-		signature, err := blind.NewSignatureFromBytes(p.GetSignature())
+		signature, err := blind.NewSignatureFromBytesUncompressed(p.GetSignature())
 		if err != nil {
 			return false, nil, fmt.Errorf("cannot compute blind CSP signature: %w", err)
 		}


### PR DESCRIPTION
This PR goes paired with https://github.com/vocdoni/blind-csp/pull/7