### PR TITLE
properly parse comma-separated CLI arguments with flag.StringSlice()

### DIFF
--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -111,15 +111,15 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 	// ethereum web3
 	globalCfg.W3Config.ChainType = *flag.StringP("ethChain", "c", "goerli",
 		fmt.Sprintf("Ethereum blockchain to use: %s", ethchain.AvailableChains))
-	globalCfg.W3Config.W3External = *flag.StringArrayP("w3External", "w", []string{},
-		"ethereum web3 endpoint. Supported protocols: http(s)://, ws(s):// and IPC filepath")
+	globalCfg.W3Config.W3External = *flag.StringSliceP("w3External", "w", []string{},
+		"comma-separated list of ethereum web3 endpoints. Supported protocols: http(s)://, ws(s):// and IPC filepath")
 	// ipfs
 	globalCfg.Ipfs.NoInit = *flag.Bool("ipfsNoInit", false,
 		"disable inter planetary file system support")
 	globalCfg.Ipfs.SyncKey = *flag.StringP("ipfsSyncKey", "i", "",
 		"enable IPFS cluster synchronization using the given secret key")
-	globalCfg.Ipfs.SyncPeers = *flag.StringArray("ipfsSyncPeers", []string{},
-		"use custom ipfsSync peers/bootnodes for accessing the DHT")
+	globalCfg.Ipfs.SyncPeers = *flag.StringSlice("ipfsSyncPeers", []string{},
+		"use custom ipfsSync peers/bootnodes for accessing the DHT (comma-separated)")
 	// vochain
 	globalCfg.VochainConfig.P2PListen = *flag.String("vochainP2PListen", "0.0.0.0:26656",
 		"p2p host and port to listent for the voting chain")
@@ -135,9 +135,9 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 		"tendermint node log level (error, info, debug, none)")
 	globalCfg.VochainConfig.LogLevelMemPool = *flag.String("vochainLogLevelMemPool", "error",
 		"tendermint mempool log level")
-	globalCfg.VochainConfig.Peers = *flag.StringArray("vochainPeers", []string{},
+	globalCfg.VochainConfig.Peers = *flag.StringSlice("vochainPeers", []string{},
 		"comma-separated list of p2p peers")
-	globalCfg.VochainConfig.Seeds = *flag.StringArray("vochainSeeds", []string{},
+	globalCfg.VochainConfig.Seeds = *flag.StringSlice("vochainSeeds", []string{},
 		"comma-separated list of p2p seed nodes")
 	globalCfg.VochainConfig.MinerKey = *flag.String("vochainMinerKey", "",
 		"user alternative vochain miner private key (hexstring[64])")
@@ -157,9 +157,9 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 		"index slot used by this node if it is a key keeper")
 	globalCfg.VochainConfig.ImportPreviousCensus = *flag.Bool("importPreviousCensus", false,
 		"if enabled the census downloader will import all existing census")
-	globalCfg.VochainConfig.EthereumWhiteListAddrs = *flag.StringArray("ethereumWhiteListAddrs",
+	globalCfg.VochainConfig.EthereumWhiteListAddrs = *flag.StringSlice("ethereumWhiteListAddrs",
 		[]string{},
-		"list of ethereum addresses allowed to create processes on the vochain (oracle mode only)")
+		"comma-separated list of ethereum addresses allowed to create processes on the vochain (oracle mode only)")
 	globalCfg.VochainConfig.ProcessArchive = *flag.Bool("processArchive", false,
 		"enables the process archiver component")
 	globalCfg.VochainConfig.ProcessArchiveKey = *flag.String("processArchiveKey", "",

--- a/cmd/ipfsSync/ipfsSync.go
+++ b/cmd/ipfsSync/ipfsSync.go
@@ -41,12 +41,12 @@ func main() {
 	port := flag.Int16("port", 4171, "port for the sync network")
 	helloInterval := flag.Int("helloInterval", 40, "period in seconds for sending hello messages")
 	updateInterval := flag.Int("updateInterval", 20, "period in seconds for sending update messages")
-	peers := flag.StringArray("peers", []string{},
+	peers := flag.StringSlice("peers", []string{},
 		"custom list of peers to connect to (multiaddresses separated by commas)")
 	private := flag.Bool("private", false,
 		"if enabled a private libp2p network will be created (using the secret key at transport layer)")
-	bootnodes := flag.StringArray("bootnodes", []string{},
-		"list of bootnodes (multiaddress separated by commas)")
+	bootnodes := flag.StringSlice("bootnodes", []string{},
+		"list of bootnodes (multiaddresses separated by commas)")
 	bootnode := flag.Bool("bootnode", false,
 		"act as a bootstrap node (will not try to connect with other bootnodes)")
 


### PR DESCRIPTION
i came across this subtle issue while working on something unrelated.

in dvotenode and ipfsSync, `flag.StringArray()` is used to parse some arguments that are described as 'comma-separated' lists. `flag.StringSlice()` should be used instead, which does split arguments on commas, unlike StringArray which only creates an array if specified multiple times (`--arg val1 --arg val2`)

(StringSlice() accepts and parses both forms, no regression here)

<details>
 <summary>Here's a small PoC</summary>

```go
package main

import (
	"fmt"
	"strings"

	flag "github.com/spf13/pflag"
	"github.com/spf13/viper"
	"go.vocdoni.io/dvote/config"
)

func main() {
	globalCfg := config.NewConfig()

	peers := flag.StringArray("arrayPeers", []string{},
		"comma-separated list of p2p peers")
	seeds := flag.StringSlice("sliceSeeds", []string{},
		"comma-separated list of p2p seed nodes")

	// parse flags
	flag.Parse()

	fmt.Println("pflag array", peers)
	fmt.Println("pflag slice", seeds)

	// setting up viper
	viper := viper.New()
	viper.SetConfigName("dvote")
	viper.SetConfigType("yml")
	viper.SetEnvPrefix("DVOTE")
	viper.AutomaticEnv()
	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

	viper.BindPFlag("vochainConfig.Peers", flag.Lookup("arrayPeers"))
	viper.BindPFlag("vochainConfig.Seeds", flag.Lookup("sliceSeeds"))
	err := viper.Unmarshal(&globalCfg)
	if err != nil {
		fmt.Errorf("cannot unmarshal loaded config file: %s", err)
	}

	fmt.Println("globalCfg Peers", globalCfg.VochainConfig.Peers)
	fmt.Println("globalCfg Seeds", globalCfg.VochainConfig.Seeds)
}
```

</details>

```
$ go run test.go --arrayPeers a,b --arrayPeers c --sliceSeeds x,y --sliceSeeds z
pflag array &[a,b c]
pflag slice &[x y z]
globalCfg Peers [a,b c]
globalCfg Seeds [x y z]
$ DVOTE_VOCHAINCONFIG_PEERS="a,b,c" go run test.go  --sliceSeeds x,y --sliceSeeds z
pflag array &[]
pflag slice &[x y z]
globalCfg Peers [a b c]
globalCfg Seeds [x y z]
```

see also that this is inconsistent with how viper parses config

in dvotenode this subtle issue goes unnoticed since for example Peers ends up being `strings.Join`ed with commas anyway.		
```
    tconfig.P2P.PersistentPeers = strings.Trim(strings.Join(localConfig.Peers, ","), "[]\"")
```

but in the case of ipfsSync it's a current bug. see the second --peers is not properly split

```
$ go run cmd/ipfsSync/ipfsSync.go --peers /ip4/1.2.3.4/tcp/4001/p2p/QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc --peers /ip4/5.6.7.8/tcp/4001/p2p/QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc,/ip6/2600::1/tcp/4001/p2p/QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc
[...]
2022-01-09T14:19:13+01:00	INFO	ipfsSync/ipfsSync.go:117	connecting to peer /ip4/1.2.3.4/tcp/4001/p2p/QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc
2022-01-09T14:19:18+01:00	WARN	ipfsSync/ipfsSync.go:119	cannot connect to custom peer: (failed to dial QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc:
  * [/ip4/1.2.3.4/tcp/4001] dial tcp4 0.0.0.0:4171->1.2.3.4:4001: i/o timeout)
2022-01-09T14:19:20+01:00	INFO	ipfsSync/ipfsSync.go:117	connecting to peer /ip4/178.190.108.8/tcp/4001/p2p/QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc,/ip6/2a02:c207:2039:730:fede::feca/tcp/4001/p2p/QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc
2022-01-09T14:19:20+01:00	WARN	ipfsSync/ipfsSync.go:119	cannot connect to custom peer: (failed to parse multiaddr "/ip4/178.190.108.8/tcp/4001/p2p/QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc,/ip6/2a02:c207:2039:730:fede::feca/tcp/4001/p2p/QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc": invalid value "QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc," for protocol p2p: failed to parse p2p addr: QmNsE8FjCngCtBGPntF4AZcB6DUt2Uz9ZnFPLpv3KmUKvc, input isn't valid multihash)
```


to make everything consistent, i just replaced all ocurrences of `flag.StringArray()` in this PR