### PR TITLE
switch to a new signing strategy

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -164,6 +164,7 @@ type APIresponse struct {
 	CensusKeys           [][]byte                         `json:"censusKeys,omitempty"`
 	CensusDump           []byte                           `json:"censusDump,omitempty"`
 	CensusValue          []byte                           `json:"censusValue,omitempty"`
+	ChainID              string                           `json:"chainId,omitempty"`
 	CircuitIndex         *int                             `json:"circuitIndex,omitempty"`
 	CircuitConfig        *artifacts.CircuitConfig         `json:"circuitConfig,omitempty"`
 	Content              []byte                           `json:"content,omitempty"`

--- a/benchmark/vochain_benchmark_test.go
+++ b/benchmark/vochain_benchmark_test.go
@@ -156,7 +156,7 @@ func BenchmarkVochain(b *testing.B) {
 	if err != nil {
 		b.Fatal("cannot marshal process")
 	}
-	stx.Signature, err = dvoteServer.Signer.Sign(stx.Tx)
+	stx.Signature, err = dvoteServer.Signer.SignVocdoni(stx.Tx)
 	if err != nil {
 		b.Fatalf("cannot sign oracle tx: %s", err)
 	}
@@ -262,7 +262,7 @@ func voteBench(b *testing.B, cl *client.Client, s *ethereum.SignKeys,
 	if err != nil {
 		b.Fatal(err)
 	}
-	stx.Signature, err = s.Sign(stx.Tx)
+	stx.Signature, err = s.SignVocdoni(stx.Tx)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/benchmark/vochain_benchmark_test.go
+++ b/benchmark/vochain_benchmark_test.go
@@ -156,7 +156,7 @@ func BenchmarkVochain(b *testing.B) {
 	if err != nil {
 		b.Fatal("cannot marshal process")
 	}
-	stx.Signature, err = dvoteServer.Signer.SignVocdoni(stx.Tx)
+	stx.Signature, err = dvoteServer.Signer.SignVocdoniTx(stx.Tx)
 	if err != nil {
 		b.Fatalf("cannot sign oracle tx: %s", err)
 	}
@@ -262,7 +262,7 @@ func voteBench(b *testing.B, cl *client.Client, s *ethereum.SignKeys,
 	if err != nil {
 		b.Fatal(err)
 	}
-	stx.Signature, err = s.SignVocdoni(stx.Tx)
+	stx.Signature, err = s.SignVocdoniTx(stx.Tx)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -329,7 +329,7 @@ func (c *Client) GetCSPproofBatch(signers []*ethereum.SignKeys,
 		if err != nil {
 			log.Fatal(err)
 		}
-		signature, err := ca.SignEthereum(bundleBytes)
+		signature, err := ca.SignVocdoniMsg(bundleBytes)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -355,7 +355,7 @@ func (c *Client) GetCSPproofBatch(signers []*ethereum.SignKeys,
 // generate a secretKey from a signature by the ethereum key.
 func testGetZKCensusKey(s *ethereum.SignKeys) ([]byte, []byte) {
 	// secret is 65 bytes
-	secret, err := s.SignEthereum([]byte("secretKey"))
+	secret, err := s.SignVocdoniMsg([]byte("secretKey"))
 	if err != nil {
 		log.Fatalf("Cannot sign: %v", err)
 	}
@@ -589,7 +589,7 @@ func (c *Client) TestPreRegisterKeys(
 			return 0, err
 		}
 
-		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -636,7 +636,7 @@ func (c *Client) TestPreRegisterKeys(
 			if err != nil {
 				return 0, err
 			}
-			if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
+			if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
 				return 0, err
 			}
 			if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -787,7 +787,7 @@ func (c *Client) TestSendVotes(
 			return 0, err
 		}
 
-		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -958,7 +958,7 @@ func (c *Client) TestSendAnonVotes(
 			return 0, err
 		}
 
-		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1100,7 +1100,7 @@ func (c *Client) CreateProcess(oracle *ethereum.SignKeys,
 	if err != nil {
 		return 0, err
 	}
-	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
 		return 0, err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1143,7 +1143,7 @@ func (c *Client) EndProcess(oracle *ethereum.SignKeys, pid []byte) error {
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {

--- a/client/api.go
+++ b/client/api.go
@@ -33,6 +33,19 @@ type pkeys struct {
 	priv []api.Key
 }
 
+func (c *Client) GetChainID() (string, error) {
+	var req api.APIrequest
+	req.Method = "getInfo"
+	resp, err := c.Request(req, nil)
+	if err != nil {
+		return "", err
+	}
+	if !resp.Ok {
+		return "", fmt.Errorf("cannot get chain ID: %v", resp.Message)
+	}
+	return resp.ChainID, nil
+}
+
 func (c *Client) GetProcessInfo(pid []byte) (*indexertypes.Process, error) {
 	var req api.APIrequest
 	req.Method = "getProcessInfo"
@@ -316,7 +329,7 @@ func (c *Client) GetCSPproofBatch(signers []*ethereum.SignKeys,
 		if err != nil {
 			log.Fatal(err)
 		}
-		signature, err := ca.Sign(bundleBytes)
+		signature, err := ca.SignEthereum(bundleBytes)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -342,7 +355,7 @@ func (c *Client) GetCSPproofBatch(signers []*ethereum.SignKeys,
 // generate a secretKey from a signature by the ethereum key.
 func testGetZKCensusKey(s *ethereum.SignKeys) ([]byte, []byte) {
 	// secret is 65 bytes
-	secret, err := s.Sign([]byte("secretKey"))
+	secret, err := s.SignEthereum([]byte("secretKey"))
 	if err != nil {
 		log.Fatalf("Cannot sign: %v", err)
 	}
@@ -576,7 +589,7 @@ func (c *Client) TestPreRegisterKeys(
 			return 0, err
 		}
 
-		if stx.Signature, err = s.Sign(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -623,7 +636,7 @@ func (c *Client) TestPreRegisterKeys(
 			if err != nil {
 				return 0, err
 			}
-			if stx.Signature, err = s.Sign(stx.Tx); err != nil {
+			if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
 				return 0, err
 			}
 			if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -774,7 +787,7 @@ func (c *Client) TestSendVotes(
 			return 0, err
 		}
 
-		if stx.Signature, err = s.Sign(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -945,7 +958,7 @@ func (c *Client) TestSendAnonVotes(
 			return 0, err
 		}
 
-		if stx.Signature, err = s.Sign(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1087,7 +1100,7 @@ func (c *Client) CreateProcess(oracle *ethereum.SignKeys,
 	if err != nil {
 		return 0, err
 	}
-	if stx.Signature, err = oracle.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
 		return 0, err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1130,7 +1143,7 @@ func (c *Client) EndProcess(oracle *ethereum.SignKeys, pid []byte) error {
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = oracle.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {

--- a/client/connection.go
+++ b/client/connection.go
@@ -67,7 +67,7 @@ func (c *Client) Request(req api.APIrequest, signer *ethereum.SignKeys) (*api.AP
 	}
 	var signature []byte
 	if signer != nil {
-		signature, err = signer.Sign(reqInner)
+		signature, err = signer.SignEthereum(reqInner)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %v", method, err)
 		}

--- a/client/connection.go
+++ b/client/connection.go
@@ -67,7 +67,7 @@ func (c *Client) Request(req api.APIrequest, signer *ethereum.SignKeys) (*api.AP
 	}
 	var signature []byte
 	if signer != nil {
-		signature, err = signer.SignEthereum(reqInner)
+		signature, err = signer.SignVocdoniMsg(reqInner)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %v", method, err)
 		}

--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -537,6 +537,10 @@ func main() {
 			log.Infof("[vochain info] replaying height %d at %d blocks/s",
 				h, (h-hPrev)/5)
 		}
+		if signer != nil {
+			signer.VocdoniChainID = vochainApp.ChainID()
+		}
+		log.Infof("vochain chainID %s", vochainApp.ChainID())
 	}
 
 	//

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -282,6 +282,12 @@ func mkTreeVoteTest(host,
 	}
 	defer mainClient.Close()
 
+	// Get the chain ID for signing the transactions
+	oracleKey.VocdoniChainID, err = mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
@@ -347,6 +353,12 @@ func mkTreeVoteTest(host,
 		log.Infof("all gateways retrieved the census! let's start voting")
 	}
 
+	// Get chainID
+	chID, err := mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Send votes
 	i := 0
 	p := len(censusKeys) / len(clients)
@@ -371,6 +383,9 @@ func mkTreeVoteTest(host,
 			copy(gwSigners, censusKeys[i:i+p])
 			gwProofs = make([]*client.Proof, p)
 			copy(gwProofs, proofs[i:i+p])
+		}
+		for _, gws := range gwSigners {
+			gws.VocdoniChainID = chID
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -503,6 +518,12 @@ func mkTreeAnonVoteTest(host,
 	}
 	defer mainClient.Close()
 
+	// Get the chain ID for signing the transactions
+	oracleKey.VocdoniChainID, err = mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
@@ -568,6 +589,12 @@ func mkTreeAnonVoteTest(host,
 		log.Infof("all gateways retrieved the census! let's start voting")
 	}
 
+	// Get chainID
+	chID, err := mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Pre-register keys zkCensusKey
 	i := 0
 	p := len(censusKeys) / len(clients)
@@ -592,6 +619,9 @@ func mkTreeAnonVoteTest(host,
 			copy(gwSigners, censusKeys[i:i+p])
 			gwProofs = make([]*client.Proof, p)
 			copy(gwProofs, proofs[i:i+p])
+		}
+		for _, gws := range gwSigners {
+			gws.VocdoniChainID = chID
 		}
 		log.Infof("%s will receive %d register keys", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -673,6 +703,9 @@ func mkTreeAnonVoteTest(host,
 		} else {
 			gwSigners = make([]*ethereum.SignKeys, p)
 			copy(gwSigners, censusKeys[i:i+p])
+		}
+		for _, gws := range gwSigners {
+			gws.VocdoniChainID = chID
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -788,6 +821,12 @@ func cspVoteTest(
 	}
 	defer mainClient.Close()
 
+	// Get the chain ID for signing the transactions
+	oracleKey.VocdoniChainID, err = mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
@@ -833,6 +872,12 @@ func cspVoteTest(
 		clients = append(clients, cl)
 	}
 
+	// Get chainID
+	chID, err := mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Send votes
 	i := 0
 	p := len(voters) / len(clients)
@@ -852,6 +897,9 @@ func cspVoteTest(
 		} else {
 			gwSigners = make([]*ethereum.SignKeys, p)
 			copy(gwSigners, voters[i:i+p])
+		}
+		for _, gws := range gwSigners {
+			gws.VocdoniChainID = chID
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl

--- a/crypto/ethereum/ethereum_test.go
+++ b/crypto/ethereum/ethereum_test.go
@@ -29,7 +29,8 @@ func TestSignature(t *testing.T) {
 	}
 	pub, priv = s2.HexString()
 	t.Logf("Imported pub:%s priv:%s", pub, priv)
-	v, err := s.Verify(message, msgSign)
+	s2.AddAuthKey(s.Address())
+	v, _, err := s2.VerifySender(message, msgSign)
 	if err != nil {
 		t.Fatalf("Verification error: %s", err)
 	}
@@ -104,7 +105,7 @@ func TestAddr(t *testing.T) {
 		t.Fatal("Cannot verify sender")
 	}
 
-	v, err = s.Verify(msg, signature)
+	v, _, err = s.VerifySender(msg, signature)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/crypto/ethereum/ethereum_test.go
+++ b/crypto/ethereum/ethereum_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/hex"
 	"testing"
+
+	qt "github.com/frankban/quicktest"
 )
 
 func TestSignature(t *testing.T) {
@@ -18,22 +20,17 @@ func TestSignature(t *testing.T) {
 	message := []byte("hello")
 	t.Logf("Message to sign: %s", message)
 	msgSign, err := s.SignEthereum(message)
-	if err != nil {
-		t.Fatalf("Error while signing %s", err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	t.Logf("Signature is %s", msgSign)
 
 	s2 := NewSignKeys()
-	if err := s2.AddHexKey(priv); err != nil {
-		t.Fatalf("Error importing hex privKey: %s", err)
-	}
+	err = s2.AddHexKey(priv)
+	qt.Assert(t, err, qt.IsNil)
 	pub, priv = s2.HexString()
 	t.Logf("Imported pub:%s priv:%s", pub, priv)
 	s2.AddAuthKey(s.Address())
 	v, _, err := s2.VerifySender(message, msgSign)
-	if err != nil {
-		t.Fatalf("Verification error: %s", err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	if !v {
 		t.Fatal("Verification failed!")
 	}
@@ -42,21 +39,16 @@ func TestSignature(t *testing.T) {
 	t.Log("Testing compatibility with standard Ethereum signing libraries")
 	hardcodedPriv := "fad9c8855b740a0b7ed4c221dbad0f33a83a49cad6b3fe8d5817ac83d38b6a19"
 	hardcodedSignature, err := hex.DecodeString("a0d0ebc374d2a4d6357eaca3da2f5f3ff547c3560008206bc234f9032a866ace6279ffb4093fb39c8bbc39021f6a5c36ef0e813c8c94f325a53f4f395a5c82de01")
-	if err != nil {
-		t.Fatal(err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	s3 := NewSignKeys()
-	if err := s3.AddHexKey(hardcodedPriv); err != nil {
-		t.Fatal(err)
-	}
+	err = s3.AddHexKey(hardcodedPriv)
+	qt.Assert(t, err, qt.IsNil)
 	_, priv = s3.HexString()
 	if priv != hardcodedPriv {
 		t.Fatalf("PrivKey from %s not match the hardcoded one\nGot %s\nMust have %s", hardcodedPriv, priv, hardcodedPriv[2:])
 	}
 	signature, err := s3.SignEthereum(message)
-	if err != nil {
-		t.Fatal(err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	t.Logf("Signature: %s", signature)
 	if !bytes.Equal(signature, hardcodedSignature) {
 		t.Fatalf("Hardcoded signature %s do not match", hardcodedSignature)
@@ -74,54 +66,40 @@ func TestAddr(t *testing.T) {
 	t.Logf("Generated pub: %s \npriv: %s", pub, priv)
 	addr1 := s.AddressString()
 	addr2, err := AddrFromPublicKey(s.PublicKey())
+	qt.Assert(t, err, qt.IsNil)
 	t.Logf("Recovered address from pubKey %s", addr2)
-	if err != nil {
-		t.Fatal(err)
-	}
 	if addr1 != addr2.String() {
 		t.Fatalf("Calculated address from pubKey do not match: %s != %s", addr1, addr2)
 	}
 	msg := []byte("hello vocdoni")
 	signature, err := s.SignEthereum(msg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	t.Logf("Signature created: %s", signature)
 	addr3, err := AddrFromSignature(msg, signature)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// addr3s := fmt.Sprintf("%x", addr3)
+	qt.Assert(t, err, qt.IsNil)
+
 	if addr3 != addr2 {
 		t.Fatalf("Extracted signature address do not match: %s != %s", addr2, addr3)
 	}
 
 	s.AddAuthKey(addr3)
 	v, _, err := s.VerifySender(msg, signature)
-	if err != nil {
-		t.Fatal(err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	if !v {
 		t.Fatal("Cannot verify sender")
 	}
 
 	v, _, err = s.VerifySender(msg, signature)
-	if err != nil {
-		t.Fatal(err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	if !v {
 		t.Fatal("Cannot verify signature")
 	}
 
 	msg = []byte("bye-bye vocdoni")
 	signature2, err := s.SignEthereum(msg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	addr4, err := AddrFromSignature(msg, signature2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	qt.Assert(t, err, qt.IsNil)
 	if addr4 != addr3 {
 		t.Fatal("extracted address from second message do not match")
 	}

--- a/crypto/ethereum/ethereum_test.go
+++ b/crypto/ethereum/ethereum_test.go
@@ -17,7 +17,7 @@ func TestSignature(t *testing.T) {
 	t.Logf("Generated pub:%s priv:%s", pub, priv)
 	message := []byte("hello")
 	t.Logf("Message to sign: %s", message)
-	msgSign, err := s.Sign(message)
+	msgSign, err := s.SignEthereum(message)
 	if err != nil {
 		t.Fatalf("Error while signing %s", err)
 	}
@@ -52,7 +52,7 @@ func TestSignature(t *testing.T) {
 	if priv != hardcodedPriv {
 		t.Fatalf("PrivKey from %s not match the hardcoded one\nGot %s\nMust have %s", hardcodedPriv, priv, hardcodedPriv[2:])
 	}
-	signature, err := s3.Sign(message)
+	signature, err := s3.SignEthereum(message)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestAddr(t *testing.T) {
 		t.Fatalf("Calculated address from pubKey do not match: %s != %s", addr1, addr2)
 	}
 	msg := []byte("hello vocdoni")
-	signature, err := s.Sign(msg)
+	signature, err := s.SignEthereum(msg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestAddr(t *testing.T) {
 	}
 
 	msg = []byte("bye-bye vocdoni")
-	signature2, err := s.Sign(msg)
+	signature2, err := s.SignEthereum(msg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/crypto/ethereum/vocdoni_test.go
+++ b/crypto/ethereum/vocdoni_test.go
@@ -1,0 +1,69 @@
+package ethereum
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestVocdoniSignature(t *testing.T) {
+	t.Parallel()
+
+	s := NewSignKeys()
+	if err := s.Generate(); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv := s.HexString()
+	t.Logf("Generated pub:%s priv:%s", pub, priv)
+
+	msg := testVocdoniSignatureMessage{Method: "getVisibility", Timestamp: 1582196988222}
+	message, err := json.Marshal(msg)
+	qt.Assert(t, err, qt.IsNil)
+
+	t.Logf("Message to sign: %s", message)
+	signature, err := s.SignVocdoniMsg(message)
+	qt.Assert(t, err, qt.IsNil)
+	t.Logf("Signature for message is %x", signature)
+
+	extractedPubKey, err := PubKeyFromSignature(BuildVocdoniMessage(message), signature)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, fmt.Sprintf("%x", extractedPubKey), qt.DeepEquals, pub)
+
+	t.Logf("Transaction to sign: %s", message)
+	s.VocdoniChainID = "chain-123"
+	signature, err = s.SignVocdoniTx(message)
+	qt.Assert(t, err, qt.IsNil)
+	t.Logf("Signature for transaction is %x", signature)
+
+	extractedPubKey, err = PubKeyFromSignature(BuildVocdoniTransaction(message, "chain-123"), signature)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, fmt.Sprintf("%x", extractedPubKey), qt.DeepEquals, pub)
+
+	// Test compatibility with JS (message)
+	msg = testVocdoniSignatureMessage{Method: "getVisibility", Timestamp: 1582196988554}
+	message, err = json.Marshal(msg)
+	qt.Assert(t, err, qt.IsNil)
+	signature, err = hex.DecodeString("2aab382d8cf025f55d8c3f7597e83dc878939ef63f1a27b818fa0814d79e91d66dc8d8112fbdcc89d2355d58a74ad227a2a9603ef7eb2321283a8ea93fb90ee11b")
+	qt.Assert(t, err, qt.IsNil)
+
+	extractedPubKey, err = PubKeyFromSignature(BuildVocdoniMessage(message), signature)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, fmt.Sprintf("%x", extractedPubKey), qt.DeepEquals, "02cb3cabb521d84fc998b5649d6b59e27a3e27633d31cc0ca6083a00d68833d5ca")
+
+	// Test compatibility with JS (transaction)
+	signature, err = hex.DecodeString("44d31937862e1f835f92d8b3f93858636bad075bd2429cf79404a81e42bd3d00196613c37a99b054c32339dde53ce3c25932c5d5f89483ccdf93234d3c4808b81b")
+	qt.Assert(t, err, qt.IsNil)
+
+	extractedPubKey, err = PubKeyFromSignature(BuildVocdoniTransaction(message, "production"), signature)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, fmt.Sprintf("%x", extractedPubKey), qt.DeepEquals, "02cb3cabb521d84fc998b5649d6b59e27a3e27633d31cc0ca6083a00d68833d5ca")
+
+}
+
+type testVocdoniSignatureMessage struct {
+	Method    string `json:"method"`
+	Timestamp int    `json:"timestamp"`
+}

--- a/ethereum/ethevents/handlers.go
+++ b/ethereum/ethevents/handlers.go
@@ -141,7 +141,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal newProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.Sign(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -181,7 +181,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal setProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.Sign(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -235,7 +235,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal setProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.Sign(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -277,7 +277,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal admin tx (addOracle): %w", err)
 		}
-		stx.Signature, err = e.Signer.Sign(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -324,7 +324,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal admin tx (removeOracle): %w", err)
 		}
-		stx.Signature, err = e.Signer.Sign(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}

--- a/ethereum/ethevents/handlers.go
+++ b/ethereum/ethevents/handlers.go
@@ -141,7 +141,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal newProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -181,7 +181,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal setProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -235,7 +235,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal setProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -277,7 +277,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal admin tx (addOracle): %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -324,7 +324,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal admin tx (removeOracle): %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoni(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}

--- a/httprouter/jsonrpcapi/jsonrpcapi.go
+++ b/httprouter/jsonrpcapi/jsonrpcapi.go
@@ -217,7 +217,9 @@ func (s *SignedJRPC) getRequest(payload []byte) (*SignedJRPCdata, error) {
 	}
 
 	var err error
-	if request.SignaturePublicKey, err = ethereum.PubKeyFromSignature(reqOuter.MessageAPI, reqOuter.Signature); err != nil {
+	if request.SignaturePublicKey, err = ethereum.PubKeyFromSignature(
+		ethereum.BuildVocdoniMessage(reqOuter.MessageAPI),
+		reqOuter.Signature); err != nil {
 		return request, err
 	}
 

--- a/httprouter/jsonrpcapi/jsonrpcapi_test.go
+++ b/httprouter/jsonrpcapi/jsonrpcapi_test.go
@@ -124,7 +124,7 @@ func doRequest(t *testing.T, url, method string, signer *ethereum.SignKeys, msg 
 	qt.Check(t, err, qt.IsNil)
 	signature := []byte{}
 	if signer != nil {
-		signature, err = signer.Sign(data)
+		signature, err = signer.SignEthereum(data)
 		qt.Check(t, err, qt.IsNil)
 	}
 	msgReq := RequestMessage{

--- a/httprouter/jsonrpcapi/jsonrpcapi_test.go
+++ b/httprouter/jsonrpcapi/jsonrpcapi_test.go
@@ -124,7 +124,7 @@ func doRequest(t *testing.T, url, method string, signer *ethereum.SignKeys, msg 
 	qt.Check(t, err, qt.IsNil)
 	signature := []byte{}
 	if signer != nil {
-		signature, err = signer.SignEthereum(data)
+		signature, err = signer.SignVocdoniMsg(data)
 		qt.Check(t, err, qt.IsNil)
 	}
 	msgReq := RequestMessage{

--- a/httprouter/jsonrpcapi/message.go
+++ b/httprouter/jsonrpcapi/message.go
@@ -46,7 +46,7 @@ func BuildReply(signer *ethereum.SignKeys, msg MessageAPI, requestID string) ([]
 		return nil, err
 	}
 
-	respRequest.Signature, err = signer.Sign(respRequest.MessageAPI)
+	respRequest.Signature, err = signer.SignEthereum(respRequest.MessageAPI)
 	if err != nil {
 		log.Error(err)
 		// continue without the signature

--- a/httprouter/jsonrpcapi/message.go
+++ b/httprouter/jsonrpcapi/message.go
@@ -46,7 +46,7 @@ func BuildReply(signer *ethereum.SignKeys, msg MessageAPI, requestID string) ([]
 		return nil, err
 	}
 
-	respRequest.Signature, err = signer.SignEthereum(respRequest.MessageAPI)
+	respRequest.Signature, err = signer.SignVocdoniMsg(respRequest.MessageAPI)
 	if err != nil {
 		log.Error(err)
 		// continue without the signature

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -82,7 +82,7 @@ func (o *Oracle) NewProcess(process *models.Process) error {
 	if err != nil {
 		return fmt.Errorf("cannot marshal newProcess tx: %w", err)
 	}
-	stx.Signature, err = o.signer.Sign(stx.Tx)
+	stx.Signature, err = o.signer.SignVocdoni(stx.Tx)
 	if err != nil {
 		return fmt.Errorf("cannot sign oracle tx: %w", err)
 	}
@@ -151,7 +151,7 @@ func (o *Oracle) OnComputeResults(results *indexertypes.Results, proc *indexerty
 		log.Errorf("cannot marshal setProcessResults tx: %v", err)
 		return
 	}
-	if stx.Signature, err = o.signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = o.signer.SignVocdoni(stx.Tx); err != nil {
 		log.Errorf("cannot sign oracle tx: %v", err)
 		return
 	}

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -82,7 +82,7 @@ func (o *Oracle) NewProcess(process *models.Process) error {
 	if err != nil {
 		return fmt.Errorf("cannot marshal newProcess tx: %w", err)
 	}
-	stx.Signature, err = o.signer.SignVocdoni(stx.Tx)
+	stx.Signature, err = o.signer.SignVocdoniTx(stx.Tx)
 	if err != nil {
 		return fmt.Errorf("cannot sign oracle tx: %w", err)
 	}
@@ -151,7 +151,7 @@ func (o *Oracle) OnComputeResults(results *indexertypes.Results, proc *indexerty
 		log.Errorf("cannot marshal setProcessResults tx: %v", err)
 		return
 	}
-	if stx.Signature, err = o.signer.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = o.signer.SignVocdoniTx(stx.Tx); err != nil {
 		log.Errorf("cannot sign oracle tx: %v", err)
 		return
 	}

--- a/rpcapi/healthinfo.go
+++ b/rpcapi/healthinfo.go
@@ -18,6 +18,9 @@ const (
 func (a *RPCAPI) info(request *api.APIrequest) (*api.APIresponse, error) {
 	response := api.APIresponse{}
 	response.APIList = a.APIs
+	if a.vocapp != nil {
+		response.ChainID = a.vocapp.ChainID()
+	}
 	if health, err := getHealth(); err == nil {
 		response.Health = health
 	} else {

--- a/vochain/account.go
+++ b/vochain/account.go
@@ -178,9 +178,7 @@ func (v *State) GetAccount(address common.Address, isQuery bool) (*Account, erro
 // VerifyAccountBalance extracts an account address from a signed message, and verifies if
 // there is enough balance to cover an amount expense
 func (v *State) VerifyAccountBalance(message, signature []byte, amount uint64) (bool, common.Address, error) {
-	var err error
-	address := common.Address{}
-	address, err = ethereum.AddrFromSignature(message, signature)
+	address, err := ethereum.AddrFromSignature(message, signature)
 	if err != nil {
 		return false, address, err
 	}

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -60,7 +60,7 @@ func testSetAccountInfoTx(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -60,7 +60,7 @@ func testSetAccountInfoTx(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/admintx_test.go
+++ b/vochain/admintx_test.go
@@ -61,7 +61,7 @@ func testAddOracle(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -136,7 +136,7 @@ func testRemoveOracle(t *testing.T, oracle *ethereum.SignKeys,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/admintx_test.go
+++ b/vochain/admintx_test.go
@@ -61,7 +61,7 @@ func testAddOracle(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -136,7 +136,7 @@ func testRemoveOracle(t *testing.T, oracle *ethereum.SignKeys,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -96,7 +96,7 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 		if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: tx}}); err != nil {
 			b.Fatal(err)
 		}
-		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
 			b.Fatal(err)
 		}
 		voters = append(voters, &stx)

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -96,7 +96,7 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 		if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: tx}}); err != nil {
 			b.Fatal(err)
 		}
-		if stx.Signature, err = s.Sign(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
 			b.Fatal(err)
 		}
 		voters = append(voters, &stx)

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -186,8 +186,8 @@ var Genesis = map[string]VochainGenesis{
 		},
 		Genesis: `
 {
-   "genesis_time":"2021-12-17T19:43:28.668436552Z",
-   "chain_id":"vocdoni-development-59",
+   "genesis_time":"2022-01-20T19:43:28.668436552Z",
+   "chain_id":"vocdoni-development-60",
    "consensus_params":{
       "block":{
          "max_bytes":"5120000",

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -484,7 +484,7 @@ func (k *KeyKeeper) signAndSendTx(tx *models.AdminTx) error {
 	if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Admin{Admin: tx}}); err != nil {
 		return err
 	}
-	if stx.Signature, err = k.signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = k.signer.SignVocdoni(stx.Tx); err != nil {
 		return err
 	}
 	vtxBytes, err := proto.Marshal(stx)

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -484,7 +484,7 @@ func (k *KeyKeeper) signAndSendTx(tx *models.AdminTx) error {
 	if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Admin{Admin: tx}}); err != nil {
 		return err
 	}
-	if stx.Signature, err = k.signer.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = k.signer.SignVocdoniTx(stx.Tx); err != nil {
 		return err
 	}
 	vtxBytes, err := proto.Marshal(stx)

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -187,7 +187,7 @@ func testSetProcessStatus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stx.Signature, err = oracle.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -312,7 +312,7 @@ func testSetProcessResults(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stx.Signature, err = oracle.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 	if cktx.Tx, err = proto.Marshal(&stx); err != nil {
@@ -442,7 +442,7 @@ func testSetProcessCensus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -187,7 +187,7 @@ func testSetProcessStatus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -312,7 +312,7 @@ func testSetProcessResults(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 	if cktx.Tx, err = proto.Marshal(&stx); err != nil {
@@ -442,7 +442,7 @@ func testSetProcessCensus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof.go
+++ b/vochain/proof.go
@@ -126,7 +126,7 @@ func VerifyProofOffChainCSP(process *models.Process, proof *models.Proof,
 	// depending on signature type, use a mechanism for extracting the ca publickey from signature
 	switch p.GetType() {
 	case models.ProofCA_ECDSA, models.ProofCA_ECDSA_PIDSALTED:
-		bundlePub, err := ethereum.PubKeyFromSignature(cspBundle, p.GetSignature())
+		bundlePub, err := ethereum.PubKeyFromSignature(ethereum.BuildVocdoniMessage(cspBundle), p.GetSignature())
 		if err != nil {
 			return false, nil, fmt.Errorf("cannot fetch CSP public key from signature: %w", err)
 		}

--- a/vochain/proof_erc20_test.go
+++ b/vochain/proof_erc20_test.go
@@ -103,7 +103,7 @@ func testEthSendVotes(t *testing.T, s testStorageProof,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof_erc20_test.go
+++ b/vochain/proof_erc20_test.go
@@ -103,7 +103,7 @@ func testEthSendVotes(t *testing.T, s testStorageProof,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof_minime_test.go
+++ b/vochain/proof_minime_test.go
@@ -123,7 +123,7 @@ func testMinimeSendVotes(t *testing.T, s ethstorageproof.StorageProof, addr comm
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof_minime_test.go
+++ b/vochain/proof_minime_test.go
@@ -123,7 +123,7 @@ func testMinimeSendVotes(t *testing.T, s ethstorageproof.StorageProof, addr comm
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -100,7 +100,7 @@ func TestMerkleTreeProof(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
 			t.Fatal(err)
 		}
 
@@ -147,7 +147,7 @@ func TestMerkleTreeProof(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if stx.Signature, err = lastKey.SignVocdoni(stx.Tx); err != nil {
+		if stx.Signature, err = lastKey.SignVocdoniTx(stx.Tx); err != nil {
 			t.Fatal(err)
 		}
 
@@ -210,7 +210,7 @@ func TestCAProof(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		signature, err := ca.SignEthereum(bundleBytes)
+		signature, err := ca.SignVocdoniMsg(bundleBytes)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -240,7 +240,7 @@ func TestCAProof(t *testing.T) {
 	if err := ca2.Generate(); err != nil {
 		t.Fatal(err)
 	}
-	signature, err := ca2.SignEthereum(bundleBytes)
+	signature, err := ca2.SignVocdoniMsg(bundleBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func testCASendVotes(t *testing.T, pid []byte, vp []byte, signer *ethereum.SignK
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.SignVocdoni(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -100,7 +100,7 @@ func TestMerkleTreeProof(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if stx.Signature, err = s.Sign(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoni(stx.Tx); err != nil {
 			t.Fatal(err)
 		}
 
@@ -147,7 +147,7 @@ func TestMerkleTreeProof(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if stx.Signature, err = lastKey.Sign(stx.Tx); err != nil {
+		if stx.Signature, err = lastKey.SignVocdoni(stx.Tx); err != nil {
 			t.Fatal(err)
 		}
 
@@ -210,7 +210,7 @@ func TestCAProof(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		signature, err := ca.Sign(bundleBytes)
+		signature, err := ca.SignEthereum(bundleBytes)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -240,7 +240,7 @@ func TestCAProof(t *testing.T) {
 	if err := ca2.Generate(); err != nil {
 		t.Fatal(err)
 	}
-	signature, err := ca2.Sign(bundleBytes)
+	signature, err := ca2.SignEthereum(bundleBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func testCASendVotes(t *testing.T, pid []byte, vp []byte, signer *ethereum.SignK
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoni(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/scrutinizer/scrutinizer_test.go
+++ b/vochain/scrutinizer/scrutinizer_test.go
@@ -240,7 +240,7 @@ func testProcessList(t *testing.T, procsCount int) {
 		t.Fatalf("expected %d processes, got %d", procsCount, len(procs))
 	}
 
-	list, err = sc.ProcessList(nil, 0, 64, "", 0, "", "", false)
+	_, err = sc.ProcessList(nil, 0, 64, "", 0, "", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -41,7 +41,7 @@ func (tx *vochainTx) Unmarshal(content []byte, chainID string) error {
 	}
 	tx.signature = stx.GetSignature()
 	tx.txID = TxKey(content)
-	tx.signedBody = ethereum.BuildVocdoniPayload(stx.GetTx(), chainID)
+	tx.signedBody = ethereum.BuildVocdoniTransaction(stx.GetTx(), chainID)
 	return nil
 }
 


### PR DESCRIPTION
Previously we were signing transactions as:
 EthereumSaltedHash(txPayload)
This commit switches to another approach:
 EthereumSaltedHash(vocdoni\nchainID\nHash(Payload))

So the message signed includes the hardcoded word "vocdoni"
and the chainID in which the transactions should be validated
in addition to the non salted Hash of the transaction Payload.

This new strategy will avoid relay attacks (a transaction is
only valid for a specific chainID) and will allow external
signers (such as hardware wallets or metamask) to sign a
shorter and secure payload.

Signed-off-by: p4u <pau@dabax.net>