### PR TITLE
vochain/scrutinizer: make the process order consistent, again

### DIFF
--- a/vochain/scrutinizer/db/process.sql.go
+++ b/vochain/scrutinizer/db/process.sql.go
@@ -157,8 +157,7 @@ WHERE (LENGTH(?) = 0 OR entity_id = ?)
 	-- TODO(mvdan): consider keeping an id_hex column for faster searches
 	AND (? = "" OR (INSTR(LOWER(HEX(id)), ?) > 0))
 	AND (? = FALSE OR have_results)
-	-- Note that badgerhold sorted by length before the bytes. For backwards compatibility.
-ORDER BY creation_time ASC, LENGTH(ID) ASC, ID ASC
+ORDER BY creation_time ASC, ID ASC
 	-- TODO(mvdan): use sqlc.arg once limit/offset support it:
 	-- https://github.com/kyleconroy/sqlc/issues/1025
 LIMIT ?

--- a/vochain/scrutinizer/process.go
+++ b/vochain/scrutinizer/process.go
@@ -220,7 +220,7 @@ func (s *Scrutinizer) ProcessList(entityID []byte,
 		return nil, err
 	}
 	// []string in hex form is easier to debug when we get mismatches
-	if diff := cmp.Diff(toHexList(procs), toHexList(sqlProcs)); diff != "" {
+	if diff := cmp.Diff(procs, sqlProcs); diff != "" {
 		params := []interface{}{
 			entityID, from, max,
 			searchTerm, namespace,
@@ -230,14 +230,6 @@ func (s *Scrutinizer) ProcessList(entityID []byte,
 	}
 
 	return procs, nil
-}
-
-func toHexList(decList [][]byte) []string {
-	encList := make([]string, len(decList))
-	for i, dec := range decList {
-		encList[i] = hex.EncodeToString(dec)
-	}
-	return encList
 }
 
 // ProcessCount returns the number of processes indexed

--- a/vochain/scrutinizer/queries/process.sql
+++ b/vochain/scrutinizer/queries/process.sql
@@ -35,8 +35,7 @@ WHERE (LENGTH(sqlc.arg(entity_id)) = 0 OR entity_id = sqlc.arg(entity_id))
 	-- TODO(mvdan): consider keeping an id_hex column for faster searches
 	AND (sqlc.arg(id_substr) = "" OR (INSTR(LOWER(HEX(id)), sqlc.arg(id_substr)) > 0))
 	AND (sqlc.arg(with_results) = FALSE OR have_results)
-	-- Note that badgerhold sorted by length before the bytes. For backwards compatibility.
-ORDER BY creation_time ASC, LENGTH(ID) ASC, ID ASC
+ORDER BY creation_time ASC, ID ASC
 	-- TODO(mvdan): use sqlc.arg once limit/offset support it:
 	-- https://github.com/kyleconroy/sqlc/issues/1025
 LIMIT ?


### PR DESCRIPTION
(see commit message)

