### PR TITLE
WIP: Enables the ethereum-less approach

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -1,27 +1,17 @@
 package client
 
 import (
-	"context"
-	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"math"
 	"math/big"
 	"math/rand"
-	"os/exec"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/vocdoni/arbo"
 	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/zk/artifacts"
 	"go.vocdoni.io/dvote/log"
-	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/dvote/vochain/scrutinizer/indexertypes"
@@ -34,6 +24,7 @@ type pkeys struct {
 	priv []api.Key
 }
 
+// GetChainID returns the chainID of the Vochain
 func (c *Client) GetChainID() (string, error) {
 	var req api.APIrequest
 	req.Method = "getInfo"
@@ -47,6 +38,7 @@ func (c *Client) GetChainID() (string, error) {
 	return resp.ChainID, nil
 }
 
+// GetProcessInfo returns useful process information and parameters
 func (c *Client) GetProcessInfo(pid []byte) (*indexertypes.Process, error) {
 	var req api.APIrequest
 	req.Method = "getProcessInfo"
@@ -61,6 +53,7 @@ func (c *Client) GetProcessInfo(pid []byte) (*indexertypes.Process, error) {
 	return resp.Process, nil
 }
 
+// GetEnvelopeStatus returns true if the vote envelope is registered
 func (c *Client) GetEnvelopeStatus(nullifier, pid []byte) (bool, error) {
 	var req api.APIrequest
 	req.Method = "getEnvelopeStatus"
@@ -75,6 +68,7 @@ func (c *Client) GetEnvelopeStatus(nullifier, pid []byte) (bool, error) {
 	return *resp.Registered, nil
 }
 
+// GetProof tries to generate a return a census proof
 func (c *Client) GetProof(pubkey, root []byte, digested bool) ([]byte, []byte, error) {
 	var req api.APIrequest
 	req.Method = "genProof"
@@ -93,6 +87,7 @@ func (c *Client) GetProof(pubkey, root []byte, digested bool) ([]byte, []byte, e
 	return resp.Siblings, resp.CensusValue, nil
 }
 
+// GetResults gets the results of a given process from the scrutinizer
 func (c *Client) GetResults(pid []byte) ([][]string, string, bool, error) {
 	var req api.APIrequest
 	req.Method = "getResults"
@@ -110,6 +105,7 @@ func (c *Client) GetResults(pid []byte) ([][]string, string, bool, error) {
 	return resp.Results, resp.State, *resp.Final, nil
 }
 
+// GetEnvelopeHeight returns the height at which the envelope was registered
 func (c *Client) GetEnvelopeHeight(pid []byte) (uint32, error) {
 	var req api.APIrequest
 	req.Method = "getEnvelopeHeight"
@@ -124,6 +120,7 @@ func (c *Client) GetEnvelopeHeight(pid []byte) (uint32, error) {
 	return *resp.Height, nil
 }
 
+// CensusSize returns the size of a census as int64
 func (c *Client) CensusSize(cid []byte) (int64, error) {
 	var req api.APIrequest
 	req.Method = "getSize"
@@ -138,6 +135,7 @@ func (c *Client) CensusSize(cid []byte) (int64, error) {
 	return *resp.Size, nil
 }
 
+// ImportCensus adds, imports and publish a given census
 func (c *Client) ImportCensus(signer *ethereum.SignKeys, uri string) ([]byte, error) {
 	var req api.APIrequest
 	req.Method = "addCensus"
@@ -170,6 +168,7 @@ func (c *Client) ImportCensus(signer *ethereum.SignKeys, uri string) ([]byte, er
 	return resp.Root, nil
 }
 
+// GetKeys gets the process encryption keys
 func (c *Client) GetKeys(pid, eid []byte) (*pkeys, error) {
 	var req api.APIrequest
 	req.Method = "getProcessKeys"
@@ -188,6 +187,7 @@ func (c *Client) GetKeys(pid, eid []byte) (*pkeys, error) {
 	}, nil
 }
 
+// GetCircuitConfig gets the ZK circuit config used for anonymous voting
 func (c *Client) GetCircuitConfig(pid []byte) (*int, *artifacts.CircuitConfig, error) {
 	var req api.APIrequest
 	req.Method = "getProcessCircuitConfig"
@@ -202,6 +202,7 @@ func (c *Client) GetCircuitConfig(pid []byte) (*int, *artifacts.CircuitConfig, e
 	return resp.CircuitIndex, resp.CircuitConfig, nil
 }
 
+// GetRollingCensusSize returns the size of a given rolling census
 func (c *Client) GetRollingCensusSize(pid []byte) (int64, error) {
 	var req api.APIrequest
 	req.Method = "getProcessRollingCensusSize"
@@ -216,6 +217,7 @@ func (c *Client) GetRollingCensusSize(pid []byte) (int64, error) {
 	return *resp.Size, nil
 }
 
+// GetRollingCensusVoterWeight returns the weight in the census of a specific address
 func (c *Client) GetRollingCensusVoterWeight(pid []byte, address common.Address) (*big.Int, error) {
 	var req api.APIrequest
 	req.Method = "getPreregisterVoterWeight"
@@ -231,6 +233,7 @@ func (c *Client) GetRollingCensusVoterWeight(pid []byte, address common.Address)
 	return resp.Weight.ToInt(), nil
 }
 
+// TestResults checks the correctness of a given process results
 func (c *Client) TestResults(pid []byte, totalVotes int, withWeight uint64) ([][]string, error) {
 	log.Infof("waiting for results...")
 	var err error
@@ -262,11 +265,13 @@ func (c *Client) TestResults(pid []byte, totalVotes int, withWeight uint64) ([][
 	return results, nil
 }
 
+// Proof wraps a merkle proof siblings and value
 type Proof struct {
 	Siblings []byte
 	Value    []byte
 }
 
+// GetMerkleProofBatch returns an array of merkle proofs for a set of given addresses
 func (c *Client) GetMerkleProofBatch(signers []*ethereum.SignKeys,
 	root []byte,
 	tolerateError bool) ([]*Proof, error) {
@@ -290,6 +295,7 @@ func (c *Client) GetMerkleProofBatch(signers []*ethereum.SignKeys,
 	return proofs, nil
 }
 
+// GetMerkleProofPoseidonBatch returns an array of poseidon merkle proofs for a set of given addresses
 func (c *Client) GetMerkleProofPoseidonBatch(signers []*ethereum.SignKeys,
 	root []byte,
 	tolerateError bool) ([]*Proof, error) {
@@ -314,6 +320,7 @@ func (c *Client) GetMerkleProofPoseidonBatch(signers []*ethereum.SignKeys,
 	return proofs, nil
 }
 
+// GetCSPproofBatch returns an array of CSP like merkle proofs for a set of given addresses
 func (c *Client) GetCSPproofBatch(signers []*ethereum.SignKeys,
 	ca *ethereum.SignKeys,
 	pid []byte) ([]*Proof, error) {
@@ -352,740 +359,8 @@ func (c *Client) GetCSPproofBatch(signers []*ethereum.SignKeys,
 	return proofs, nil
 }
 
-// testGetZKCensusKey returns zkCensusKey, secretKey.  For testing purposes, we
-// generate a secretKey from a signature by the ethereum key.
-func testGetZKCensusKey(s *ethereum.SignKeys) ([]byte, []byte) {
-	// secret is 65 bytes
-	secret, err := s.SignVocdoniMsg([]byte("secretKey"))
-	if err != nil {
-		log.Fatalf("Cannot sign: %v", err)
-	}
-	hasher := arbo.HashPoseidon{}
-	secretKey, err := hasher.Hash(secret[:22], secret[22:44], secret[44:])
-	if err != nil {
-		log.Fatalf("Cannnot calculate pre-register key with Poseidon: %v", err)
-	}
-	pubKey, err := hasher.Hash(secretKey)
-	if err != nil {
-		log.Fatalf("Cannnot calculate pre-register key with Poseidon: %v", err)
-	}
-	return pubKey, secretKey
-}
-
-type SNARKProofCircom struct {
-	A []string   `json:"pi_a"`
-	B [][]string `json:"pi_b"`
-	C []string   `json:"pi_c"`
-	// PublicInputs []string // onl
-}
-
-type SNARKProof struct {
-	A            []string
-	B            []string
-	C            []string
-	PublicInputs []string // only nullifier
-}
-
-type SNARKProofInputs struct {
-	CensusRoot     string   `json:"censusRoot"`
-	CensusSiblings []string `json:"censusSiblings"`
-	Index          string   `json:"index"`
-	SecretKey      string   `json:"secretKey"`
-	VoteHash       []string `json:"voteHash"`
-	ProcessID      []string `json:"processId"`
-	Nullifier      string   `json:"nullifier"`
-}
-
-type GenSNARKData struct {
-	CircuitIndex  int                      `json:"circuitIndex"`
-	CircuitConfig *artifacts.CircuitConfig `json:"circuitConfig"`
-	Inputs        SNARKProofInputs         `json:"inputs"`
-}
-
-func testGenSNARKProof(circuitIndex int, circuitConfig *artifacts.CircuitConfig,
-	censusRoot, merkleProof []byte, treeSize int64,
-	secretKey, votePackage, processId []byte) (*SNARKProof, []byte, error) {
-	if len(merkleProof) < 8 {
-		return nil, nil, fmt.Errorf("merkleProof too short")
-	}
-	indexLE := merkleProof[:8]
-	index := binary.LittleEndian.Uint64(indexLE)
-	siblingsBytes := merkleProof[8:]
-
-	levels := int(math.Log2(float64(treeSize)))
-	siblings, err := arbo.UnpackSiblings(arbo.HashFunctionPoseidon, siblingsBytes)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot arbo.UnpackSiblings: %w", err)
-	}
-	for i := len(siblings); i < levels; i++ {
-		siblings = append(siblings, []byte{0})
-	}
-	siblings = append(siblings, []byte{0})
-	var siblingsStr []string
-	for i := 0; i < len(siblings); i++ {
-		siblingsStr = append(siblingsStr, arbo.BytesToBigInt(siblings[i]).String())
-	}
-
-	voteHash := sha256.Sum256(votePackage)
-	voteHash0, voteHash1 := voteHash[:16], voteHash[16:]
-
-	processId0, processId1 := processId[:16], processId[16:]
-	poseidon := arbo.HashPoseidon{}
-	nullifier, err := poseidon.Hash(
-		secretKey,
-		processId0,
-		processId1,
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("poseidon: %w", err)
-	}
-
-	inputs := SNARKProofInputs{
-		CensusRoot:     arbo.BytesToBigInt(censusRoot).String(),
-		CensusSiblings: siblingsStr,
-		Index:          new(big.Int).SetUint64(index).String(),
-		SecretKey:      arbo.BytesToBigInt(secretKey).String(),
-		VoteHash: []string{
-			arbo.BytesToBigInt(voteHash0).String(),
-			arbo.BytesToBigInt(voteHash1).String(),
-		},
-		ProcessID: []string{
-			arbo.BytesToBigInt(processId0).String(),
-			arbo.BytesToBigInt(processId1).String(),
-		},
-		Nullifier: arbo.BytesToBigInt(nullifier).String(),
-	}
-	data := GenSNARKData{
-		CircuitIndex:  circuitIndex,
-		CircuitConfig: circuitConfig,
-		Inputs:        inputs,
-	}
-	dataJSON, err := json.Marshal(&data)
-	if err != nil {
-		return nil, nil, err
-	}
-	log.Debugf("gen-vote-snark.js input: %v", string(dataJSON))
-	cmd := exec.Command("node", "/app/js/gen-vote-snark.js", string(dataJSON))
-	proofJSON, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, nil, fmt.Errorf("node /app/js/gen-vote-snark.js: %w\n%s",
-			err, string(proofJSON))
-	}
-	log.Debugf("gen-vote-snark.js output: %v", string(proofJSON))
-	var proofCircom SNARKProofCircom
-	if err := json.Unmarshal(proofJSON, &proofCircom); err != nil {
-		return nil, nil, fmt.Errorf("/app/js/gen-vote-snark.js output unmarshal: %w\n%s",
-			err, string(proofJSON))
-	}
-	return &SNARKProof{
-		A: proofCircom.A,
-		B: []string{
-			proofCircom.B[0][0], proofCircom.B[0][1],
-			proofCircom.B[1][0], proofCircom.B[1][1],
-			proofCircom.B[2][0], proofCircom.B[2][1],
-		},
-		C: proofCircom.C,
-		// PublicInputs is not used in the anonymous-voting flow, as
-		// the only needed public input from user's side is the
-		// nullifier, which is already in the VoteEnvelope struct
-	}, nullifier, nil
-}
-
-func (c *Client) TestPreRegisterKeys(
-	pid,
-	eid,
-	root []byte,
-	startBlock uint32,
-	signers []*ethereum.SignKeys,
-	censusOrigin models.CensusOrigin,
-	caSigner *ethereum.SignKeys,
-	proofs []*Proof,
-	doublePreRegister, checkNullifiers bool,
-	wg *sync.WaitGroup) (time.Duration, error) {
-
-	var err error
-	registerKeyWeight := "1"
-	// Generate merkle proofs
-	if proofs == nil {
-		switch censusOrigin {
-		case models.CensusOrigin_OFF_CHAIN_TREE:
-			proofs, err = c.GetMerkleProofBatch(signers, root, false)
-		case models.CensusOrigin_OFF_CHAIN_CA:
-			proofs, err = c.GetCSPproofBatch(signers, caSigner, pid)
-		default:
-			return 0, fmt.Errorf("censusOrigin not supported")
-		}
-	}
-	if err != nil {
-		return 0, err
-	}
-	// Wait until all gateway connections are ready
-	wg.Done()
-	log.Infof("%s is waiting other gateways to be ready before it can start voting", c.Addr)
-	wg.Wait()
-
-	// Wait for process to be registered
-	log.Infof("waiting for process %x to be registered...", pid)
-	for {
-		proc, err := c.GetProcessInfo(pid)
-		if err != nil {
-			log.Infof("Process not yet available: %v", err)
-			time.Sleep(5 * time.Second)
-			continue
-		}
-		log.Infof("Process: %+v\n", proc)
-		break
-	}
-	cb, err := c.GetCurrentBlock()
-	if err != nil {
-		return 0, err
-	}
-	log.Infof("Current block: %v", cb)
-
-	// Send votes
-	log.Infof("sending pre-register keys")
-	timeDeadLine := time.Second * 200
-	if len(signers) > 1000 {
-		timeDeadLine = time.Duration(len(signers)/5) * time.Second
-	}
-	log.Infof("time deadline set to %d seconds", timeDeadLine/time.Second)
-	req := api.APIrequest{Method: "submitRawTx"}
-	start := time.Now()
-
-	for i := 0; i < len(signers); i++ {
-		s := signers[i]
-		zkCensusKey, _ := testGetZKCensusKey(s)
-		v := &models.RegisterKeyTx{
-			Nonce:     util.RandomBytes(32),
-			ProcessId: pid,
-			NewKey:    zkCensusKey,
-			Weight:    registerKeyWeight,
-		}
-		switch censusOrigin {
-		case models.CensusOrigin_OFF_CHAIN_TREE:
-			v.Proof = &models.Proof{
-				Payload: &models.Proof_Arbo{
-					Arbo: &models.ProofArbo{
-						Type:     models.ProofArbo_BLAKE2B,
-						Siblings: proofs[i].Siblings,
-						Value:    proofs[i].Value,
-					},
-				},
-			}
-
-		case models.CensusOrigin_OFF_CHAIN_CA:
-			p := &models.ProofCA{}
-			if err := proto.Unmarshal(proofs[i].Siblings, p); err != nil {
-				log.Fatal(err)
-			}
-			v.Proof = &models.Proof{Payload: &models.Proof_Ca{Ca: p}}
-
-		default:
-			log.Fatal("censusOrigin %s not supported", censusOrigin.String())
-		}
-
-		stx := &models.SignedTx{}
-		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_RegisterKey{RegisterKey: v}})
-		if err != nil {
-			return 0, err
-		}
-
-		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
-			return 0, err
-		}
-		if req.Payload, err = proto.Marshal(stx); err != nil {
-			return 0, err
-		}
-		log.Debugf("pre-registering zkCensusKey:%x", zkCensusKey)
-		resp, err := c.Request(req, nil)
-		if err != nil {
-			return 0, err
-		}
-		if !resp.Ok {
-			if strings.Contains(resp.Message, "mempool is full") {
-				log.Warnf("mempool is full, waiting and retrying")
-				time.Sleep(1 * time.Second)
-				i--
-			} else {
-				// FIXME: once the req.Message are no longer in hex, remove this
-				msg, err := hex.DecodeString(resp.Message)
-				if err != nil {
-					return 0, fmt.Errorf("resp.Message hex decode: %w", err)
-				}
-				return 0, fmt.Errorf("%s failed: %s", req.Method, msg)
-			}
-		}
-		if (i+1)%100 == 0 {
-			log.Infof("pre-register progress for %s: %d%%", c.Addr, ((i+1)*100)/(len(signers)))
-		}
-
-		// Try double preRegister.  The request will not fail but
-		// that's OK.  For each user we will have 2 pre-register Txs in
-		// the pool, only one of them will succeed (the first one
-		// assuming that the node includes the transactions in the
-		// mempool received order).  Later on we check that the Rolling
-		// Census Size has the expected size, so we verify that there
-		// were no more pre-registers than expected.  And finally we
-		// vote with the first zkCensusKey for each user, making sure
-		// those pre-register succeded (and thus the second ones
-		// failed).
-		if doublePreRegister {
-			// We change the key in order to submit a different Tx
-			// with the same pre-census proof.
-			v.NewKey[1] = ^v.NewKey[1]
-			stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_RegisterKey{RegisterKey: v}})
-			if err != nil {
-				return 0, err
-			}
-			if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
-				return 0, err
-			}
-			if req.Payload, err = proto.Marshal(stx); err != nil {
-				return 0, err
-			}
-			resp, err := c.Request(req, nil)
-			if err != nil {
-				return 0, err
-			}
-			// log.Warnf("DBG Double: %#v", resp)
-			if resp.Ok {
-				continue
-				// We can't detect double pre-register here yet
-				// because we're not caching the RegisterKeyTx
-				// verification.  Nevertheless when the block
-				// is mined, only one pre-register will
-				// succeed.
-				// Uncomment once we have a pre-regsiter
-				// verification cache.
-				// return 0, fmt.Errorf("double pre-register not detected")
-			}
-		}
-	}
-
-	tries := 10
-	log.Infof("checking first pre-registered key")
-	for ; tries >= 0; tries-- {
-		weight, err := c.GetRollingCensusVoterWeight(pid, signers[0].Address())
-		if err != nil {
-			return 0, fmt.Errorf("the pre-register key cannot be verified: %w", err)
-		}
-		if weight.String() == registerKeyWeight {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-	if tries == 0 {
-		return 0, fmt.Errorf("could not get pre-register key")
-	}
-
-	log.Infof("pre-registers submited! took %s", time.Since(start))
-	preRegisterEapsedTime := time.Since(start)
-
-	return preRegisterEapsedTime, nil
-}
-
-func (c *Client) TestSendVotes(
-	pid,
-	eid,
-	root []byte,
-	startBlock uint32,
-	signers []*ethereum.SignKeys,
-	censusOrigin models.CensusOrigin,
-	caSigner *ethereum.SignKeys,
-	proofs []*Proof,
-	encrypted, doubleVoting, checkNullifiers bool,
-	wg *sync.WaitGroup) (time.Duration, error) {
-
-	var err error
-	var keys []string
-	// Generate merkle proofs
-	if proofs == nil {
-		switch censusOrigin {
-		case models.CensusOrigin_OFF_CHAIN_TREE, models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED:
-			proofs, err = c.GetMerkleProofBatch(signers, root, false)
-		case models.CensusOrigin_OFF_CHAIN_CA:
-			proofs, err = c.GetCSPproofBatch(signers, caSigner, pid)
-		default:
-			return 0, fmt.Errorf("censusOrigin not supported")
-		}
-	}
-	if err != nil {
-		return 0, err
-	}
-	// Wait until all gateway connections are ready
-	wg.Done()
-	log.Infof("%s is waiting other gateways to be ready before it can start voting", c.Addr)
-	c.WaitUntilBlock(startBlock)
-	wg.Wait()
-
-	// Get encryption keys
-	keyIndexes := []uint32{}
-	if encrypted {
-		if pk, err := c.GetKeys(pid, eid); err != nil {
-			return 0, fmt.Errorf("cannot get process keys: (%s)", err)
-		} else {
-			for _, k := range pk.pub {
-				if len(k.Key) > 0 {
-					keyIndexes = append(keyIndexes, uint32(k.Idx))
-					keys = append(keys, k.Key)
-				}
-			}
-		}
-		if len(keys) == 0 {
-			return 0, fmt.Errorf("process keys is empty")
-		}
-		log.Infof("got encryption keys!")
-	}
-	// Send votes
-	log.Infof("sending votes")
-	timeDeadLine := time.Second * 200
-	if len(signers) > 1000 {
-		timeDeadLine = time.Duration(len(signers)/5) * time.Second
-	}
-	log.Infof("time deadline set to %d seconds", timeDeadLine/time.Second)
-	req := api.APIrequest{Method: "submitRawTx"}
-	nullifiers := []string{}
-	var vpb []byte
-	start := time.Now()
-
-	for i := 0; i < len(signers); i++ {
-		s := signers[i]
-		if vpb, err = genVote(encrypted, keys); err != nil {
-			return 0, err
-		}
-		v := &models.VoteEnvelope{
-			Nonce:                util.RandomBytes(32),
-			ProcessId:            pid,
-			VotePackage:          vpb,
-			EncryptionKeyIndexes: keyIndexes,
-		}
-		switch censusOrigin {
-		case models.CensusOrigin_OFF_CHAIN_TREE, models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED:
-			v.Proof = &models.Proof{
-				Payload: &models.Proof_Arbo{
-					Arbo: &models.ProofArbo{
-						Type:     models.ProofArbo_BLAKE2B,
-						Siblings: proofs[i].Siblings,
-						Value:    proofs[i].Value,
-					},
-				},
-			}
-
-		case models.CensusOrigin_OFF_CHAIN_CA:
-			p := &models.ProofCA{}
-			if err := proto.Unmarshal(proofs[i].Siblings, p); err != nil {
-				log.Fatal(err)
-			}
-			v.Proof = &models.Proof{Payload: &models.Proof_Ca{Ca: p}}
-
-		default:
-			log.Fatal("censusOrigin %s not supported", censusOrigin.String())
-		}
-
-		stx := &models.SignedTx{}
-		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: v}})
-		if err != nil {
-			return 0, err
-		}
-
-		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
-			return 0, err
-		}
-		if req.Payload, err = proto.Marshal(stx); err != nil {
-			return 0, err
-		}
-		pub, _ := s.HexString()
-		log.Debugf("voting with pubKey:%s {%s}", pub, log.FormatProto(v))
-		resp, err := c.Request(req, nil)
-		if err != nil {
-			return 0, err
-		}
-		if !resp.Ok {
-			if strings.Contains(resp.Message, "mempool is full") {
-				log.Warnf("mempool is full, waiting and retrying")
-				time.Sleep(1 * time.Second)
-				i--
-			} else {
-				return 0, fmt.Errorf("%s failed: %s", req.Method, resp.Message)
-			}
-		}
-		nullifiers = append(nullifiers, resp.Payload)
-		if (i+1)%100 == 0 {
-			log.Infof("voting progress for %s: %d%%", c.Addr, ((i+1)*100)/(len(signers)))
-		}
-
-		// Try double voting (should fail)
-		if doubleVoting {
-			resp, err := c.Request(req, nil)
-			if err != nil {
-				return 0, err
-			}
-			if resp.Ok {
-				return 0, fmt.Errorf("double voting detected")
-			}
-		}
-	}
-	log.Infof("votes submited! took %s", time.Since(start))
-	checkStart := time.Now()
-	registered := 0
-	log.Infof("waiting for votes to be validated...")
-	for {
-		time.Sleep(time.Millisecond * 500)
-		if h, err := c.GetEnvelopeHeight(pid); err != nil {
-			log.Warnf("error getting envelope height: %v", err)
-			continue
-		} else {
-			if h >= uint32(len(signers)) {
-				break
-			}
-		}
-		if time.Since(checkStart) > timeDeadLine {
-			return 0, fmt.Errorf("waiting for envelope height took longer than deadline, skipping")
-		}
-	}
-	votingElapsedTime := time.Since(start)
-
-	if !checkNullifiers {
-		return votingElapsedTime, nil
-	}
-	// If checkNullifiers, wait until all votes have been verified
-	for {
-		for i, nullHex := range nullifiers {
-			if nullHex == "registered" {
-				registered++
-				continue
-			}
-			null, err := hex.DecodeString(nullHex)
-			if err != nil {
-				return 0, err
-			}
-			if es, _ := c.GetEnvelopeStatus(null, pid); es {
-				nullifiers[i] = "registered"
-			}
-		}
-		if registered == len(nullifiers) {
-			break
-		}
-		registered = 0
-		if time.Since(checkStart) > timeDeadLine {
-			return 0, fmt.Errorf("checking nullifier time took more than deadline, skipping")
-		}
-	}
-
-	return votingElapsedTime, nil
-}
-
-func (c *Client) TestSendAnonVotes(
-	pid,
-	eid,
-	root []byte,
-	startBlock uint32,
-	signers []*ethereum.SignKeys,
-	doubleVoting, checkNullifiers bool,
-	wg *sync.WaitGroup) (time.Duration, error) {
-
-	proofs, err := c.GetMerkleProofPoseidonBatch(signers, root, false)
-	if err != nil {
-		return 0, err
-	}
-	log.Infof("Requested %v proofs", len(proofs))
-	circuitIndex, circuitConfig, err := c.GetCircuitConfig(pid)
-	if err != nil {
-		return 0, err
-	}
-	log.Infof("CircuitIndex: %v, CircuitPath: %+v", *circuitIndex, circuitConfig.CircuitPath)
-	// Wait until all gateway connections are ready
-	wg.Done()
-	log.Infof("%s is waiting other gateways to be ready before it can start voting", c.Addr)
-	c.WaitUntilBlock(startBlock)
-	wg.Wait()
-
-	log.Infof("Downloading Circuit Artifacts")
-	circuitConfig.LocalDir = "/tmp"
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	if err := artifacts.DownloadCircuitFiles(ctx, *circuitConfig); err != nil {
-		return 0, err
-	}
-
-	// Send votes
-	log.Infof("sending votes")
-	timeDeadLine := time.Second * 200
-	if len(signers) > 1000 {
-		timeDeadLine = time.Duration(len(signers)/5) * time.Second
-	}
-	log.Infof("time deadline set to %d seconds", timeDeadLine/time.Second)
-	req := api.APIrequest{Method: "submitRawTx"}
-	nullifiers := []string{}
-	var vpb []byte
-	start := time.Now()
-
-	for i := 0; i < len(signers); i++ {
-		s := signers[i]
-		if vpb, err = genVote(false, nil); err != nil {
-			return 0, err
-		}
-		_, secretKey := testGetZKCensusKey(s)
-		proof, nullifier, err := testGenSNARKProof(*circuitIndex, circuitConfig,
-			root, proofs[i].Siblings, circuitConfig.Parameters[0], secretKey, vpb, pid)
-		if err != nil {
-			return 0, fmt.Errorf("cannot generate test SNARK proof: %w", err)
-		}
-		v := &models.VoteEnvelope{
-			Nonce:       util.RandomBytes(32),
-			ProcessId:   pid,
-			VotePackage: vpb,
-			Nullifier:   nullifier,
-		}
-		v.Proof = &models.Proof{
-			Payload: &models.Proof_ZkSnark{
-				ZkSnark: &models.ProofZkSNARK{
-					CircuitParametersIndex: int32(*circuitIndex),
-					A:                      proof.A,
-					B:                      proof.B,
-					C:                      proof.C,
-					// PublicInputs is not used in the
-					// anonymous-voting flow, as the only
-					// needed public input from user's side
-					// is the nullifier, which is already
-					// in the VoteEnvelope struct
-				},
-			},
-		}
-
-		stx := &models.SignedTx{}
-		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: v}})
-		if err != nil {
-			return 0, err
-		}
-
-		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
-			return 0, err
-		}
-		if req.Payload, err = proto.Marshal(stx); err != nil {
-			return 0, err
-		}
-		pub, _ := s.HexString()
-		log.Debugf("voting with pubKey:%s", pub)
-		resp, err := c.Request(req, nil)
-		if err != nil {
-			return 0, err
-		}
-		if !resp.Ok {
-			if strings.Contains(resp.Message, "mempool is full") {
-				log.Warnf("mempool is full, waiting and retrying")
-				time.Sleep(1 * time.Second)
-				i--
-			} else {
-				// FIXME: once the req.Message are no longer in hex, remove this
-				msg, err := hex.DecodeString(resp.Message)
-				if err != nil {
-					return 0, fmt.Errorf("resp.Message hex decode: %w", err)
-				}
-				return 0, fmt.Errorf("%s failed: %s", req.Method, msg)
-			}
-		}
-		nullifiers = append(nullifiers, resp.Payload)
-		if (i+1)%100 == 0 {
-			log.Infof("voting progress for %s: %d%%", c.Addr, ((i+1)*100)/(len(signers)))
-		}
-
-		// Try double voting (should fail)
-		if doubleVoting {
-			resp, err := c.Request(req, nil)
-			if err != nil {
-				return 0, err
-			}
-			if resp.Ok {
-				return 0, fmt.Errorf("double voting not detected")
-			}
-		}
-	}
-	log.Infof("votes submited! took %s", time.Since(start))
-	checkStart := time.Now()
-	registered := 0
-	log.Infof("waiting for votes to be validated...")
-	for {
-		time.Sleep(time.Millisecond * 500)
-		if h, err := c.GetEnvelopeHeight(pid); err != nil {
-			log.Warnf("error getting envelope height: %v", err)
-			continue
-		} else {
-			if h >= uint32(len(signers)) {
-				break
-			}
-		}
-		if time.Since(checkStart) > timeDeadLine {
-			return 0, fmt.Errorf("waiting for envelope height took longer than deadline, skipping")
-		}
-	}
-	votingElapsedTime := time.Since(start)
-
-	if !checkNullifiers {
-		return votingElapsedTime, nil
-	}
-	// If checkNullifiers, wait until all votes have been verified
-	for {
-		for i, nullHex := range nullifiers {
-			if nullHex == "registered" {
-				registered++
-				continue
-			}
-			null, err := hex.DecodeString(nullHex)
-			if err != nil {
-				return 0, err
-			}
-			if es, _ := c.GetEnvelopeStatus(null, pid); es {
-				nullifiers[i] = "registered"
-			}
-		}
-		if registered == len(nullifiers) {
-			break
-		}
-		registered = 0
-		if time.Since(checkStart) > timeDeadLine {
-			return 0, fmt.Errorf("checking nullifier time took more than deadline, skipping")
-		}
-	}
-
-	return votingElapsedTime, nil
-}
-
-func (c *Client) CreateAccount(signer *ethereum.SignKeys, infoURI string, nonce uint32) error {
-	var req api.APIrequest
-	var err error
-	req.Method = "submitRawTx"
-
-	tx := &models.SetAccountInfoTx{
-		Txtype:  models.TxType_SET_ACCOUNT_INFO,
-		Nonce:   nonce,
-		InfoURI: infoURI,
-		Account: signer.Address().Bytes(),
-	}
-
-	stx := &models.SignedTx{}
-	stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_SetAccountInfo{SetAccountInfo: tx}})
-	if err != nil {
-		return err
-	}
-	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
-		return err
-	}
-	if req.Payload, err = proto.Marshal(stx); err != nil {
-		return err
-	}
-
-	resp, err := c.Request(req, nil)
-	if err != nil {
-		return err
-	}
-	if !resp.Ok {
-		return fmt.Errorf("%s failed: %s", req.Method, resp.Message)
-	}
-	return nil
-}
-
-func (c *Client) SetAccountInfoURI(signer *ethereum.SignKeys, to common.Address, infoURI string, nonce uint32) error {
+// CreateOrSetAccount creates or sets the infoURI of a Vochain account
+func (c *Client) CreateOrSetAccount(signer *ethereum.SignKeys, to common.Address, infoURI string, nonce uint32) error {
 	var req api.APIrequest
 	var err error
 	req.Method = "submitRawTx"
@@ -1119,6 +394,7 @@ func (c *Client) SetAccountInfoURI(signer *ethereum.SignKeys, to common.Address,
 	return nil
 }
 
+// GetAccount returns information of a given account
 func (c *Client) GetAccount(signer *ethereum.SignKeys, accountAddr common.Address) (*vochain.Account, error) {
 	req := api.APIrequest{Method: "getAccount", EntityId: accountAddr.Bytes()}
 	resp, err := c.Request(req, signer)
@@ -1146,6 +422,7 @@ func (c *Client) GetAccount(signer *ethereum.SignKeys, accountAddr common.Addres
 	return acc, nil
 }
 
+// GetTreasurer returns information about the treasurer
 func (c *Client) GetTreasurer(signer *ethereum.SignKeys) (*models.Treasurer, error) {
 	req := api.APIrequest{Method: "getTreasurer"}
 	resp, err := c.Request(req, signer)
@@ -1166,6 +443,7 @@ func (c *Client) GetTreasurer(signer *ethereum.SignKeys) (*models.Treasurer, err
 }
 
 // del = true -> delete operation
+// SetAccountDelegate adds or remove a given account delegate
 func (c *Client) SetAccountDelegate(signer *ethereum.SignKeys, delegate common.Address, nonce uint32, del bool) error {
 	var req api.APIrequest
 	var err error
@@ -1203,6 +481,7 @@ func (c *Client) SetAccountDelegate(signer *ethereum.SignKeys, delegate common.A
 	return nil
 }
 
+// SendTokens sends tokens to a given address
 func (c *Client) SendTokens(from *ethereum.SignKeys, to common.Address, value uint64, nonce uint32) error {
 	var req api.APIrequest
 	var err error
@@ -1238,6 +517,7 @@ func (c *Client) SendTokens(from *ethereum.SignKeys, to common.Address, value ui
 	return nil
 }
 
+// GenerateFaucetPackage generates a faucet package
 func (c *Client) GenerateFaucetPackage(from *ethereum.SignKeys, to common.Address, value uint64) (*models.FaucetPackage, error) {
 	rand.Seed(time.Now().UnixNano())
 	payload := &models.FaucetPayload{
@@ -1259,6 +539,7 @@ func (c *Client) GenerateFaucetPackage(from *ethereum.SignKeys, to common.Addres
 	}, nil
 }
 
+// CollectFaucet sends a CollectFaucetTx given a valid faucet package
 func (c *Client) CollectFaucet(signer *ethereum.SignKeys, fpkg *models.FaucetPackage, nonce uint32) error {
 	var req api.APIrequest
 	var err error
@@ -1292,6 +573,7 @@ func (c *Client) CollectFaucet(signer *ethereum.SignKeys, fpkg *models.FaucetPac
 	return nil
 }
 
+// MintTokens sends a MintTokensTx in order to mint tokens for a given address
 func (c *Client) MintTokens(treasurer *ethereum.SignKeys, to common.Address, amount uint64, nonce uint32) error {
 	var req api.APIrequest
 	var err error
@@ -1326,83 +608,7 @@ func (c *Client) MintTokens(treasurer *ethereum.SignKeys, to common.Address, amo
 	return nil
 }
 
-func (c *Client) CreateProcess(signer *ethereum.SignKeys,
-	entityID, censusRoot []byte,
-	censusURI string,
-	pid []byte,
-	envelopeType *models.EnvelopeType,
-	mode *models.ProcessMode,
-	censusOrigin models.CensusOrigin,
-	startBlockIncrement int,
-	duration int,
-	maxCensusSize uint64) (uint32, error) {
-
-	startBlock := uint32(0)
-	if startBlockIncrement > 0 {
-		current, err := c.GetCurrentBlock()
-		if err != nil {
-			return 0, err
-		}
-		startBlock = current + uint32(startBlockIncrement)
-	}
-
-	var req api.APIrequest
-	req.Method = "submitRawTx"
-	if mode == nil {
-		mode = &models.ProcessMode{AutoStart: true, Interruptible: true}
-	}
-	processData := &models.Process{
-		EntityId:      entityID,
-		CensusRoot:    censusRoot,
-		CensusURI:     &censusURI,
-		CensusOrigin:  censusOrigin,
-		BlockCount:    uint32(duration),
-		ProcessId:     pid,
-		StartBlock:    startBlock,
-		EnvelopeType:  envelopeType,
-		Mode:          mode,
-		Status:        models.ProcessStatus_READY,
-		VoteOptions:   &models.ProcessVoteOptions{MaxCount: 16, MaxValue: 8},
-		MaxCensusSize: &maxCensusSize,
-	}
-	p := &models.NewProcessTx{
-		Txtype:  models.TxType_NEW_PROCESS,
-		Nonce:   util.RandomBytes(32),
-		Process: processData,
-	}
-	var err error
-	stx := &models.SignedTx{}
-	stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_NewProcess{NewProcess: p}})
-	if err != nil {
-		return 0, err
-	}
-	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
-		return 0, err
-	}
-	if req.Payload, err = proto.Marshal(stx); err != nil {
-		return 0, err
-	}
-
-	resp, err := c.Request(req, nil)
-	if err != nil {
-		return 0, err
-	}
-	if !resp.Ok {
-		return 0, fmt.Errorf("%s failed: %s", req.Method, resp.Message)
-	}
-	if startBlockIncrement == 0 {
-		for i := 0; i < 10; i++ {
-			time.Sleep(2 * time.Second)
-			p, err := c.GetProcessInfo(pid)
-			if err == nil && p != nil {
-				return p.StartBlock, nil
-			}
-		}
-		return 0, fmt.Errorf("process was not created")
-	}
-	return startBlock, nil
-}
-
+// EndProcess sends a SetProcessStatusTx for ending a given process
 func (c *Client) EndProcess(oracle *ethereum.SignKeys, pid []byte) error {
 	var req api.APIrequest
 	var err error
@@ -1436,6 +642,7 @@ func (c *Client) EndProcess(oracle *ethereum.SignKeys, pid []byte) error {
 	return nil
 }
 
+// GetCurrentBlock returns the current vochain block number
 func (c *Client) GetCurrentBlock() (uint32, error) {
 	var req api.APIrequest
 	req.Method = "getBlockHeight"
@@ -1450,119 +657,4 @@ func (c *Client) GetCurrentBlock() (uint32, error) {
 		return 0, fmt.Errorf("height is nil")
 	}
 	return *resp.Height, nil
-}
-
-// CreateCensus creates a new census on the remote gateway and publishes it.
-// Users public keys can be added using censusSigner (ethereum.SignKeys) or
-// censusPubKeys (raw hex public keys).
-// censusValues can be empty for a non-weighted census
-func (c *Client) CreateCensus(signer *ethereum.SignKeys, censusSigners []*ethereum.SignKeys,
-	censusPubKeys []string, censusValues []*types.BigInt) (root []byte, uri string, _ error) {
-	var req api.APIrequest
-
-	// Create census
-	log.Infof("Create census")
-	req.Method = "addCensus"
-	req.CensusType = models.Census_ARBO_BLAKE2B
-	req.CensusID = fmt.Sprintf("test%d", rand.Int())
-	resp, err := c.Request(req, signer)
-	if err != nil {
-		return nil, "", err
-	}
-	if !resp.Ok {
-		return nil, "", fmt.Errorf("%s failed: %s", req.Method, resp.Message)
-	}
-	// Set correct censusID for commint requests
-	req.CensusID = resp.CensusID
-
-	// addClaimBulk
-	censusSize := 0
-	if censusSigners != nil {
-		censusSize = len(censusSigners)
-	} else {
-		censusSize = len(censusPubKeys)
-	}
-	if len(censusValues) > 0 && len(censusValues) != censusSize {
-		return nil, "", fmt.Errorf("census keys and values are not the same lenght (%d != %d)",
-			censusSize, len(censusValues))
-	}
-	log.Infof("add bulk claims (size %d)", censusSize)
-	req.Method = "addClaimBulk"
-	req.CensusKey = []byte{}
-	req.Digested = false
-	currentSize := censusSize
-	i := 0
-	var hexpub string
-	for currentSize > 0 {
-		claims := [][]byte{}
-		values := []*types.BigInt{}
-		for j := 0; j < 100; j++ {
-			if currentSize < 1 {
-				break
-			}
-			if censusSigners != nil {
-				hexpub, _ = censusSigners[currentSize-1].HexString()
-			} else {
-				hexpub = censusPubKeys[currentSize-1]
-			}
-			pub, err := hex.DecodeString(hexpub)
-			if err != nil {
-				return nil, "", err
-			}
-			claims = append(claims, pub)
-			if len(censusValues) > 0 {
-				values = append(values, censusValues[currentSize-1])
-			}
-			currentSize--
-		}
-		req.CensusKeys = claims
-		req.Weights = values
-		resp, err := c.Request(req, signer)
-		if err != nil {
-			return nil, "", err
-		}
-		if !resp.Ok {
-			return nil, "", fmt.Errorf("%s failed: %s", req.Method, resp.Message)
-		}
-		i++
-		log.Infof("census creation progress: %d%%", (i*100*100)/(censusSize))
-	}
-	req.CensusKeys = nil
-	req.Weights = nil
-
-	// getSize
-	log.Infof("get size")
-	req.Method = "getSize"
-	req.RootHash = nil
-	resp, err = c.Request(req, nil)
-	if err != nil {
-		return nil, "", err
-	}
-	if got := *resp.Size; int64(censusSize) != got {
-		return nil, "", fmt.Errorf("expected size %v, got %v", censusSize, got)
-	}
-
-	// publish
-	log.Infof("publish census")
-	req.Method = "publish"
-	resp, err = c.Request(req, signer)
-	if err != nil {
-		return nil, "", err
-	}
-	if !resp.Ok {
-		return nil, "", fmt.Errorf("%s failed: %s", req.Method, resp.Message)
-	}
-	uri = resp.URI
-	if len(uri) < 40 {
-		return nil, "", fmt.Errorf("got invalid URI")
-	}
-
-	// getRoot
-	log.Infof("get root")
-	req.Method = "getRoot"
-	resp, err = c.Request(req, nil)
-	if err != nil {
-		return nil, "", err
-	}
-	return resp.Root, uri, nil
 }

--- a/client/api.go
+++ b/client/api.go
@@ -1138,6 +1138,11 @@ func (c *Client) GetAccount(signer *ethereum.SignKeys, accountAddr common.Addres
 	if resp.InfoURI != "" {
 		acc.InfoURI = resp.InfoURI
 	}
+	if len(resp.Delegates) > 0 {
+		for _, v := range resp.Delegates {
+			acc.DelegateAddrs = append(acc.DelegateAddrs, common.HexToAddress(v).Bytes())
+		}
+	}
 	return acc, nil
 }
 

--- a/client/api.go
+++ b/client/api.go
@@ -1068,7 +1068,7 @@ func (c *Client) CreateAccount(signer *ethereum.SignKeys, infoURI string, nonce 
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1102,7 +1102,7 @@ func (c *Client) SetAccountInfoURI(signer *ethereum.SignKeys, to common.Address,
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1181,7 +1181,7 @@ func (c *Client) SetAccountDelegate(signer *ethereum.SignKeys, delegate common.A
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1216,7 +1216,7 @@ func (c *Client) SendTokens(from *ethereum.SignKeys, to common.Address, value ui
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = from.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = from.SignVocdoniTx(stx.Tx); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1244,7 +1244,7 @@ func (c *Client) GenerateFaucetPackage(from *ethereum.SignKeys, to common.Addres
 	if err != nil {
 		return nil, err
 	}
-	payloadSignature, err := from.Sign(payloadBytes)
+	payloadSignature, err := from.SignEthereum(payloadBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -1270,7 +1270,7 @@ func (c *Client) CollectFaucet(signer *ethereum.SignKeys, fpkg *models.FaucetPac
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1304,7 +1304,7 @@ func (c *Client) MintTokens(treasurer *ethereum.SignKeys, to common.Address, amo
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = treasurer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = treasurer.SignVocdoniTx(stx.Tx); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1321,7 +1321,7 @@ func (c *Client) MintTokens(treasurer *ethereum.SignKeys, to common.Address, amo
 	return nil
 }
 
-func (c *Client) CreateProcess(oracle *ethereum.SignKeys,
+func (c *Client) CreateProcess(signer *ethereum.SignKeys,
 	entityID, censusRoot []byte,
 	censusURI string,
 	pid []byte,
@@ -1371,7 +1371,7 @@ func (c *Client) CreateProcess(oracle *ethereum.SignKeys,
 	if err != nil {
 		return 0, err
 	}
-	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		return 0, err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {

--- a/client/testutil.go
+++ b/client/testutil.go
@@ -1,0 +1,889 @@
+package client
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vocdoni/arbo"
+	"go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/zk/artifacts"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/dvote/util"
+	models "go.vocdoni.io/proto/build/go/models"
+	"google.golang.org/protobuf/proto"
+)
+
+func (c *Client) TestPreRegisterKeys(
+	pid,
+	eid,
+	root []byte,
+	startBlock uint32,
+	signers []*ethereum.SignKeys,
+	censusOrigin models.CensusOrigin,
+	caSigner *ethereum.SignKeys,
+	proofs []*Proof,
+	doublePreRegister, checkNullifiers bool,
+	wg *sync.WaitGroup) (time.Duration, error) {
+
+	var err error
+	registerKeyWeight := "1"
+	// Generate merkle proofs
+	if proofs == nil {
+		switch censusOrigin {
+		case models.CensusOrigin_OFF_CHAIN_TREE:
+			proofs, err = c.GetMerkleProofBatch(signers, root, false)
+		case models.CensusOrigin_OFF_CHAIN_CA:
+			proofs, err = c.GetCSPproofBatch(signers, caSigner, pid)
+		default:
+			return 0, fmt.Errorf("censusOrigin not supported")
+		}
+	}
+	if err != nil {
+		return 0, err
+	}
+	// Wait until all gateway connections are ready
+	wg.Done()
+	log.Infof("%s is waiting other gateways to be ready before it can start voting", c.Addr)
+	wg.Wait()
+
+	// Wait for process to be registered
+	log.Infof("waiting for process %x to be registered...", pid)
+	for {
+		proc, err := c.GetProcessInfo(pid)
+		if err != nil {
+			log.Infof("Process not yet available: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		log.Infof("Process: %+v\n", proc)
+		break
+	}
+	cb, err := c.GetCurrentBlock()
+	if err != nil {
+		return 0, err
+	}
+	log.Infof("Current block: %v", cb)
+
+	// Send votes
+	log.Infof("sending pre-register keys")
+	timeDeadLine := time.Second * 200
+	if len(signers) > 1000 {
+		timeDeadLine = time.Duration(len(signers)/5) * time.Second
+	}
+	log.Infof("time deadline set to %d seconds", timeDeadLine/time.Second)
+	req := api.APIrequest{Method: "submitRawTx"}
+	start := time.Now()
+
+	for i := 0; i < len(signers); i++ {
+		s := signers[i]
+		zkCensusKey, _ := testGetZKCensusKey(s)
+		v := &models.RegisterKeyTx{
+			Nonce:     util.RandomBytes(32),
+			ProcessId: pid,
+			NewKey:    zkCensusKey,
+			Weight:    registerKeyWeight,
+		}
+		switch censusOrigin {
+		case models.CensusOrigin_OFF_CHAIN_TREE:
+			v.Proof = &models.Proof{
+				Payload: &models.Proof_Arbo{
+					Arbo: &models.ProofArbo{
+						Type:     models.ProofArbo_BLAKE2B,
+						Siblings: proofs[i].Siblings,
+						Value:    proofs[i].Value,
+					},
+				},
+			}
+
+		case models.CensusOrigin_OFF_CHAIN_CA:
+			p := &models.ProofCA{}
+			if err := proto.Unmarshal(proofs[i].Siblings, p); err != nil {
+				log.Fatal(err)
+			}
+			v.Proof = &models.Proof{Payload: &models.Proof_Ca{Ca: p}}
+
+		default:
+			log.Fatal("censusOrigin %s not supported", censusOrigin.String())
+		}
+
+		stx := &models.SignedTx{}
+		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_RegisterKey{RegisterKey: v}})
+		if err != nil {
+			return 0, err
+		}
+
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+			return 0, err
+		}
+		if req.Payload, err = proto.Marshal(stx); err != nil {
+			return 0, err
+		}
+		log.Debugf("pre-registering zkCensusKey:%x", zkCensusKey)
+		resp, err := c.Request(req, nil)
+		if err != nil {
+			return 0, err
+		}
+		if !resp.Ok {
+			if strings.Contains(resp.Message, "mempool is full") {
+				log.Warnf("mempool is full, waiting and retrying")
+				time.Sleep(1 * time.Second)
+				i--
+			} else {
+				// FIXME: once the req.Message are no longer in hex, remove this
+				msg, err := hex.DecodeString(resp.Message)
+				if err != nil {
+					return 0, fmt.Errorf("resp.Message hex decode: %w", err)
+				}
+				return 0, fmt.Errorf("%s failed: %s", req.Method, msg)
+			}
+		}
+		if (i+1)%100 == 0 {
+			log.Infof("pre-register progress for %s: %d%%", c.Addr, ((i+1)*100)/(len(signers)))
+		}
+
+		// Try double preRegister.  The request will not fail but
+		// that's OK.  For each user we will have 2 pre-register Txs in
+		// the pool, only one of them will succeed (the first one
+		// assuming that the node includes the transactions in the
+		// mempool received order).  Later on we check that the Rolling
+		// Census Size has the expected size, so we verify that there
+		// were no more pre-registers than expected.  And finally we
+		// vote with the first zkCensusKey for each user, making sure
+		// those pre-register succeded (and thus the second ones
+		// failed).
+		if doublePreRegister {
+			// We change the key in order to submit a different Tx
+			// with the same pre-census proof.
+			v.NewKey[1] = ^v.NewKey[1]
+			stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_RegisterKey{RegisterKey: v}})
+			if err != nil {
+				return 0, err
+			}
+			if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+				return 0, err
+			}
+			if req.Payload, err = proto.Marshal(stx); err != nil {
+				return 0, err
+			}
+			resp, err := c.Request(req, nil)
+			if err != nil {
+				return 0, err
+			}
+			// log.Warnf("DBG Double: %#v", resp)
+			if resp.Ok {
+				continue
+				// We can't detect double pre-register here yet
+				// because we're not caching the RegisterKeyTx
+				// verification.  Nevertheless when the block
+				// is mined, only one pre-register will
+				// succeed.
+				// Uncomment once we have a pre-regsiter
+				// verification cache.
+				// return 0, fmt.Errorf("double pre-register not detected")
+			}
+		}
+	}
+
+	tries := 10
+	log.Infof("checking first pre-registered key")
+	for ; tries >= 0; tries-- {
+		weight, err := c.GetRollingCensusVoterWeight(pid, signers[0].Address())
+		if err != nil {
+			return 0, fmt.Errorf("the pre-register key cannot be verified: %w", err)
+		}
+		if weight.String() == registerKeyWeight {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if tries == 0 {
+		return 0, fmt.Errorf("could not get pre-register key")
+	}
+
+	log.Infof("pre-registers submited! took %s", time.Since(start))
+	preRegisterEapsedTime := time.Since(start)
+
+	return preRegisterEapsedTime, nil
+}
+
+func (c *Client) TestSendVotes(
+	pid,
+	eid,
+	root []byte,
+	startBlock uint32,
+	signers []*ethereum.SignKeys,
+	censusOrigin models.CensusOrigin,
+	caSigner *ethereum.SignKeys,
+	proofs []*Proof,
+	encrypted, doubleVoting, checkNullifiers bool,
+	wg *sync.WaitGroup) (time.Duration, error) {
+
+	var err error
+	var keys []string
+	// Generate merkle proofs
+	if proofs == nil {
+		switch censusOrigin {
+		case models.CensusOrigin_OFF_CHAIN_TREE, models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED:
+			proofs, err = c.GetMerkleProofBatch(signers, root, false)
+		case models.CensusOrigin_OFF_CHAIN_CA:
+			proofs, err = c.GetCSPproofBatch(signers, caSigner, pid)
+		default:
+			return 0, fmt.Errorf("censusOrigin not supported")
+		}
+	}
+	if err != nil {
+		return 0, err
+	}
+	// Wait until all gateway connections are ready
+	wg.Done()
+	log.Infof("%s is waiting other gateways to be ready before it can start voting", c.Addr)
+	c.WaitUntilBlock(startBlock)
+	wg.Wait()
+
+	// Get encryption keys
+	keyIndexes := []uint32{}
+	if encrypted {
+		if pk, err := c.GetKeys(pid, eid); err != nil {
+			return 0, fmt.Errorf("cannot get process keys: (%s)", err)
+		} else {
+			for _, k := range pk.pub {
+				if len(k.Key) > 0 {
+					keyIndexes = append(keyIndexes, uint32(k.Idx))
+					keys = append(keys, k.Key)
+				}
+			}
+		}
+		if len(keys) == 0 {
+			return 0, fmt.Errorf("process keys is empty")
+		}
+		log.Infof("got encryption keys!")
+	}
+	// Send votes
+	log.Infof("sending votes")
+	timeDeadLine := time.Second * 200
+	if len(signers) > 1000 {
+		timeDeadLine = time.Duration(len(signers)/5) * time.Second
+	}
+	log.Infof("time deadline set to %d seconds", timeDeadLine/time.Second)
+	req := api.APIrequest{Method: "submitRawTx"}
+	nullifiers := []string{}
+	var vpb []byte
+	start := time.Now()
+
+	for i := 0; i < len(signers); i++ {
+		s := signers[i]
+		if vpb, err = genVote(encrypted, keys); err != nil {
+			return 0, err
+		}
+		v := &models.VoteEnvelope{
+			Nonce:                util.RandomBytes(32),
+			ProcessId:            pid,
+			VotePackage:          vpb,
+			EncryptionKeyIndexes: keyIndexes,
+		}
+		switch censusOrigin {
+		case models.CensusOrigin_OFF_CHAIN_TREE, models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED:
+			v.Proof = &models.Proof{
+				Payload: &models.Proof_Arbo{
+					Arbo: &models.ProofArbo{
+						Type:     models.ProofArbo_BLAKE2B,
+						Siblings: proofs[i].Siblings,
+						Value:    proofs[i].Value,
+					},
+				},
+			}
+
+		case models.CensusOrigin_OFF_CHAIN_CA:
+			p := &models.ProofCA{}
+			if err := proto.Unmarshal(proofs[i].Siblings, p); err != nil {
+				log.Fatal(err)
+			}
+			v.Proof = &models.Proof{Payload: &models.Proof_Ca{Ca: p}}
+
+		default:
+			log.Fatal("censusOrigin %s not supported", censusOrigin.String())
+		}
+
+		stx := &models.SignedTx{}
+		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: v}})
+		if err != nil {
+			return 0, err
+		}
+
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+			return 0, err
+		}
+		if req.Payload, err = proto.Marshal(stx); err != nil {
+			return 0, err
+		}
+		pub, _ := s.HexString()
+		log.Debugf("voting with pubKey:%s {%s}", pub, log.FormatProto(v))
+		resp, err := c.Request(req, nil)
+		if err != nil {
+			return 0, err
+		}
+		if !resp.Ok {
+			if strings.Contains(resp.Message, "mempool is full") {
+				log.Warnf("mempool is full, waiting and retrying")
+				time.Sleep(1 * time.Second)
+				i--
+			} else {
+				return 0, fmt.Errorf("%s failed: %s", req.Method, resp.Message)
+			}
+		}
+		nullifiers = append(nullifiers, resp.Payload)
+		if (i+1)%100 == 0 {
+			log.Infof("voting progress for %s: %d%%", c.Addr, ((i+1)*100)/(len(signers)))
+		}
+
+		// Try double voting (should fail)
+		if doubleVoting {
+			resp, err := c.Request(req, nil)
+			if err != nil {
+				return 0, err
+			}
+			if resp.Ok {
+				return 0, fmt.Errorf("double voting detected")
+			}
+		}
+	}
+	log.Infof("votes submited! took %s", time.Since(start))
+	checkStart := time.Now()
+	registered := 0
+	log.Infof("waiting for votes to be validated...")
+	for {
+		time.Sleep(time.Millisecond * 500)
+		if h, err := c.GetEnvelopeHeight(pid); err != nil {
+			log.Warnf("error getting envelope height: %v", err)
+			continue
+		} else {
+			if h >= uint32(len(signers)) {
+				break
+			}
+		}
+		if time.Since(checkStart) > timeDeadLine {
+			return 0, fmt.Errorf("waiting for envelope height took longer than deadline, skipping")
+		}
+	}
+	votingElapsedTime := time.Since(start)
+
+	if !checkNullifiers {
+		return votingElapsedTime, nil
+	}
+	// If checkNullifiers, wait until all votes have been verified
+	for {
+		for i, nullHex := range nullifiers {
+			if nullHex == "registered" {
+				registered++
+				continue
+			}
+			null, err := hex.DecodeString(nullHex)
+			if err != nil {
+				return 0, err
+			}
+			if es, _ := c.GetEnvelopeStatus(null, pid); es {
+				nullifiers[i] = "registered"
+			}
+		}
+		if registered == len(nullifiers) {
+			break
+		}
+		registered = 0
+		if time.Since(checkStart) > timeDeadLine {
+			return 0, fmt.Errorf("checking nullifier time took more than deadline, skipping")
+		}
+	}
+
+	return votingElapsedTime, nil
+}
+
+func (c *Client) TestSendAnonVotes(
+	pid,
+	eid,
+	root []byte,
+	startBlock uint32,
+	signers []*ethereum.SignKeys,
+	doubleVoting, checkNullifiers bool,
+	wg *sync.WaitGroup) (time.Duration, error) {
+
+	proofs, err := c.GetMerkleProofPoseidonBatch(signers, root, false)
+	if err != nil {
+		return 0, err
+	}
+	log.Infof("Requested %v proofs", len(proofs))
+	circuitIndex, circuitConfig, err := c.GetCircuitConfig(pid)
+	if err != nil {
+		return 0, err
+	}
+	log.Infof("CircuitIndex: %v, CircuitPath: %+v", *circuitIndex, circuitConfig.CircuitPath)
+	// Wait until all gateway connections are ready
+	wg.Done()
+	log.Infof("%s is waiting other gateways to be ready before it can start voting", c.Addr)
+	c.WaitUntilBlock(startBlock)
+	wg.Wait()
+
+	log.Infof("Downloading Circuit Artifacts")
+	circuitConfig.LocalDir = "/tmp"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	if err := artifacts.DownloadCircuitFiles(ctx, *circuitConfig); err != nil {
+		return 0, err
+	}
+
+	// Send votes
+	log.Infof("sending votes")
+	timeDeadLine := time.Second * 200
+	if len(signers) > 1000 {
+		timeDeadLine = time.Duration(len(signers)/5) * time.Second
+	}
+	log.Infof("time deadline set to %d seconds", timeDeadLine/time.Second)
+	req := api.APIrequest{Method: "submitRawTx"}
+	nullifiers := []string{}
+	var vpb []byte
+	start := time.Now()
+
+	for i := 0; i < len(signers); i++ {
+		s := signers[i]
+		if vpb, err = genVote(false, nil); err != nil {
+			return 0, err
+		}
+		_, secretKey := testGetZKCensusKey(s)
+		proof, nullifier, err := testGenSNARKProof(*circuitIndex, circuitConfig,
+			root, proofs[i].Siblings, circuitConfig.Parameters[0], secretKey, vpb, pid)
+		if err != nil {
+			return 0, fmt.Errorf("cannot generate test SNARK proof: %w", err)
+		}
+		v := &models.VoteEnvelope{
+			Nonce:       util.RandomBytes(32),
+			ProcessId:   pid,
+			VotePackage: vpb,
+			Nullifier:   nullifier,
+		}
+		v.Proof = &models.Proof{
+			Payload: &models.Proof_ZkSnark{
+				ZkSnark: &models.ProofZkSNARK{
+					CircuitParametersIndex: int32(*circuitIndex),
+					A:                      proof.A,
+					B:                      proof.B,
+					C:                      proof.C,
+					// PublicInputs is not used in the
+					// anonymous-voting flow, as the only
+					// needed public input from user's side
+					// is the nullifier, which is already
+					// in the VoteEnvelope struct
+				},
+			},
+		}
+
+		stx := &models.SignedTx{}
+		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: v}})
+		if err != nil {
+			return 0, err
+		}
+
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+			return 0, err
+		}
+		if req.Payload, err = proto.Marshal(stx); err != nil {
+			return 0, err
+		}
+		pub, _ := s.HexString()
+		log.Debugf("voting with pubKey:%s", pub)
+		resp, err := c.Request(req, nil)
+		if err != nil {
+			return 0, err
+		}
+		if !resp.Ok {
+			if strings.Contains(resp.Message, "mempool is full") {
+				log.Warnf("mempool is full, waiting and retrying")
+				time.Sleep(1 * time.Second)
+				i--
+			} else {
+				// FIXME: once the req.Message are no longer in hex, remove this
+				msg, err := hex.DecodeString(resp.Message)
+				if err != nil {
+					return 0, fmt.Errorf("resp.Message hex decode: %w", err)
+				}
+				return 0, fmt.Errorf("%s failed: %s", req.Method, msg)
+			}
+		}
+		nullifiers = append(nullifiers, resp.Payload)
+		if (i+1)%100 == 0 {
+			log.Infof("voting progress for %s: %d%%", c.Addr, ((i+1)*100)/(len(signers)))
+		}
+
+		// Try double voting (should fail)
+		if doubleVoting {
+			resp, err := c.Request(req, nil)
+			if err != nil {
+				return 0, err
+			}
+			if resp.Ok {
+				return 0, fmt.Errorf("double voting not detected")
+			}
+		}
+	}
+	log.Infof("votes submited! took %s", time.Since(start))
+	checkStart := time.Now()
+	registered := 0
+	log.Infof("waiting for votes to be validated...")
+	for {
+		time.Sleep(time.Millisecond * 500)
+		if h, err := c.GetEnvelopeHeight(pid); err != nil {
+			log.Warnf("error getting envelope height: %v", err)
+			continue
+		} else {
+			if h >= uint32(len(signers)) {
+				break
+			}
+		}
+		if time.Since(checkStart) > timeDeadLine {
+			return 0, fmt.Errorf("waiting for envelope height took longer than deadline, skipping")
+		}
+	}
+	votingElapsedTime := time.Since(start)
+
+	if !checkNullifiers {
+		return votingElapsedTime, nil
+	}
+	// If checkNullifiers, wait until all votes have been verified
+	for {
+		for i, nullHex := range nullifiers {
+			if nullHex == "registered" {
+				registered++
+				continue
+			}
+			null, err := hex.DecodeString(nullHex)
+			if err != nil {
+				return 0, err
+			}
+			if es, _ := c.GetEnvelopeStatus(null, pid); es {
+				nullifiers[i] = "registered"
+			}
+		}
+		if registered == len(nullifiers) {
+			break
+		}
+		registered = 0
+		if time.Since(checkStart) > timeDeadLine {
+			return 0, fmt.Errorf("checking nullifier time took more than deadline, skipping")
+		}
+	}
+
+	return votingElapsedTime, nil
+}
+
+// TestCreateCensus creates a new census on the remote gateway and publishes it.
+// Users public keys can be added using censusSigner (ethereum.SignKeys) or
+// censusPubKeys (raw hex public keys).
+// censusValues can be empty for a non-weighted census
+func (c *Client) TestCreateCensus(signer *ethereum.SignKeys, censusSigners []*ethereum.SignKeys,
+	censusPubKeys []string, censusValues []*types.BigInt) (root []byte, uri string, _ error) {
+	var req api.APIrequest
+
+	// Create census
+	log.Infof("Create census")
+	req.Method = "addCensus"
+	req.CensusType = models.Census_ARBO_BLAKE2B
+	req.CensusID = fmt.Sprintf("test%d", rand.Int())
+	resp, err := c.Request(req, signer)
+	if err != nil {
+		return nil, "", err
+	}
+	if !resp.Ok {
+		return nil, "", fmt.Errorf("%s failed: %s", req.Method, resp.Message)
+	}
+	// Set correct censusID for commint requests
+	req.CensusID = resp.CensusID
+
+	// addClaimBulk
+	censusSize := 0
+	if censusSigners != nil {
+		censusSize = len(censusSigners)
+	} else {
+		censusSize = len(censusPubKeys)
+	}
+	if len(censusValues) > 0 && len(censusValues) != censusSize {
+		return nil, "", fmt.Errorf("census keys and values are not the same lenght (%d != %d)",
+			censusSize, len(censusValues))
+	}
+	log.Infof("add bulk claims (size %d)", censusSize)
+	req.Method = "addClaimBulk"
+	req.CensusKey = []byte{}
+	req.Digested = false
+	currentSize := censusSize
+	i := 0
+	var hexpub string
+	for currentSize > 0 {
+		claims := [][]byte{}
+		values := []*types.BigInt{}
+		for j := 0; j < 100; j++ {
+			if currentSize < 1 {
+				break
+			}
+			if censusSigners != nil {
+				hexpub, _ = censusSigners[currentSize-1].HexString()
+			} else {
+				hexpub = censusPubKeys[currentSize-1]
+			}
+			pub, err := hex.DecodeString(hexpub)
+			if err != nil {
+				return nil, "", err
+			}
+			claims = append(claims, pub)
+			if len(censusValues) > 0 {
+				values = append(values, censusValues[currentSize-1])
+			}
+			currentSize--
+		}
+		req.CensusKeys = claims
+		req.Weights = values
+		resp, err := c.Request(req, signer)
+		if err != nil {
+			return nil, "", err
+		}
+		if !resp.Ok {
+			return nil, "", fmt.Errorf("%s failed: %s", req.Method, resp.Message)
+		}
+		i++
+		log.Infof("census creation progress: %d%%", (i*100*100)/(censusSize))
+	}
+	req.CensusKeys = nil
+	req.Weights = nil
+
+	// getSize
+	log.Infof("get size")
+	req.Method = "getSize"
+	req.RootHash = nil
+	resp, err = c.Request(req, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	if got := *resp.Size; int64(censusSize) != got {
+		return nil, "", fmt.Errorf("expected size %v, got %v", censusSize, got)
+	}
+
+	// publish
+	log.Infof("publish census")
+	req.Method = "publish"
+	resp, err = c.Request(req, signer)
+	if err != nil {
+		return nil, "", err
+	}
+	if !resp.Ok {
+		return nil, "", fmt.Errorf("%s failed: %s", req.Method, resp.Message)
+	}
+	uri = resp.URI
+	if len(uri) < 40 {
+		return nil, "", fmt.Errorf("got invalid URI")
+	}
+
+	// getRoot
+	log.Infof("get root")
+	req.Method = "getRoot"
+	resp, err = c.Request(req, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Root, uri, nil
+}
+
+// TestCreateProcess sends a NewProcessTx transaction for creating a process with the given parameters
+func (c *Client) TestCreateProcess(signer *ethereum.SignKeys,
+	entityID, censusRoot []byte,
+	censusURI string,
+	pid []byte,
+	envelopeType *models.EnvelopeType,
+	mode *models.ProcessMode,
+	censusOrigin models.CensusOrigin,
+	startBlockIncrement int,
+	duration int,
+	maxCensusSize uint64) (uint32, error) {
+
+	startBlock := uint32(0)
+	if startBlockIncrement > 0 {
+		current, err := c.GetCurrentBlock()
+		if err != nil {
+			return 0, err
+		}
+		startBlock = current + uint32(startBlockIncrement)
+	}
+
+	var req api.APIrequest
+	req.Method = "submitRawTx"
+	if mode == nil {
+		mode = &models.ProcessMode{AutoStart: true, Interruptible: true}
+	}
+	processData := &models.Process{
+		EntityId:      entityID,
+		CensusRoot:    censusRoot,
+		CensusURI:     &censusURI,
+		CensusOrigin:  censusOrigin,
+		BlockCount:    uint32(duration),
+		ProcessId:     pid,
+		StartBlock:    startBlock,
+		EnvelopeType:  envelopeType,
+		Mode:          mode,
+		Status:        models.ProcessStatus_READY,
+		VoteOptions:   &models.ProcessVoteOptions{MaxCount: 16, MaxValue: 8},
+		MaxCensusSize: &maxCensusSize,
+	}
+	p := &models.NewProcessTx{
+		Txtype:  models.TxType_NEW_PROCESS,
+		Nonce:   util.RandomBytes(32),
+		Process: processData,
+	}
+	var err error
+	stx := &models.SignedTx{}
+	stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_NewProcess{NewProcess: p}})
+	if err != nil {
+		return 0, err
+	}
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
+		return 0, err
+	}
+	if req.Payload, err = proto.Marshal(stx); err != nil {
+		return 0, err
+	}
+
+	resp, err := c.Request(req, nil)
+	if err != nil {
+		return 0, err
+	}
+	if !resp.Ok {
+		return 0, fmt.Errorf("%s failed: %s", req.Method, resp.Message)
+	}
+	if startBlockIncrement == 0 {
+		for i := 0; i < 10; i++ {
+			time.Sleep(2 * time.Second)
+			p, err := c.GetProcessInfo(pid)
+			if err == nil && p != nil {
+				return p.StartBlock, nil
+			}
+		}
+		return 0, fmt.Errorf("process was not created")
+	}
+	return startBlock, nil
+}
+
+func testGenSNARKProof(circuitIndex int, circuitConfig *artifacts.CircuitConfig,
+	censusRoot, merkleProof []byte, treeSize int64,
+	secretKey, votePackage, processId []byte) (*SNARKProof, []byte, error) {
+	if len(merkleProof) < 8 {
+		return nil, nil, fmt.Errorf("merkleProof too short")
+	}
+	indexLE := merkleProof[:8]
+	index := binary.LittleEndian.Uint64(indexLE)
+	siblingsBytes := merkleProof[8:]
+
+	levels := int(math.Log2(float64(treeSize)))
+	siblings, err := arbo.UnpackSiblings(arbo.HashFunctionPoseidon, siblingsBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot arbo.UnpackSiblings: %w", err)
+	}
+	for i := len(siblings); i < levels; i++ {
+		siblings = append(siblings, []byte{0})
+	}
+	siblings = append(siblings, []byte{0})
+	var siblingsStr []string
+	for i := 0; i < len(siblings); i++ {
+		siblingsStr = append(siblingsStr, arbo.BytesToBigInt(siblings[i]).String())
+	}
+
+	voteHash := sha256.Sum256(votePackage)
+	voteHash0, voteHash1 := voteHash[:16], voteHash[16:]
+
+	processId0, processId1 := processId[:16], processId[16:]
+	poseidon := arbo.HashPoseidon{}
+	nullifier, err := poseidon.Hash(
+		secretKey,
+		processId0,
+		processId1,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("poseidon: %w", err)
+	}
+
+	inputs := SNARKProofInputs{
+		CensusRoot:     arbo.BytesToBigInt(censusRoot).String(),
+		CensusSiblings: siblingsStr,
+		Index:          new(big.Int).SetUint64(index).String(),
+		SecretKey:      arbo.BytesToBigInt(secretKey).String(),
+		VoteHash: []string{
+			arbo.BytesToBigInt(voteHash0).String(),
+			arbo.BytesToBigInt(voteHash1).String(),
+		},
+		ProcessID: []string{
+			arbo.BytesToBigInt(processId0).String(),
+			arbo.BytesToBigInt(processId1).String(),
+		},
+		Nullifier: arbo.BytesToBigInt(nullifier).String(),
+	}
+	data := GenSNARKData{
+		CircuitIndex:  circuitIndex,
+		CircuitConfig: circuitConfig,
+		Inputs:        inputs,
+	}
+	dataJSON, err := json.Marshal(&data)
+	if err != nil {
+		return nil, nil, err
+	}
+	log.Debugf("gen-vote-snark.js input: %v", string(dataJSON))
+	cmd := exec.Command("node", "/app/js/gen-vote-snark.js", string(dataJSON))
+	proofJSON, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, nil, fmt.Errorf("node /app/js/gen-vote-snark.js: %w\n%s",
+			err, string(proofJSON))
+	}
+	log.Debugf("gen-vote-snark.js output: %v", string(proofJSON))
+	var proofCircom SNARKProofCircom
+	if err := json.Unmarshal(proofJSON, &proofCircom); err != nil {
+		return nil, nil, fmt.Errorf("/app/js/gen-vote-snark.js output unmarshal: %w\n%s",
+			err, string(proofJSON))
+	}
+	return &SNARKProof{
+		A: proofCircom.A,
+		B: []string{
+			proofCircom.B[0][0], proofCircom.B[0][1],
+			proofCircom.B[1][0], proofCircom.B[1][1],
+			proofCircom.B[2][0], proofCircom.B[2][1],
+		},
+		C: proofCircom.C,
+		// PublicInputs is not used in the anonymous-voting flow, as
+		// the only needed public input from user's side is the
+		// nullifier, which is already in the VoteEnvelope struct
+	}, nullifier, nil
+}
+
+// testGetZKCensusKey returns zkCensusKey, secretKey.  For testing purposes, we
+// generate a secretKey from a signature by the ethereum key.
+func testGetZKCensusKey(s *ethereum.SignKeys) ([]byte, []byte) {
+	// secret is 65 bytes
+	secret, err := s.SignVocdoniMsg([]byte("secretKey"))
+	if err != nil {
+		log.Fatalf("Cannot sign: %v", err)
+	}
+	hasher := arbo.HashPoseidon{}
+	secretKey, err := hasher.Hash(secret[:22], secret[22:44], secret[44:])
+	if err != nil {
+		log.Fatalf("Cannnot calculate pre-register key with Poseidon: %v", err)
+	}
+	pubKey, err := hasher.Hash(secretKey)
+	if err != nil {
+		log.Fatalf("Cannnot calculate pre-register key with Poseidon: %v", err)
+	}
+	return pubKey, secretKey
+}

--- a/client/zk.go
+++ b/client/zk.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"go.vocdoni.io/dvote/crypto/zk/artifacts"
+)
+
+type SNARKProofCircom struct {
+	A []string   `json:"pi_a"`
+	B [][]string `json:"pi_b"`
+	C []string   `json:"pi_c"`
+	// PublicInputs []string // onl
+}
+
+type SNARKProof struct {
+	A            []string
+	B            []string
+	C            []string
+	PublicInputs []string // only nullifier
+}
+
+type SNARKProofInputs struct {
+	CensusRoot     string   `json:"censusRoot"`
+	CensusSiblings []string `json:"censusSiblings"`
+	Index          string   `json:"index"`
+	SecretKey      string   `json:"secretKey"`
+	VoteHash       []string `json:"voteHash"`
+	ProcessID      []string `json:"processId"`
+	Nullifier      string   `json:"nullifier"`
+}
+
+type GenSNARKData struct {
+	CircuitIndex  int                      `json:"circuitIndex"`
+	CircuitConfig *artifacts.CircuitConfig `json:"circuitConfig"`
+	Inputs        SNARKProofInputs         `json:"inputs"`
+}

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -287,13 +287,23 @@ func mkTreeVoteTest(host,
 	}
 	defer mainClient.Close()
 
+	chainId, err := mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+	oracleKey.VocdoniChainID = chainId
+	entityKey.VocdoniChainID = chainId
 	// create and top-up entity account
-	mainClient.CreateAccount(entityKey, "ipfs://", 0)
+	if err := mainClient.CreateAccount(entityKey, "ipfs://", 0); err != nil {
+		log.Fatal(err)
+	}
 	treasurer, err := mainClient.GetTreasurer(oracleKey)
 	if err != nil {
 		log.Fatal(err)
 	}
-	mainClient.MintTokens(oracleKey, entityKey.Address(), 10000, treasurer.Nonce)
+	if err := mainClient.MintTokens(oracleKey, entityKey.Address(), 10000, treasurer.Nonce); err != nil {
+		log.Fatal(err)
+	}
 	h, err := mainClient.GetCurrentBlock()
 	if err != nil {
 		log.Fatal("cannot get current height")
@@ -332,7 +342,7 @@ func mkTreeVoteTest(host,
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
 	start, err := mainClient.CreateProcess(
-		oracleKey,
+		entityKey,
 		entityKey.Address().Bytes(),
 		censusRoot,
 		censusURI,
@@ -393,12 +403,6 @@ func mkTreeVoteTest(host,
 		log.Infof("all gateways retrieved the census! let's start voting")
 	}
 
-	// Get chainID
-	chID, err := mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Send votes
 	i := 0
 	p := len(censusKeys) / len(clients)
@@ -425,7 +429,7 @@ func mkTreeVoteTest(host,
 			copy(gwProofs, proofs[i:i+p])
 		}
 		for _, gws := range gwSigners {
-			gws.VocdoniChainID = chID
+			gws.VocdoniChainID = chainId
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -558,6 +562,13 @@ func mkTreeAnonVoteTest(host,
 	}
 	defer mainClient.Close()
 
+	chainId, err := mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+	oracleKey.VocdoniChainID = chainId
+	entityKey.VocdoniChainID = chainId
+
 	// create and top-up entity account
 	mainClient.CreateAccount(entityKey, "ipfs://", 0)
 	treasurer, err := mainClient.GetTreasurer(oracleKey)
@@ -603,7 +614,7 @@ func mkTreeAnonVoteTest(host,
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
 	start, err := mainClient.CreateProcess(
-		oracleKey,
+		entityKey,
 		entityKey.Address().Bytes(),
 		censusRoot,
 		censusURI,
@@ -664,12 +675,6 @@ func mkTreeAnonVoteTest(host,
 		log.Infof("all gateways retrieved the census! let's start voting")
 	}
 
-	// Get chainID
-	chID, err := mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Pre-register keys zkCensusKey
 	i := 0
 	p := len(censusKeys) / len(clients)
@@ -696,7 +701,7 @@ func mkTreeAnonVoteTest(host,
 			copy(gwProofs, proofs[i:i+p])
 		}
 		for _, gws := range gwSigners {
-			gws.VocdoniChainID = chID
+			gws.VocdoniChainID = chainId
 		}
 		log.Infof("%s will receive %d register keys", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -780,7 +785,7 @@ func mkTreeAnonVoteTest(host,
 			copy(gwSigners, censusKeys[i:i+p])
 		}
 		for _, gws := range gwSigners {
-			gws.VocdoniChainID = chID
+			gws.VocdoniChainID = chainId
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -896,6 +901,13 @@ func cspVoteTest(
 	}
 	defer mainClient.Close()
 
+	chainId, err := mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+	oracleKey.VocdoniChainID = chainId
+	entityKey.VocdoniChainID = chainId
+
 	// create and top-up entity account
 	mainClient.CreateAccount(entityKey, "ipfs://", 0)
 	treasurer, err := mainClient.GetTreasurer(oracleKey)
@@ -908,7 +920,7 @@ func cspVoteTest(
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
 	start, err := mainClient.CreateProcess(
-		oracleKey,
+		entityKey,
 		entityKey.Address().Bytes(),
 		cspKey.PublicKey(),
 		"https://dumycsp.foo",
@@ -949,12 +961,6 @@ func cspVoteTest(
 		clients = append(clients, cl)
 	}
 
-	// Get chainID
-	chID, err := mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Send votes
 	i := 0
 	p := len(voters) / len(clients)
@@ -976,7 +982,7 @@ func cspVoteTest(
 			copy(gwSigners, voters[i:i+p])
 		}
 		for _, gws := range gwSigners {
-			gws.VocdoniChainID = chID
+			gws.VocdoniChainID = chainId
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -1053,6 +1059,11 @@ func testAllTransactions(
 	}
 	defer mainClient.Close()
 
+	chainId, err := mainClient.GetChainID()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// create and top-up main entity account
 	h, err := mainClient.GetCurrentBlock()
 	if err != nil {
@@ -1062,6 +1073,10 @@ func testAllTransactions(
 	if err := randomSigner.Generate(); err != nil {
 		log.Fatal(err)
 	}
+
+	oracleKey.VocdoniChainID = chainId
+	randomSigner.VocdoniChainID = chainId
+
 	mainClient.CreateAccount(randomSigner, "ipfs://", 0)
 	treasurer, err := mainClient.GetTreasurer(oracleKey)
 	if err != nil {
@@ -1074,6 +1089,7 @@ func testAllTransactions(
 	if err := newSigner.Generate(); err != nil {
 		log.Fatal(err)
 	}
+	newSigner.VocdoniChainID = chainId
 	err = mainClient.CreateAccount(newSigner, "ipfs://xyz", 0)
 	if err != nil {
 		log.Fatalf("cannot create account: %v", err)
@@ -1098,7 +1114,7 @@ func testAllTransactions(
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := mainClient.MintTokens(oracleKey, newSigner.Address(), 100, treasurer.Nonce); err != nil {
+	if err := mainClient.MintTokens(oracleKey, newSigner.Address(), 15000, treasurer.Nonce); err != nil {
 		log.Fatalf("cannot mint tokens: %v", err)
 	}
 	log.Infof("minted 15000 tokens to account %s", newSigner.Address().String())
@@ -1240,8 +1256,8 @@ func testAllTransactions(
 	if newSignerAccount.Nonce != 1 {
 		log.Fatalf("expected nonce %d for account %s, got %d", 1, newSigner.Address().String(), newSignerAccount.Nonce)
 	}
-	if newSignerAccount.Balance != 2090 {
-		log.Fatalf("expected balance %d for account %s, got %d", 2090, newSigner.Address().String(), newSignerAccount.Balance)
+	if newSignerAccount.Balance != 16990 {
+		log.Fatalf("expected balance %d for account %s, got %d", 16990, newSigner.Address().String(), newSignerAccount.Balance)
 	}
 
 	log.Info("all done!")

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -171,7 +171,7 @@ func censusGenerate(host string, signer *ethereum.SignKeys, size int, filepath s
 		weights = append(weights, new(types.BigInt).SetUint64(withWeight))
 	}
 
-	root, uri, err := cl.CreateCensus(signer, keys, nil, weights)
+	root, uri, err := cl.TestCreateCensus(signer, keys, nil, weights)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func censusImport(host string, signer *ethereum.SignKeys) {
 		keys = append(keys, pubk)
 		i++
 	}
-	root, uri, err := cl.CreateCensus(signer, nil, keys, nil)
+	root, uri, err := cl.TestCreateCensus(signer, nil, keys, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -295,7 +295,7 @@ func mkTreeVoteTest(host,
 	oracleKey.VocdoniChainID = chainId
 	entityKey.VocdoniChainID = chainId
 	// create and top-up entity account
-	if err := mainClient.CreateAccount(entityKey, "ipfs://", 0); err != nil {
+	if err := mainClient.CreateOrSetAccount(entityKey, common.Address{}, "ipfs://", 0); err != nil {
 		log.Fatal(err)
 	}
 	treasurer, err := mainClient.GetTreasurer(oracleKey)
@@ -321,7 +321,7 @@ func mkTreeVoteTest(host,
 		}
 	}
 	// create and top-up oracle
-	mainClient.CreateAccount(oracleKey, "ipfs://", 0)
+	mainClient.CreateOrSetAccount(oracleKey, common.Address{}, "ipfs://", 0)
 	mainClient.MintTokens(oracleKey, oracleKey.Address(), 10000, treasurer.Nonce+1)
 	h, err = mainClient.GetCurrentBlock()
 	if err != nil {
@@ -342,7 +342,7 @@ func mkTreeVoteTest(host,
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
-	start, err := mainClient.CreateProcess(
+	start, err := mainClient.TestCreateProcess(
 		entityKey,
 		entityKey.Address().Bytes(),
 		censusRoot,
@@ -571,7 +571,7 @@ func mkTreeAnonVoteTest(host,
 	entityKey.VocdoniChainID = chainId
 
 	// create and top-up entity account
-	mainClient.CreateAccount(entityKey, "ipfs://", 0)
+	mainClient.CreateOrSetAccount(entityKey, common.Address{}, "ipfs://", 0)
 	treasurer, err := mainClient.GetTreasurer(oracleKey)
 	if err != nil {
 		log.Fatal(err)
@@ -593,7 +593,7 @@ func mkTreeAnonVoteTest(host,
 		}
 	}
 	// create and top-up oracle
-	mainClient.CreateAccount(oracleKey, "ipfs://", 0)
+	mainClient.CreateOrSetAccount(oracleKey, common.Address{}, "ipfs://", 0)
 	mainClient.MintTokens(oracleKey, oracleKey.Address(), 10000, treasurer.Nonce+1)
 	h, err = mainClient.GetCurrentBlock()
 	if err != nil {
@@ -614,7 +614,7 @@ func mkTreeAnonVoteTest(host,
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
-	start, err := mainClient.CreateProcess(
+	start, err := mainClient.TestCreateProcess(
 		entityKey,
 		entityKey.Address().Bytes(),
 		censusRoot,
@@ -910,7 +910,7 @@ func cspVoteTest(
 	entityKey.VocdoniChainID = chainId
 
 	// create and top-up entity account
-	mainClient.CreateAccount(entityKey, "ipfs://", 0)
+	mainClient.CreateOrSetAccount(entityKey, common.Address{}, "ipfs://", 0)
 	treasurer, err := mainClient.GetTreasurer(oracleKey)
 	if err != nil {
 		log.Fatal(err)
@@ -920,7 +920,7 @@ func cspVoteTest(
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
-	start, err := mainClient.CreateProcess(
+	start, err := mainClient.TestCreateProcess(
 		entityKey,
 		entityKey.Address().Bytes(),
 		cspKey.PublicKey(),
@@ -1074,7 +1074,7 @@ func testAllTransactions(
 	oracleKey.VocdoniChainID = chainId
 	mainSigner.VocdoniChainID = chainId
 
-	if err := mainClient.CreateAccount(mainSigner, "ipfs://", 0); err != nil {
+	if err := mainClient.CreateOrSetAccount(mainSigner, common.Address{}, "ipfs://", 0); err != nil {
 		log.Fatal(err)
 	}
 	treasurer, err := mainClient.GetTreasurer(oracleKey)
@@ -1133,7 +1133,7 @@ func testAllTransactions(
 		log.Fatal(err)
 	}
 	newSigner.VocdoniChainID = chainId
-	err = mainClient.CreateAccount(newSigner, "ipfs://xyz", 0)
+	err = mainClient.CreateOrSetAccount(newSigner, common.Address{}, "ipfs://xyz", 0)
 	if err != nil {
 		log.Fatalf("cannot create account: %v", err)
 	}
@@ -1193,7 +1193,7 @@ func testAllTransactions(
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := mainClient.CreateAccount(mainSigner, "ipfs://xyz", mainSignerAccount.Nonce); err != nil {
+	if err := mainClient.CreateOrSetAccount(mainSigner, common.Address{}, "ipfs://xyz", mainSignerAccount.Nonce); err != nil {
 		log.Fatalf("cannot change account info: %v", err)
 	}
 
@@ -1254,7 +1254,7 @@ func testAllTransactions(
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := mainClient.SetAccountInfoURI(newSigner, mainSigner.Address(), "ipfs://zyx", newSignerAccount.Nonce); err != nil {
+	if err := mainClient.CreateOrSetAccount(newSigner, mainSigner.Address(), "ipfs://zyx", newSignerAccount.Nonce); err != nil {
 		log.Fatalf("cannot change account info: %v", err)
 	}
 	h, err = mainClient.GetCurrentBlock()

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -294,6 +294,39 @@ func mkTreeVoteTest(host,
 		log.Fatal(err)
 	}
 	mainClient.MintTokens(oracleKey, entityKey.Address(), 10000, treasurer.Nonce)
+	h, err := mainClient.GetCurrentBlock()
+	if err != nil {
+		log.Fatal("cannot get current height")
+	}
+	for {
+		time.Sleep(time.Millisecond * 500)
+		if h2, err := mainClient.GetCurrentBlock(); err != nil {
+			log.Warnf("error getting current height: %v", err)
+			continue
+		} else {
+			if h2 > h {
+				break
+			}
+		}
+	}
+	// create and top-up oracle
+	mainClient.CreateAccount(oracleKey, "ipfs://", 0)
+	mainClient.MintTokens(oracleKey, oracleKey.Address(), 10000, treasurer.Nonce+1)
+	h, err = mainClient.GetCurrentBlock()
+	if err != nil {
+		log.Fatal("cannot get current height")
+	}
+	for {
+		time.Sleep(time.Millisecond * 500)
+		if h2, err := mainClient.GetCurrentBlock(); err != nil {
+			log.Warnf("error getting current height: %v", err)
+			continue
+		} else {
+			if h2 > h {
+				break
+			}
+		}
+	}
 
 	// Create process
 	pid := client.Random(32)
@@ -532,6 +565,39 @@ func mkTreeAnonVoteTest(host,
 		log.Fatal(err)
 	}
 	mainClient.MintTokens(oracleKey, entityKey.Address(), 10000, treasurer.Nonce)
+	h, err := mainClient.GetCurrentBlock()
+	if err != nil {
+		log.Fatal("cannot get current height")
+	}
+	for {
+		time.Sleep(time.Millisecond * 500)
+		if h2, err := mainClient.GetCurrentBlock(); err != nil {
+			log.Warnf("error getting current height: %v", err)
+			continue
+		} else {
+			if h2 > h {
+				break
+			}
+		}
+	}
+	// create and top-up oracle
+	mainClient.CreateAccount(oracleKey, "ipfs://", 0)
+	mainClient.MintTokens(oracleKey, oracleKey.Address(), 10000, treasurer.Nonce+1)
+	h, err = mainClient.GetCurrentBlock()
+	if err != nil {
+		log.Fatal("cannot get current height")
+	}
+	for {
+		time.Sleep(time.Millisecond * 500)
+		if h2, err := mainClient.GetCurrentBlock(); err != nil {
+			log.Warnf("error getting current height: %v", err)
+			continue
+		} else {
+			if h2 > h {
+				break
+			}
+		}
+	}
 
 	// Create process
 	pid := client.Random(32)

--- a/dockerfiles/testsuite/genesis.json
+++ b/dockerfiles/testsuite/genesis.json
@@ -170,15 +170,20 @@
     "oracles": [
       "0xf7FB77ee1F309D9468fB6DCB71aDD0f934a33c6B"
     ],
-    "treasurer": "0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d",
+    "processes": {},
+    "treasurer": "0xf7FB77ee1F309D9468fB6DCB71aDD0f934a33c6B",
     "tx_cost": {
-       "Tx_SetProcess": 100,
-       "Tx_RegisterKey": 100,
-       "Tx_NewProcess": 100,
-       "Tx_SendTokens": 100,
-       "Tx_SetAccountInfo": 100,
-       "Tx_SetAccountDelegate": 100,
-       "Tx_CollectFaucet": 100
-     }
-  }
+        "Tx_SetProcessStatus": 10,
+        "Tx_SetProcessCensus": 10,
+        "Tx_SetProcessResults": 10,
+        "Tx_SetProcessQuestionIndex": 10,
+        "Tx_RegisterKey": 10,
+        "Tx_NewProcess": 10,
+        "Tx_SendTokens": 10,
+        "Tx_SetAccountInfo": 10,
+        "Tx_AddDelegateForAccount": 10,
+        "Tx_DelDelegateForAccount": 10,
+        "Tx_CollectFaucet": 10
+      }
+    }
 }

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -6,6 +6,7 @@ set -x
 #  2: run encrypted vote test
 #  3: run anonymous vote test
 #  4: run csp vote test
+#  5: run all transactions test (end-user voting is not included)
 
 export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1
 ORACLE_KEY=${TESTSUITE_ORACLE_KEY:-6aae1d165dd9776c580b8fdaf8622e39c5f943c715e20690080bbfce2c760223}
@@ -26,6 +27,8 @@ test_anon() {
 
 test_csp() {
 	docker-compose run test timeout 300 ./vochaintest --oracleKey=$ORACLE_KEY --electionSize=$ELECTION_SIZE --gwHost http://gateway:9090/dvote --logLevel=$LOGLEVEL --operation=cspvoting --electionType=$1
+test_txs() {
+	docker-compose run test timeout 300 ./vochaintest --oracleKey=$ORACLE_KEY --gwHost http://gateway:9090/dvote --logLevel=$LOGLEVEL --operation=testtxs
 	echo $? >$1
 }
 
@@ -63,7 +66,16 @@ testid="/tmp/.vochaintest$RANDOM"
 	test test_csp ${testid}4 &
 } || echo 0 >${testid}4
 
-echo "### Waiting for tests ###"
+echo "### Waiting for voting process tests ###"
+wait
+
+echo "### Waiting for all state txs tests ###"
+
+[ $TEST -eq 5 -o $TEST -eq 0 ] && {
+	echo "### Running test 5 ###"
+	test_txs ${testid}5 &
+} || echo 0 >${testid}5
+
 wait
 
 [ $CLEAN -eq 1 ] && {
@@ -71,7 +83,7 @@ wait
 	docker-compose down -v --remove-orphans
 }
 
-[ "$(cat ${testid}1)" == "0" -a "$(cat ${testid}2)" == "0" -a "$(cat ${testid}3)" == "0" -a "$(cat ${testid}4)" == "0" ] && {
+[ "$(cat ${testid}1)" == "0" -a "$(cat ${testid}2)" == "0" -a "$(cat ${testid}3)" == "0" -a "$(cat ${testid}4)" == "0" -a "$(cat ${testid}5)" == "0" ] && {
 	echo "Vochain test finished correctly!"
 	RET=0
 } || {
@@ -80,5 +92,5 @@ wait
 	echo "### Post run logs ###"
 	docker-compose logs --tail 1000
 }
-rm -f ${testid}1 ${testid}2 ${testid}3 ${testid}4
+rm -f ${testid}1 ${testid}2 ${testid}3 ${testid}4 ${testid}5
 exit $RET

--- a/rpcapi/accounthandlers.go
+++ b/rpcapi/accounthandlers.go
@@ -40,8 +40,7 @@ func (r *RPCAPI) getAccount(request *api.APIrequest) (*api.APIresponse, error) {
 }
 
 func (r *RPCAPI) getTreasurer(request *api.APIrequest) (*api.APIresponse, error) {
-
-	// try get treasyrer and send reply
+	// try get treasurer and send reply
 	var response api.APIresponse
 	t, err := r.vocapp.State.Treasurer(true)
 	if err != nil {

--- a/rpcapi/accounthandlers.go
+++ b/rpcapi/accounthandlers.go
@@ -9,12 +9,12 @@ import (
 )
 
 func (r *RPCAPI) getAccount(request *api.APIrequest) (*api.APIresponse, error) {
-	// check pid
+	// check entity id
 	if len(request.EntityId) != types.EntityIDsize {
 		return nil, fmt.Errorf("cannot get account info: (malformed entityId)")
 
 	}
-	// Check account and send reply
+	// check account and send reply
 	var response api.APIresponse
 	entityIdAddr := common.BytesToAddress(request.EntityId)
 	acc, err := r.vocapp.State.GetAccount(entityIdAddr, true)
@@ -36,5 +36,24 @@ func (r *RPCAPI) getAccount(request *api.APIrequest) (*api.APIresponse, error) {
 		delegates = append(delegates, common.BytesToAddress(acc.DelegateAddrs[i]).String())
 	}
 	response.Delegates = delegates
+	return &response, nil
+}
+
+func (r *RPCAPI) getTreasurer(request *api.APIrequest) (*api.APIresponse, error) {
+
+	// try get treasyrer and send reply
+	var response api.APIresponse
+	t, err := r.vocapp.State.Treasurer(true)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get treasurer: %w", err)
+	}
+	// treasurer does not exist
+	if t == nil {
+		// response ok meaning the treasurer does not exist
+		return &response, nil
+	}
+	response.EntityID = common.BytesToAddress(t.Address).String()
+	response.Nonce = new(uint32)
+	*response.Nonce = t.Nonce
 	return &response, nil
 }

--- a/rpcapi/accounthandlers.go
+++ b/rpcapi/accounthandlers.go
@@ -31,11 +31,11 @@ func (r *RPCAPI) getAccount(request *api.APIrequest) (*api.APIresponse, error) {
 	response.Nonce = new(uint32)
 	*response.Nonce = acc.Nonce
 	response.InfoURI = acc.InfoURI
-	delegates := make([]string, len(acc.DelegateAddrs))
-	for i := 0; i < len(acc.DelegateAddrs); i++ {
-		delegates = append(delegates, common.BytesToAddress(acc.DelegateAddrs[i]).String())
+	if len(acc.DelegateAddrs) > 0 {
+		for _, v := range acc.DelegateAddrs {
+			response.Delegates = append(response.Delegates, common.BytesToAddress(v).String())
+		}
 	}
-	response.Delegates = delegates
 	return &response, nil
 }
 

--- a/rpcapi/handlers.go
+++ b/rpcapi/handlers.go
@@ -115,6 +115,7 @@ func (r *RPCAPI) EnableResultsAPI(vocapp *vochain.BaseApplication, scrutinizer *
 	r.RegisterPublic("getEntityCount", false, r.getEntityCount)
 	r.RegisterPublic("getEnvelope", false, r.getEnvelope)
 	r.RegisterPublic("getAccount", false, r.getAccount)
+	r.RegisterPublic("getTreasurer", false, r.getTreasurer)
 	return nil
 }
 

--- a/test/statedb_test.go
+++ b/test/statedb_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tendermint/tendermint/privval"
 	models "go.vocdoni.io/proto/build/go/models"
 
+	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/test/testcommon"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
@@ -119,7 +120,26 @@ func TestAddProcess(t *testing.T) {
 	t.Parallel()
 
 	s := testcommon.NewVochainState(t)
-	err := s.AddProcess(testcommon.ProcessHardcoded)
+	// set tx cost for Tx: NewProcess
+	if err := s.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+	// create account
+	signer := ethereum.SignKeys{}
+	err := signer.AddHexKey(testcommon.SignerPrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acc := &vochain.Account{}
+	acc.Balance = 100
+	acc.InfoURI = "ipfs://"
+	if err := s.SetAccount(
+		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+	err = s.AddProcess(testcommon.ProcessHardcoded)
 	qt.Assert(t, err, qt.IsNil)
 }
 

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -46,7 +46,7 @@ var (
 
 	ProcessHardcoded = &models.Process{
 		ProcessId:    testutil.Hex2byte(nil, "e9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"),
-		EntityId:     testutil.Hex2byte(nil, "180dd5765d9f7ecef810b565a2e5bd14a3ccd536c442b3de74867df552855e85"),
+		EntityId:     testutil.Hex2byte(nil, "0x06d0d2C41F4560f8ffEa1285F44Ce0Ffa2E19eF0"),
 		CensusRoot:   testutil.Hex2byte(nil, "0a975f5cf517899e6116000fd366dc0feb34a2ea1b64e9b213278442dd9852fe"),
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
 		BlockCount:   1000,

--- a/types/consts.go
+++ b/types/consts.go
@@ -7,8 +7,9 @@ func Bool(b bool) *bool { return &b }
 // These exported variables should be treated as constants, to be used in API
 // responses which require *bool fields.
 var (
-	False = Bool(false)
-	True  = Bool(true)
+	False                    = Bool(false)
+	True                     = Bool(true)
+	EthereumZeroAddressBytes = [20]byte{}
 )
 
 const (
@@ -32,7 +33,7 @@ const (
 	// EthereumAddressSize is the size of an ethereum address
 	EthereumAddressSize = 20
 	// EthereumZeroAddress is the 0x0000000000000000000000000000000000000000 address
-	EthereumZeroAddress = "0x0000000000000000000000000000000000000000"
+	EthereumZeroAddressString = "0x0000000000000000000000000000000000000000"
 
 	// EntityIDsizeV2 legacy: in the past we used hash(addr)
 	// this is a temporal work around to support both

--- a/vochain/account.go
+++ b/vochain/account.go
@@ -354,17 +354,13 @@ func SetAccountDelegateTxCheck(vtx *models.Tx, txBytes, signature []byte, state 
 		}
 		return sigAddress, delAcc, nil
 	case models.TxType_DEL_DELEGATE_FOR_ACCOUNT:
-		f := false
 		for i := 0; i < len(acc.DelegateAddrs); i++ {
 			delegateToCmp := common.BytesToAddress(acc.DelegateAddrs[i])
 			if delegateToCmp == delAcc {
-				f = true
+				return sigAddress, delAcc, nil
 			}
 		}
-		if !f {
-			return common.Address{}, common.Address{}, fmt.Errorf("cannot remove a non existent delegate")
-		}
-		return sigAddress, delAcc, nil
+		return common.Address{}, common.Address{}, fmt.Errorf("cannot remove a non existent delegate")
 	default:
 		return common.Address{}, common.Address{}, fmt.Errorf("unsupported SetAccountDelegate operation")
 	}

--- a/vochain/account.go
+++ b/vochain/account.go
@@ -306,9 +306,9 @@ func (v *State) CreateAccount(accountAddress common.Address, infoURI string, del
 	newAccount.InfoURI = infoURI
 	if len(delegates) > 0 {
 		newAccount.DelegateAddrs = make([][]byte, len(delegates))
-		for i := 0; i < len(delegates); i++ {
-			if delegates[i].String() != types.EthereumZeroAddressString {
-				newAccount.DelegateAddrs = append(newAccount.DelegateAddrs, delegates[i].Bytes())
+		for _, v := range delegates {
+			if v.String() != types.EthereumZeroAddressString {
+				newAccount.DelegateAddrs = append(newAccount.DelegateAddrs, v.Bytes())
 			}
 		}
 	}

--- a/vochain/account.go
+++ b/vochain/account.go
@@ -2,10 +2,12 @@ package vochain
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/tendermint/tendermint/crypto"
 	"github.com/vocdoni/arbo"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/types"
@@ -42,6 +44,7 @@ func (a *Account) Transfer(dest *Account, amount uint64, nonce uint32) error {
 	if a.Nonce != nonce {
 		return ErrAccountNonceInvalid
 	}
+	a.Nonce++
 	if a.Balance < amount {
 		return ErrNotEnoughBalance
 	}
@@ -50,7 +53,6 @@ func (a *Account) Transfer(dest *Account, amount uint64, nonce uint32) error {
 	}
 	dest.Balance += amount
 	a.Balance -= amount
-	a.Nonce++
 	return nil
 }
 
@@ -89,7 +91,7 @@ func (a *Account) DelDelegate(addr common.Address) error {
 // and updates the state with the new values (including nonce).
 // If origin address acc is not enough, ErrNotEnoughBalance is returned.
 // If provided nonce does not match origin address nonce+1, ErrAccountNonceInvalid is returned.
-func (v *State) TransferBalance(from, to common.Address, amount uint64, nonce uint32) error {
+func (v *State) TransferBalance(from, to common.Address, amount uint64, nonce uint64) error {
 	var accFrom, accTo Account
 	v.Tx.Lock()
 	defer v.Tx.Unlock()
@@ -107,7 +109,62 @@ func (v *State) TransferBalance(from, to common.Address, amount uint64, nonce ui
 	if err := accTo.Unmarshal(accToRaw); err != nil {
 		return err
 	}
-	if err := accFrom.Transfer(&accTo, amount, nonce); err != nil {
+	if err := accFrom.Transfer(&accTo, amount, uint32(nonce)); err != nil {
+		return err
+	}
+	af, err := accFrom.Marshal()
+	if err != nil {
+		return err
+	}
+	if err := v.Tx.DeepSet(from.Bytes(), af, AccountsCfg); err != nil {
+		return err
+	}
+	at, err := accTo.Marshal()
+	if err != nil {
+		return err
+	}
+	if err := v.Tx.DeepSet(to.Bytes(), at, AccountsCfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CollectFaucet transfers balance from faucet generated package address to collector address,
+// and updates the state with the new values (including nonce).
+func (v *State) CollectFaucet(from, to common.Address, amount uint64, nonce uint64) error {
+	var accFrom, accTo Account
+	v.Tx.Lock()
+	defer v.Tx.Unlock()
+	accFromRaw, err := v.Tx.DeepGet(from.Bytes(), AccountsCfg)
+	if err != nil {
+		return err
+	}
+	if err := accFrom.Unmarshal(accFromRaw); err != nil {
+		return err
+	}
+	accToRaw, err := v.Tx.DeepGet(to.Bytes(), AccountsCfg)
+	if err != nil {
+		return err
+	}
+	if err := accTo.Unmarshal(accToRaw); err != nil {
+		return err
+	}
+	if amount == 0 {
+		return fmt.Errorf("cannot transfer zero amount")
+	}
+	if accFrom.Balance < amount {
+		return ErrNotEnoughBalance
+	}
+	if accTo.Balance+amount <= accTo.Balance {
+		return ErrBalanceOverflow
+	}
+	accTo.Balance += amount
+	accFrom.Balance -= amount
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, nonce)
+	key := from.Bytes()
+	key = append(key, b...)
+	if err := v.Tx.DeepSet(crypto.Sha256(key), nil, FaucetNonceCfg); err != nil {
 		return err
 	}
 	af, err := accFrom.Marshal()
@@ -384,21 +441,28 @@ func (v *State) setDelegate(accountAddr, delegateAddr common.Address, txType mod
 	}
 }
 
-func SendTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) (common.Address, common.Address, uint64, uint32, error) {
+type SendTokensTxCheckValues struct {
+	From  common.Address
+	To    common.Address
+	Value uint64
+	Nonce uint32
+}
+
+func SendTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) (*SendTokensTxCheckValues, error) {
 	tx := vtx.GetSendTokens()
 	// check signature available
 	if signature == nil || tx == nil || txBytes == nil {
-		return common.Address{}, common.Address{}, 0, 0, fmt.Errorf("missing signature and/or transaction")
+		return nil, fmt.Errorf("missing signature and/or transaction")
 	}
 	// get address from signature
 	sigAddress, err := ethereum.AddrFromSignature(txBytes, signature)
 	if err != nil {
-		return common.Address{}, common.Address{}, 0, 0, err
+		return nil, err
 	}
 	// check from
 	txFromAddress := common.BytesToAddress(tx.From)
 	if txFromAddress != sigAddress {
-		return common.Address{}, common.Address{}, 0, 0, fmt.Errorf("from (%s) field and extracted signature (%s) mismatch",
+		return nil, fmt.Errorf("from (%s) field and extracted signature (%s) mismatch",
 			txFromAddress.String(),
 			sigAddress.String(),
 		)
@@ -406,25 +470,74 @@ func SendTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) 
 	// check to
 	txToAddress := common.BytesToAddress(tx.To)
 	if txToAddress.String() == types.EthereumZeroAddress {
-		return common.Address{}, common.Address{}, 0, 0, fmt.Errorf("invalid address")
+		return nil, fmt.Errorf("invalid address")
 	}
 	_, err = state.GetAccount(txToAddress, false)
 	if err != nil {
-		return common.Address{}, common.Address{}, 0, 0, fmt.Errorf("cannot get to account info: %v", err)
+		return nil, fmt.Errorf("cannot get to account info: %v", err)
 	}
 	// check nonce
 	acc, err := state.GetAccount(sigAddress, false)
 	if err != nil {
-		return common.Address{}, common.Address{}, 0, 0, fmt.Errorf("cannot get account info: %v", err)
+		return nil, fmt.Errorf("cannot get account info: %v", err)
 	}
 	if tx.Nonce != acc.Nonce {
-		return common.Address{}, common.Address{}, 0, 0, fmt.Errorf("invalid nonce, expected %d got %d", acc.Nonce, tx.Nonce)
+		return nil, fmt.Errorf("invalid nonce, expected %d got %d", acc.Nonce, tx.Nonce)
 	}
 	// check value
 	if tx.Value > acc.Balance {
-		return common.Address{}, common.Address{}, 0, 0, ErrNotEnoughBalance
+		return nil, ErrNotEnoughBalance
 	}
-	return sigAddress, txToAddress, tx.Value, tx.Nonce, nil
+	return &SendTokensTxCheckValues{sigAddress, txToAddress, tx.Value, tx.Nonce}, nil
+}
+
+func CollectFaucetTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) (common.Address, error) {
+	tx := vtx.GetCollectFaucet()
+	// check signature available
+	if signature == nil || tx == nil || txBytes == nil {
+		return common.Address{}, fmt.Errorf("missing signature and/or transaction")
+	}
+	// get recipient address from signature
+	recipientAddress, err := ethereum.AddrFromSignature(txBytes, signature)
+	if err != nil {
+		return common.Address{}, err
+	}
+	// get issuer address from faucetPayload
+	faucetPkgPayload := tx.FaucetPackage.GetPayload()
+	faucetPackageBytes, err := proto.Marshal(faucetPkgPayload)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("cannot extract faucet package payload: %v", err)
+	}
+	issuerAddress, err := ethereum.AddrFromSignature(faucetPackageBytes, tx.FaucetPackage.Signature)
+	if err != nil {
+		return common.Address{}, err
+	}
+	// check recipient address extracted from signature matches with payload.To
+	payloadToAddr := common.BytesToAddress(faucetPkgPayload.GetTo())
+	if recipientAddress != payloadToAddr {
+		return common.Address{}, fmt.Errorf("address extracted from tx (%s) does not match recipient address (%s)", recipientAddress.String(), payloadToAddr.String())
+	}
+	// check issuer nonce not used
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, faucetPkgPayload.Identifier)
+	key := issuerAddress.Bytes()
+	key = append(key, b...)
+	used, err := state.FaucetNonce(crypto.Sha256(key), false)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("cannot check faucet nonce: %v", err)
+	}
+	if used {
+		return common.Address{}, fmt.Errorf("nonce %d already used", faucetPkgPayload.Identifier)
+	}
+	// check issuer have enough funds
+	issuerAcc, err := state.GetAccount(issuerAddress, false)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("cannot get faucet account: %v", err)
+	}
+	if issuerAcc.Balance < faucetPkgPayload.Amount {
+		return common.Address{}, fmt.Errorf("faucet does not have enough balance %d < %d", issuerAcc.Balance, faucetPkgPayload.Amount)
+	}
+	return issuerAddress, nil
 }
 
 func (v *State) setAccount(accountAddress common.Address, account *Account) error {

--- a/vochain/account.go
+++ b/vochain/account.go
@@ -237,6 +237,7 @@ func (v *State) AccountFromSignature(message, signature []byte) (common.Address,
 	return address, acc, nil
 }
 
+// SetAccountInfoURI sets a given account infoURI
 func (v *State) SetAccountInfoURI(accountAddress, txSender common.Address, infoURI string) error {
 	acc, err := v.GetAccount(accountAddress, false)
 	if err != nil {
@@ -287,6 +288,7 @@ func (v *State) SetAccountInfoURI(accountAddress, txSender common.Address, infoU
 	return v.Tx.DeepSet(txSender.Bytes(), senderBytes, AccountsCfg)
 }
 
+// Create account creates an account
 func (v *State) CreateAccount(accountAddress common.Address, infoURI string, delegates []common.Address, initBalance uint64, faucetSender common.Address, faucetNonce uint64) error {
 	// check valid address
 	if accountAddress.String() == types.EthereumZeroAddressString {
@@ -468,6 +470,7 @@ func SetAccountInfoTxCheck(vtx *models.Tx, txBytes, signature []byte, state *Sta
 	return returnValues, nil
 }
 
+// MintTokensTxCheck checks if a given MintTokensTx and its data are valid
 func MintTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) (common.Address, uint64, error) {
 	tx := vtx.GetMintTokens()
 	// check signature available
@@ -508,6 +511,7 @@ func MintTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) 
 	return common.BytesToAddress(tx.To), tx.Value, nil
 }
 
+// SetAccountDelegateTxCheck checks if a SetAccountDelegateTx and its data are valid
 func SetAccountDelegateTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) (common.Address, common.Address, error) {
 	tx := vtx.GetSetAccountDelegateTx()
 	// check signature available
@@ -556,6 +560,7 @@ func SetAccountDelegateTxCheck(vtx *models.Tx, txBytes, signature []byte, state 
 	}
 }
 
+// SetDelegate sets a delegate for a given account
 func (v *State) SetDelegate(accountAddr, delegateAddr common.Address, txType models.TxType) error {
 	// get account
 	acc, err := v.GetAccount(accountAddr, false)
@@ -587,6 +592,7 @@ func (v *State) SetDelegate(accountAddr, delegateAddr common.Address, txType mod
 	}
 }
 
+// SendTokensTxCheck checks if a given SendTokensTx and its data are valid
 func SendTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) (*sendTokensTxCheckValues, error) {
 	tx := vtx.GetSendTokens()
 	// check signature available
@@ -644,6 +650,7 @@ func SendTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) 
 	return &sendTokensTxCheckValues{sigAddress, txToAddress, tx.Value, tx.Nonce}, nil
 }
 
+// CollectFaucetTxCheck checks if a given CollectFaucetTx and its data are valid
 func CollectFaucetTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) (common.Address, error) {
 	tx := vtx.GetCollectFaucet()
 	// check signature available
@@ -704,6 +711,7 @@ func CollectFaucetTxCheck(vtx *models.Tx, txBytes, signature []byte, state *Stat
 	return issuerAddress, nil
 }
 
+// SetAccount sets the given account data to the state
 func (v *State) SetAccount(accountAddress common.Address, account *Account) error {
 	accBytes, err := proto.Marshal(account)
 	if err != nil {

--- a/vochain/account.go
+++ b/vochain/account.go
@@ -280,3 +280,40 @@ func SetAccountInfoTxCheck(vtx *models.Tx, txBytes, signature []byte, state *Sta
 	}
 	return accountAddress, false, nil
 }
+
+func MintTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) (common.Address, uint64, error) {
+	tx := vtx.GetMintTokens()
+	// check signature available
+	if signature == nil || tx == nil || txBytes == nil {
+		return common.Address{}, 0, fmt.Errorf("missing signature and/or transaction")
+	}
+	// get address from signature
+	sigAddress, err := ethereum.AddrFromSignature(txBytes, signature)
+	if err != nil {
+		return common.Address{}, 0, err
+	}
+	// get treasurer
+	treasurer, err := state.Treasurer(true)
+	if err != nil {
+		return common.Address{}, 0, err
+	}
+	// check signature recovered address
+	tAddr := common.BytesToAddress(treasurer.Address)
+	if tAddr != sigAddress {
+		return common.Address{}, 0, fmt.Errorf("address recovered not treasurer: expected %s got %s", treasurer.String(), sigAddress.String())
+	}
+	// check nonce
+	if tx.Nonce != treasurer.Nonce {
+		return common.Address{}, 0, fmt.Errorf("invalid nonce %d, expected: %d", tx.Nonce, treasurer.Nonce+1)
+	}
+	// check to
+	to := common.BytesToAddress(tx.To)
+	if to.String() == types.EthereumZeroAddress || to.String() == tAddr.String() {
+		return common.Address{}, 0, fmt.Errorf("invalid address to mint")
+	}
+	// check value
+	if tx.Value <= 0 {
+		return common.Address{}, 0, fmt.Errorf("invalid value")
+	}
+	return to, tx.Value, nil
+}

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -173,7 +173,7 @@ func testMintTokensTx(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -324,7 +324,7 @@ func testSetDelegateTx(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -458,7 +458,7 @@ func testSendTokensTx(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -570,7 +570,7 @@ func testCollectFaucetTx(t *testing.T,
 	if err != nil {
 		t.Fatal(err)
 	}
-	faucetPayloadSignature, err := from.Sign(faucetPayloadBytes)
+	faucetPayloadSignature, err := from.SignEthereum(faucetPayloadBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -586,7 +586,7 @@ func testCollectFaucetTx(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = to.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = to.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -675,7 +675,7 @@ func testSetTransactionCostsTx(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -141,9 +141,111 @@ func testMintTokensTx(t *testing.T,
 		Txtype: models.TxType_MINT_TOKENS,
 		To:     toAddr.Bytes(),
 		Value:  value,
+		Nonce:  0,
 	}
 
 	if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_MintTokens{MintTokens: tx}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+		t.Fatal(err)
+	}
+
+	if cktx.Tx, err = proto.Marshal(&stx); err != nil {
+		t.Fatal(err)
+	}
+	cktxresp = app.CheckTx(cktx)
+	if cktxresp.Code != 0 {
+		return fmt.Errorf("checkTx failed: %s", cktxresp.Data)
+	}
+	if detx.Tx, err = proto.Marshal(&stx); err != nil {
+		t.Fatal(err)
+	}
+	detxresp = app.DeliverTx(detx)
+	if detxresp.Code != 0 {
+		return fmt.Errorf("deliverTx failed: %s", detxresp.Data)
+	}
+	app.Commit()
+	return nil
+}
+
+func TestSetDelegateTx(t *testing.T) {
+	app := TestBaseApplication(t)
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+
+	// create account
+	testSetAccountInfoTx(t, &signer, app, infoURI)
+	// get nonce
+	acc, err := app.State.GetAccount(signer.Address(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// should add new delegate
+	if err := testSetDelegateTx(t, &signer, app, randomEthAccount, acc.Nonce, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// should fail adding same delegate
+	if err := testSetDelegateTx(t, &signer, app, randomEthAccount, acc.Nonce+1, true); err == nil {
+		t.Fatal(err)
+	}
+
+	// should remove an existing delegate
+	if err := testSetDelegateTx(t, &signer, app, randomEthAccount, acc.Nonce+1, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// should fail removing a non existent delegate
+	if err := testSetDelegateTx(t, &signer, app, randomEthAccount, acc.Nonce+2, false); err == nil {
+		t.Fatal(err)
+	}
+
+	// should fail using a wrong nonce
+	if err := testSetDelegateTx(t, &signer, app, randomEthAccount, acc.Nonce+4, true); err == nil {
+		t.Fatal(err)
+	}
+
+	// get account
+	acc, err = app.State.GetAccount(signer.Address(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(acc.DelegateAddrs) != 0 {
+		t.Fatalf("expected delegates length to be 0, got %d", len(acc.DelegateAddrs))
+	}
+	if acc.Nonce != 2 {
+		t.Fatalf("expected next nonce is 2, got %d", acc.Nonce)
+	}
+}
+
+func testSetDelegateTx(t *testing.T,
+	signer *ethereum.SignKeys,
+	app *BaseApplication,
+	delegate string,
+	nonce uint32,
+	op bool) error { // op == true -> add, op == false -> del
+	var cktx abcitypes.RequestCheckTx
+	var detx abcitypes.RequestDeliverTx
+	var cktxresp abcitypes.ResponseCheckTx
+	var detxresp abcitypes.ResponseDeliverTx
+	var stx models.SignedTx
+	var err error
+
+	delegateAddr := common.HexToAddress(delegate)
+	tx := &models.SetAccountDelegateTx{}
+	if op {
+		tx.Txtype = models.TxType_ADD_DELEGATE_FOR_ACCOUNT
+	} else {
+		tx.Txtype = models.TxType_DEL_DELEGATE_FOR_ACCOUNT
+	}
+	tx.Delegate = delegateAddr.Bytes()
+	tx.Nonce = nonce
+
+	if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_SetAccountDelegateTx{SetAccountDelegateTx: tx}}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -56,6 +56,9 @@ func TestSetAccountInfoTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if acc == nil {
+		t.Fatal(ErrAccountNotFound)
+	}
 	qt.Assert(t, acc.InfoURI, qt.Equals, ipfsUrl)
 	qt.Assert(t, acc.Balance, qt.Equals, uint64(90))
 }
@@ -130,6 +133,9 @@ func TestMintTokensTx(t *testing.T) {
 	acc, err := app.State.GetAccount(toAcc, false)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if acc == nil {
+		t.Fatal(ErrAccountNotFound)
 	}
 	if acc.Balance != 100 {
 		t.Fatal(fmt.Sprintf("infoURI missmatch, got %d expected %d", acc.Balance, 100))
@@ -228,6 +234,9 @@ func TestSetDelegateTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if signerAcc == nil {
+		t.Fatal(ErrAccountNotFound)
+	}
 	qt.Assert(t, strings.ToLower(common.BytesToAddress(signerAcc.DelegateAddrs[0]).String()), qt.Equals, randomEthAccount)
 	qt.Assert(t, signerAcc.Balance, qt.Equals, uint64(20))
 
@@ -240,6 +249,9 @@ func TestSetDelegateTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if signerAcc == nil {
+		t.Fatal(ErrAccountNotFound)
+	}
 	qt.Assert(t, strings.ToLower(common.BytesToAddress(signerAcc.DelegateAddrs[0]).String()), qt.Equals, randomEthAccount)
 	qt.Assert(t, signerAcc.Balance, qt.Equals, uint64(20))
 
@@ -251,6 +263,9 @@ func TestSetDelegateTx(t *testing.T) {
 	signerAcc, err = app.State.GetAccount(signer.Address(), false)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if signerAcc == nil {
+		t.Fatal(ErrAccountNotFound)
 	}
 	qt.Assert(t, signerAcc.Balance, qt.Equals, uint64(10))
 	// should fail removing a non existent delegate
@@ -273,6 +288,9 @@ func TestSetDelegateTx(t *testing.T) {
 	signerAcc, err = app.State.GetAccount(signer.Address(), false)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if signerAcc == nil {
+		t.Fatal(ErrAccountNotFound)
 	}
 	qt.Assert(t, strings.ToLower(common.BytesToAddress(signerAcc.DelegateAddrs[0]).String()), qt.Equals, randomEthAccount)
 	qt.Assert(t, signerAcc.Balance, qt.Equals, uint64(0))
@@ -373,6 +391,9 @@ func TestSendTokensTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if signerAcc == nil {
+		t.Fatal(ErrAccountNotFound)
+	}
 	// should transfer tokens
 	if err := testSendTokensTx(t, &signer, app, signer2.Address().String(), 10, signerAcc.Nonce); err != nil {
 		t.Fatal(err)
@@ -398,9 +419,15 @@ func TestSendTokensTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if signerAcc == nil {
+		t.Fatal(ErrAccountNotFound)
+	}
 	toAcc, err := app.State.GetAccount(signer2.Address(), false)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if toAcc == nil {
+		t.Fatal(ErrAccountNotFound)
 	}
 	qt.Assert(t, signerAcc.Balance, qt.Equals, uint64(10))
 	qt.Assert(t, signerAcc.Nonce, qt.Equals, uint32(1))
@@ -506,9 +533,15 @@ func TestCollectFaucetTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if signerAcc == nil {
+		t.Fatal(ErrAccountNotFound)
+	}
 	signerAcc2, err := app.State.GetAccount(signer2.Address(), false)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if signerAcc2 == nil {
+		t.Fatal(ErrAccountNotFound)
 	}
 	qt.Assert(t, signerAcc.Balance, qt.Equals, uint64(10))
 	qt.Assert(t, signerAcc2.Balance, qt.Equals, uint64(20))

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -607,3 +607,92 @@ func testCollectFaucetTx(t *testing.T,
 	app.Commit()
 	return nil
 }
+
+func TestSetTransactionsCosts(t *testing.T) {
+	app := TestBaseApplication(t)
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+
+	// set tx cost for Tx: SendTokens
+	if err := app.State.SetTxCost(models.TxType_COLLECT_FAUCET, 10); err != nil {
+		t.Fatal(err)
+	}
+	// set treasurer account (same as signer for testing purposes)
+	if err := app.State.setTreasurer(signer.Address()); err != nil {
+		t.Fatal(err)
+	}
+	// create account
+	if err := app.State.SetAccount(
+		signer.Address(),
+		&Account{
+			models.Account{
+				Balance: 30,
+				InfoURI: infoURI,
+			},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// should change tx cost if treasurer
+	if err := testSetTransactionCostsTx(t, app, &signer, 0, 20); err != nil {
+		t.Fatal(err)
+	}
+	// should not change tx costs not treasurer
+	if err := testSetTransactionCostsTx(t, app, &signer, 0, 20); err == nil {
+		t.Fatal(err)
+	}
+
+	if cost, err := app.State.TxCost(models.TxType_COLLECT_FAUCET, false); err != nil {
+		t.Fatal(err)
+	} else {
+		qt.Assert(t, cost, qt.Equals, uint64(20))
+	}
+}
+
+func testSetTransactionCostsTx(t *testing.T,
+	app *BaseApplication,
+	signer *ethereum.SignKeys,
+	nonce uint32,
+	cost uint64) error { // op == true -> add, op == false -> del
+	var cktx abcitypes.RequestCheckTx
+	var detx abcitypes.RequestDeliverTx
+	var cktxresp abcitypes.ResponseCheckTx
+	var detxresp abcitypes.ResponseDeliverTx
+	var stx models.SignedTx
+	var err error
+
+	// tx
+	tx := &models.SetTransactionCostsTx{
+		Txtype: models.TxType_COLLECT_FAUCET,
+		Nonce:  nonce,
+		Value:  cost,
+	}
+
+	if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_SetTransactionCosts{SetTransactionCosts: tx}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
+		t.Fatal(err)
+	}
+
+	if cktx.Tx, err = proto.Marshal(&stx); err != nil {
+		t.Fatal(err)
+	}
+	cktxresp = app.CheckTx(cktx)
+	if cktxresp.Code != 0 {
+		return fmt.Errorf("checkTx failed: %s", cktxresp.Data)
+	}
+	if detx.Tx, err = proto.Marshal(&stx); err != nil {
+		t.Fatal(err)
+	}
+	detxresp = app.DeliverTx(detx)
+	if detxresp.Code != 0 {
+		return fmt.Errorf("deliverTx failed: %s", detxresp.Data)
+	}
+	app.Commit()
+	return nil
+}

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/proto/build/go/models"
@@ -12,6 +13,7 @@ import (
 
 // https://ipfs.io/ipfs/QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF
 const infoURI string = "ipfs://QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF"
+const randomEthAccount = "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"
 
 func TestSetAccountInfoTx(t *testing.T) {
 	app := TestBaseApplication(t)
@@ -61,6 +63,91 @@ func testSetAccountInfoTx(t *testing.T,
 	}
 
 	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
+		t.Fatal(err)
+	}
+
+	if cktx.Tx, err = proto.Marshal(&stx); err != nil {
+		t.Fatal(err)
+	}
+	cktxresp = app.CheckTx(cktx)
+	if cktxresp.Code != 0 {
+		return fmt.Errorf("checkTx failed: %s", cktxresp.Data)
+	}
+	if detx.Tx, err = proto.Marshal(&stx); err != nil {
+		t.Fatal(err)
+	}
+	detxresp = app.DeliverTx(detx)
+	if detxresp.Code != 0 {
+		return fmt.Errorf("deliverTx failed: %s", detxresp.Data)
+	}
+	app.Commit()
+	return nil
+}
+
+func TestMintTokensTx(t *testing.T) {
+	app := TestBaseApplication(t)
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+
+	app.State.setTreasurer(signer.Address())
+	app.Commit()
+
+	// should mint
+	if err := testMintTokensTx(t, &signer, app, randomEthAccount, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	// should fail minting
+	if err := testMintTokensTx(t, &signer, app, randomEthAccount, 0); err == nil {
+		t.Fatal(err)
+	}
+
+	// get account
+	toAcc := common.HexToAddress(randomEthAccount)
+	acc, err := app.State.GetAccount(toAcc, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acc.Balance != 100 {
+		t.Fatal(fmt.Sprintf("infoURI missmatch, got %d expected %d", acc.Balance, 100))
+	}
+	// get treasurer
+	treasurer, err := app.State.Treasurer(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check nonce incremented
+	if treasurer.Nonce != 1 {
+		t.Fatal(err)
+	}
+}
+
+func testMintTokensTx(t *testing.T,
+	signer *ethereum.SignKeys,
+	app *BaseApplication,
+	to string,
+	value uint64) error {
+	var cktx abcitypes.RequestCheckTx
+	var detx abcitypes.RequestDeliverTx
+	var cktxresp abcitypes.ResponseCheckTx
+	var detxresp abcitypes.ResponseDeliverTx
+	var stx models.SignedTx
+	var err error
+
+	toAddr := common.HexToAddress(to)
+	tx := &models.MintTokensTx{
+		Txtype: models.TxType_MINT_TOKENS,
+		To:     toAddr.Bytes(),
+		Value:  value,
+	}
+
+	if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_MintTokens{MintTokens: tx}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if stx.Signature, err = signer.Sign(stx.Tx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -392,6 +392,14 @@ func (app *BaseApplication) InitChain(req abcitypes.RequestInitChain) abcitypes.
 		log.Fatalf("could not set State.Treasurer from genesis file: %s", err)
 	}
 
+	// add tx costs
+	for k, v := range genesisAppState.TxCost.AsMap() {
+		err = app.State.SetTxCost(k, v)
+		if err != nil {
+			log.Fatalf("could not set tx cost %q to value %q from genesis file to the State", k, v)
+		}
+	}
+
 	// Is this save needed?
 	if _, err := app.State.Save(); err != nil {
 		log.Fatalf("cannot save state: %s", err)

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -296,7 +296,8 @@ var Genesis = map[string]VochainGenesis{
          "Tx_NewProcess": 100,
          "Tx_SendTokens": 100,
          "Tx_SetAccountInfo": 100,
-         "Tx_SetAccountDelegate": 100,
+         "Tx_AddDelegateForAccount": 100,
+         "Tx_DelDelegateForAccount": 100,
          "Tx_CollectFaucet": 100
        }
    }

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -288,7 +288,10 @@ var Genesis = map[string]VochainGenesis{
       ],
       "treasurer": "0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d",
       "tx_cost": {
-         "Tx_SetProcess": 100,
+         "Tx_SetProcessStatus": 100,
+         "Tx_SetProcessCensus": 100,
+         "Tx_SetProcessResults": 100,
+         "Tx_SetProcessQuestionIndex": 100,
          "Tx_RegisterKey": 100,
          "Tx_NewProcess": 100,
          "Tx_SendTokens": 100,

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -62,20 +62,20 @@ func (v *State) AddProcess(p *models.Process) error {
 	if err != nil {
 		return err
 	}
+	creatorAddress := common.BytesToAddress(p.EntityId)
+	processCreationCost, err := v.TxCost(models.TxType_NEW_PROCESS, false)
+	if err != nil {
+		return err
+	}
+	if err := v.substractTxCost(creatorAddress, processCreationCost); err != nil {
+		return err
+	}
 	censusURI := ""
 	if p.CensusURI != nil {
 		censusURI = *p.CensusURI
 	}
 	for _, l := range v.eventListeners {
 		l.OnProcess(p.ProcessId, p.EntityId, fmt.Sprintf("%x", p.CensusRoot), censusURI, v.TxCounter())
-	}
-	creatorAddress := common.BytesToAddress(p.EntityId)
-	processCreationCost, err := v.TxCost(models.TxType_NEW_PROCESS, false)
-	if err != nil {
-		return err
-	}
-	if err := v.burnAccountBalance(creatorAddress, processCreationCost); err != nil {
-		return err
 	}
 	return nil
 }
@@ -264,7 +264,7 @@ func (v *State) SetProcessStatus(pid []byte, newstatus models.ProcessStatus, com
 		if err != nil {
 			return err
 		}
-		if err := v.burnAccountBalance(creatorAddress, processCreationCost); err != nil {
+		if err := v.substractTxCost(creatorAddress, processCreationCost); err != nil {
 			return err
 		}
 	}
@@ -338,7 +338,7 @@ func (v *State) SetProcessResults(pid []byte, result *models.ProcessResult, comm
 		if err != nil {
 			return err
 		}
-		if err := v.burnAccountBalance(creatorAddress, processCreationCost); err != nil {
+		if err := v.substractTxCost(creatorAddress, processCreationCost); err != nil {
 			return err
 		}
 	}
@@ -403,7 +403,7 @@ func (v *State) SetProcessCensus(pid, censusRoot []byte, censusURI string, commi
 		if err != nil {
 			return err
 		}
-		if err := v.burnAccountBalance(creatorAddress, processCreationCost); err != nil {
+		if err := v.substractTxCost(creatorAddress, processCreationCost); err != nil {
 			return err
 		}
 	}
@@ -446,7 +446,7 @@ func (app *BaseApplication) NewProcessTxCheck(vtx *models.Tx, txBytes,
 	if err != nil {
 		return nil, fmt.Errorf("cannot get tx cost from state %w", err)
 	}
-	authorized, addr, err := state.VerifyAccountBalance(txBytes, signature, cost)
+	authorized, addr, err := state.VerifyAccountBalanceFromSignature(txBytes, signature, cost)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func SetProcessTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) 
 	if err != nil {
 		return fmt.Errorf("cannot get tx cost from state %w", err)
 	}
-	authorized, addr, err := state.VerifyAccountBalance(txBytes, signature, cost)
+	authorized, addr, err := state.VerifyAccountBalanceFromSignature(txBytes, signature, cost)
 	if err != nil {
 		return err
 	}

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -445,7 +445,7 @@ func (app *BaseApplication) NewProcessTxCheck(vtx *models.Tx, txBytes,
 	if err != nil {
 		return nil, fmt.Errorf("cannot get tx cost from state %w", err)
 	}
-	sigAddress, acc, err := state.AccountFromSignature(txBytes, signature, cost)
+	sigAddress, acc, err := state.AccountFromSignature(txBytes, signature)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get account from signature %w", err)
 	}
@@ -538,7 +538,7 @@ func SetProcessTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) 
 	if err != nil {
 		return common.Address{}, fmt.Errorf("cannot get tx cost from state %w", err)
 	}
-	sigAddress, acc, err := state.AccountFromSignature(txBytes, signature, cost)
+	sigAddress, acc, err := state.AccountFromSignature(txBytes, signature)
 	if err != nil {
 		return common.Address{}, fmt.Errorf("cannot get account from signature %w", err)
 	}

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -66,6 +66,9 @@ func (v *State) AddProcess(p *models.Process) error {
 	if err != nil {
 		return err
 	}
+	if bytes.Equal(p.Owner, []byte{}) {
+		p.Owner = p.EntityId
+	}
 	if err := v.substractTxCostIncrementNonce(common.BytesToAddress(p.Owner), processCreationCost); err != nil {
 		return err
 	}

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -25,6 +25,27 @@ func TestProcessSetStatusTransition(t *testing.T) {
 	if err := app.State.AddOracle(common.HexToAddress(oracle.AddressString())); err != nil {
 		t.Fatal(err)
 	}
+	// set tx cost for Tx: NewProcess
+	if err := app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.State.SetTxCost(models.TxType_SET_PROCESS_STATUS, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+	acc := &Account{}
+	acc.Balance = 1000
+	acc.InfoURI = "ipfs://"
+	if err := app.State.SetAccount(
+		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
 
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl
@@ -36,7 +57,7 @@ func TestProcessSetStatusTransition(t *testing.T) {
 		Mode:         &models.ProcessMode{Interruptible: true},
 		VoteOptions:  &models.ProcessVoteOptions{MaxCount: 16, MaxValue: 16},
 		Status:       models.ProcessStatus_READY,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   util.RandomBytes(32),
 		CensusURI:    &censusURI,
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
@@ -86,7 +107,7 @@ func TestProcessSetStatusTransition(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         &models.ProcessMode{Interruptible: true},
 		Status:       models.ProcessStatus_PAUSED,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   util.RandomBytes(32),
 		CensusURI:    &censusURI,
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
@@ -136,7 +157,7 @@ func TestProcessSetStatusTransition(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         &models.ProcessMode{Interruptible: false, AutoStart: false},
 		Status:       models.ProcessStatus_PAUSED,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   util.RandomBytes(32),
 		CensusURI:    &censusURI,
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
@@ -165,6 +186,14 @@ func TestProcessSetStatusTransition(t *testing.T) {
 	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err == nil {
 		t.Fatal("ready to ended should not be valid if interruptible=false")
 	}
+
+	if acc, err := app.State.GetAccount(signer.Address(), false); err != nil {
+		t.Fatal(err)
+	} else {
+		fmt.Printf("%d", acc.Balance)
+		fmt.Printf("/n%d", acc.Nonce)
+	}
+
 }
 
 func testSetProcessStatus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
@@ -225,6 +254,31 @@ func TestProcessSetResultsTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// set tx cost for Tx: NewProcess
+	if err := app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.State.SetTxCost(models.TxType_SET_PROCESS_RESULTS, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.State.SetTxCost(models.TxType_SET_PROCESS_STATUS, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+	acc := &Account{}
+	acc.Balance = 1000
+	acc.InfoURI = "ipfs://"
+	if err := app.State.SetAccount(
+		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl
 	pid := util.RandomBytes(types.ProcessIDsize)
@@ -234,7 +288,7 @@ func TestProcessSetResultsTransition(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         &models.ProcessMode{Interruptible: true},
 		Status:       models.ProcessStatus_READY,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   util.RandomBytes(32),
 		CensusURI:    &censusURI,
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
@@ -366,6 +420,28 @@ func TestProcessSetCensusTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// set tx cost for Tx: NewProcess
+	if err := app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.State.SetTxCost(models.TxType_SET_PROCESS_CENSUS, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+	acc := &Account{}
+	acc.Balance = 1000
+	acc.InfoURI = "ipfs://"
+	if err := app.State.SetAccount(
+		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl
 	censusURI2 := "ipfs://987654321"
@@ -378,7 +454,7 @@ func TestProcessSetCensusTransition(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         &models.ProcessMode{Interruptible: true, DynamicCensus: true},
 		Status:       models.ProcessStatus_READY,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   util.RandomBytes(32),
 		CensusURI:    &censusURI,
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
@@ -391,7 +467,7 @@ func TestProcessSetCensusTransition(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         &models.ProcessMode{Interruptible: true},
 		Status:       models.ProcessStatus_READY,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   util.RandomBytes(32),
 		CensusURI:    &censusURI2,
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
@@ -404,7 +480,7 @@ func TestProcessSetCensusTransition(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         &models.ProcessMode{Interruptible: true, DynamicCensus: true},
 		Status:       models.ProcessStatus_READY,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   util.RandomBytes(32),
 		CensusURI:    &censusURI2,
 		CensusOrigin: models.CensusOrigin_ERC20,

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -189,6 +189,8 @@ func TestProcessSetStatusTransition(t *testing.T) {
 
 	if acc, err := app.State.GetAccount(signer.Address(), false); err != nil {
 		t.Fatal(err)
+	} else if acc == nil {
+		t.Fatal(ErrAccountNotFound)
 	} else {
 		fmt.Printf("%d", acc.Balance)
 		fmt.Printf("/n%d", acc.Nonce)

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -22,9 +22,10 @@ func TestProcessSetStatusTransition(t *testing.T) {
 	if err := oracle.Generate(); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.State.AddOracle(common.HexToAddress(oracle.AddressString())); err != nil {
+	if err := app.State.AddOracle(oracle.Address()); err != nil {
 		t.Fatal(err)
 	}
+
 	// set tx cost for Tx: NewProcess
 	if err := app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
 		t.Fatal(err)
@@ -70,31 +71,31 @@ func TestProcessSetStatusTransition(t *testing.T) {
 
 	// Set it to PAUSE (should work)
 	status := models.ProcessStatus_PAUSED
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err != nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set it to READY (should work)
 	status = models.ProcessStatus_READY
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err != nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set it to ENDED (should work)
 	status = models.ProcessStatus_ENDED
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err != nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set it to RESULTS (should work)
 	status = models.ProcessStatus_RESULTS
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err != nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set it to READY (should fail)
 	status = models.ProcessStatus_READY
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err == nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err == nil {
 		t.Fatal("results to ready should not be valid")
 	}
 
@@ -120,31 +121,31 @@ func TestProcessSetStatusTransition(t *testing.T) {
 
 	// Set it to READY (should work)
 	status = models.ProcessStatus_READY
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err != nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set it to PAUSED (should work)
 	status = models.ProcessStatus_PAUSED
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err != nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set it to ENDED (should fail)
 	status = models.ProcessStatus_ENDED
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err == nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err == nil {
 		t.Fatal("paused to ended should not be valid")
 	}
 
 	// Set it to CANCELED (should work)
 	status = models.ProcessStatus_CANCELED
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err != nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set it to READY (should fail)
 	status = models.ProcessStatus_READY
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err == nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err == nil {
 		t.Fatal("cancel to ready should not be valid")
 	}
 
@@ -170,20 +171,20 @@ func TestProcessSetStatusTransition(t *testing.T) {
 
 	// Set it to READY (should work)
 	status = models.ProcessStatus_READY
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err != nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set it to PAUSE (should fail)
 	status = models.ProcessStatus_PAUSED
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err == nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err == nil {
 		t.Fatal("ready to paused should not be possible if interruptible=false")
 	}
 
 	// Set it to ENDED (should fail)
 	status = models.ProcessStatus_ENDED
 	t.Logf("height: %d", app.State.CurrentHeight())
-	if err := testSetProcessStatus(t, pid, &oracle, app, &status); err == nil {
+	if err := testSetProcessStatus(t, pid, &signer, app, &status); err == nil {
 		t.Fatal("ready to ended should not be valid if interruptible=false")
 	}
 
@@ -272,10 +273,17 @@ func TestProcessSetResultsTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 	acc := &Account{}
-	acc.Balance = 1000
+	acc.Balance = 10000
+	acc.DelegateAddrs = append(acc.DelegateAddrs, oracle.Address().Bytes())
 	acc.InfoURI = "ipfs://"
 	if err := app.State.SetAccount(
 		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.State.SetAccount(
+		oracle.Address(),
 		acc,
 	); err != nil {
 		t.Fatal(err)
@@ -301,7 +309,6 @@ func TestProcessSetResultsTransition(t *testing.T) {
 	}
 
 	t.Log(app.State.Process(process.ProcessId, false))
-
 	// Set results  (should not work)
 	votes := make([]*models.QuestionResult, 1)
 	votes[0] = &models.QuestionResult{
@@ -418,7 +425,7 @@ func TestProcessSetCensusTransition(t *testing.T) {
 	if err := oracle.Generate(); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.State.AddOracle(common.HexToAddress(oracle.AddressString())); err != nil {
+	if err := app.State.AddOracle(oracle.Address()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -439,6 +446,12 @@ func TestProcessSetCensusTransition(t *testing.T) {
 	acc.InfoURI = "ipfs://"
 	if err := app.State.SetAccount(
 		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.State.SetAccount(
+		oracle.Address(),
 		acc,
 	); err != nil {
 		t.Fatal(err)

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -288,6 +288,12 @@ func TestProcessSetResultsTransition(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+	if err := app.State.SetAccount(
+		oracle2.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
 
 	// Add a process with status=READY and interruptible=true
 	censusURI := ipfsUrl

--- a/vochain/proof_erc20_test.go
+++ b/vochain/proof_erc20_test.go
@@ -22,6 +22,25 @@ func TestEthProof(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// set tx cost for Tx: NewProcess
+	if err := app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+	acc := &Account{}
+	acc.Balance = 1000
+	acc.InfoURI = "ipfs://"
+	if err := app.State.SetAccount(
+		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	pid := util.RandomBytes(types.ProcessIDsize)
 	process := &models.Process{
 		ProcessId:    pid,
@@ -29,7 +48,7 @@ func TestEthProof(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         new(models.ProcessMode),
 		Status:       models.ProcessStatus_READY,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   testEthStorageRoot,
 		CensusOrigin: models.CensusOrigin_ERC20,
 		BlockCount:   1024,

--- a/vochain/proof_minime_test.go
+++ b/vochain/proof_minime_test.go
@@ -26,6 +26,25 @@ func TestMinimeProof(t *testing.T) {
 		}
 	}
 
+	// set tx cost for Tx: NewProcess
+	if err := app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+	acc := &Account{}
+	acc.Balance = 1000
+	acc.InfoURI = "ipfs://"
+	if err := app.State.SetAccount(
+		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	pid := util.RandomBytes(types.ProcessIDsize)
 	process := &models.Process{
 		ProcessId:         pid,
@@ -33,7 +52,7 @@ func TestMinimeProof(t *testing.T) {
 		EnvelopeType:      &models.EnvelopeType{EncryptedVotes: false},
 		Mode:              new(models.ProcessMode),
 		Status:            models.ProcessStatus_READY,
-		EntityId:          util.RandomBytes(types.EthereumAddressSize),
+		EntityId:          signer.Address().Bytes(),
 		CensusRoot:        testMinimeStorageRoot,
 		CensusOrigin:      models.CensusOrigin_MINI_ME,
 		BlockCount:        1024,

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -49,13 +49,33 @@ func TestMerkleTreeProof(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// set tx cost for Tx: NewProcess
+	if err := app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	signer := ethereum.SignKeys{}
+	if err := signer.Generate(); err != nil {
+		t.Fatal(err)
+	}
+	acc := &Account{}
+	acc.Balance = 1000
+	acc.InfoURI = "ipfs://"
+	if err := app.State.SetAccount(
+		signer.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	process := &models.Process{
 		ProcessId:    pid,
 		StartBlock:   0,
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         &models.ProcessMode{},
 		Status:       models.ProcessStatus_READY,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     signer.Address().Bytes(),
 		CensusRoot:   root,
 		CensusURI:    &censusURI,
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
@@ -182,6 +202,22 @@ func TestCAProof(t *testing.T) {
 	if err := ca.Generate(); err != nil {
 		t.Fatal(err)
 	}
+
+	// set tx cost for Tx: NewProcess
+	if err := app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	acc := &Account{}
+	acc.Balance = 1000
+	acc.InfoURI = "ipfs://"
+	if err := app.State.SetAccount(
+		ca.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	pid := util.RandomBytes(types.ProcessIDsize)
 	process := &models.Process{
 		ProcessId:    pid,
@@ -189,7 +225,7 @@ func TestCAProof(t *testing.T) {
 		EnvelopeType: &models.EnvelopeType{EncryptedVotes: false},
 		Mode:         new(models.ProcessMode),
 		Status:       models.ProcessStatus_READY,
-		EntityId:     util.RandomBytes(types.EthereumAddressSize),
+		EntityId:     ca.Address().Bytes(),
 		CensusRoot:   ca.PublicKey(),
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_CA,
 		BlockCount:   1024,

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -667,6 +667,15 @@ func (v *State) SetFaucetNonce(key []byte) error {
 	return v.Tx.DeepSet(key, nil, FaucetNonceCfg)
 }
 
+func (v *State) burnAccountBalance(accoutAddress common.Address, value uint64) error {
+	acc, err := v.GetAccount(accoutAddress, false)
+	if err != nil {
+		return err
+	}
+	acc.Balance -= value
+	return v.setAccount(accoutAddress, acc)
+}
+
 // hexPubKeyToTendermintEd25519 decodes a pubKey string to a ed25519 pubKey
 func hexPubKeyToTendermintEd25519(pubKey string) (tmcrypto.PubKey, error) {
 	var tmkey ed25519.PubKey

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -556,6 +556,7 @@ func (v *State) setTreasurer(address common.Address) error {
 	return v.Tx.DeepSet([]byte(TreasurerKey), tBytes, ExtraCfg)
 }
 
+// Treasurer returns the address and the Treasurer nonce
 func (v *State) Treasurer(isQuery bool) (*models.Treasurer, error) {
 	if !isQuery {
 		v.Tx.RLock()
@@ -576,6 +577,7 @@ func (v *State) Treasurer(isQuery bool) (*models.Treasurer, error) {
 	return &t, nil
 }
 
+// IsTreasurer returns true if the given address matches the Treasurer address
 func (v *State) IsTreasurer(addr common.Address) (bool, error) {
 	t, err := v.Treasurer(false)
 	if err != nil {
@@ -585,6 +587,7 @@ func (v *State) IsTreasurer(addr common.Address) (bool, error) {
 	return addr == tAddr, nil
 }
 
+// incrementTreasurerNonce increments the treasurer nonce
 func (v *State) incrementTreasurerNonce() error {
 	t, err := v.Treasurer(false)
 	if err != nil {
@@ -600,6 +603,7 @@ func (v *State) incrementTreasurerNonce() error {
 	return v.Tx.DeepSet([]byte(TreasurerKey), tBytes, ExtraCfg)
 }
 
+// SetTxCost sets the given transaction cost
 func (v *State) SetTxCost(txType models.TxType, cost uint64) error {
 	key, ok := TxTypeCostToStateKey[txType]
 	if !ok {
@@ -613,6 +617,7 @@ func (v *State) SetTxCost(txType models.TxType, cost uint64) error {
 	return v.Tx.DeepSet([]byte(key), costBytes[:], ExtraCfg)
 }
 
+// TxCost returns the cost of a given transaction
 func (v *State) TxCost(txType models.TxType, isQuery bool) (uint64, error) {
 	key, ok := TxTypeCostToStateKey[txType]
 	if !ok {
@@ -667,8 +672,9 @@ func (v *State) SetFaucetNonce(key []byte) error {
 	return v.Tx.DeepSet(key, nil, FaucetNonceCfg)
 }
 
-func (v *State) substractTxCostIncrementNonce(accoutAddress common.Address, value uint64) error {
-	acc, err := v.GetAccount(accoutAddress, false)
+// substractTxCostIncrementNonce substracts the tx cost from the account balance and increments the nonce
+func (v *State) substractTxCostIncrementNonce(accountAddress common.Address, value uint64) error {
+	acc, err := v.GetAccount(accountAddress, false)
 	if err != nil {
 		return err
 	}
@@ -677,7 +683,7 @@ func (v *State) substractTxCostIncrementNonce(accoutAddress common.Address, valu
 	}
 	acc.Nonce++
 	acc.Balance -= value
-	return v.SetAccount(accoutAddress, acc)
+	return v.SetAccount(accountAddress, acc)
 }
 
 // hexPubKeyToTendermintEd25519 decodes a pubKey string to a ed25519 pubKey

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -667,7 +667,7 @@ func (v *State) SetFaucetNonce(key []byte) error {
 	return v.Tx.DeepSet(key, nil, FaucetNonceCfg)
 }
 
-func (v *State) substractTxCost(accoutAddress common.Address, value uint64) error {
+func (v *State) substractTxCostIncrementNonce(accoutAddress common.Address, value uint64) error {
 	acc, err := v.GetAccount(accoutAddress, false)
 	if err != nil {
 		return err
@@ -675,6 +675,7 @@ func (v *State) substractTxCost(accoutAddress common.Address, value uint64) erro
 	if acc == nil {
 		return fmt.Errorf("account not found")
 	}
+	acc.Nonce++
 	acc.Balance -= value
 	return v.SetAccount(accoutAddress, acc)
 }

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -504,36 +504,61 @@ func (v *State) IsOracle(addr common.Address) (bool, error) {
 
 // setTreasurer saves the Treasurer address to the state
 func (v *State) setTreasurer(address common.Address) error {
+	t := &models.Treasurer{
+		Address: address.Bytes(),
+		Nonce:   0,
+	}
+	tBytes, err := proto.Marshal(t)
+	if err != nil {
+		return err
+	}
 	v.Tx.Lock()
 	defer v.Tx.Unlock()
-	return v.Tx.DeepSet([]byte(TreasurerKey), address.Bytes(), ExtraCfg)
+	return v.Tx.DeepSet([]byte(TreasurerKey), tBytes, ExtraCfg)
 }
 
-func (v *State) Treasurer(isQuery bool) (common.Address, error) {
+func (v *State) Treasurer(isQuery bool) (*models.Treasurer, error) {
 	if !isQuery {
 		v.Tx.RLock()
 		defer v.Tx.RUnlock()
 	}
-
 	extraTree, err := v.mainTreeViewer(isQuery).SubTree(ExtraCfg)
 	if err != nil {
-		return common.Address{}, err
+		return nil, err
 	}
-
 	var rawTreasurer []byte
 	if rawTreasurer, err = extraTree.Get([]byte(TreasurerKey)); err != nil {
-		return common.Address{}, err
+		return nil, err
 	}
-	return common.BytesToAddress(rawTreasurer), nil
+	var t models.Treasurer
+	if err := proto.Unmarshal(rawTreasurer, &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
 }
 
 func (v *State) IsTreasurer(addr common.Address) (bool, error) {
-	tAddr, err := v.Treasurer(false)
+	t, err := v.Treasurer(false)
 	if err != nil {
 		return false, err
 	}
-
+	tAddr := common.BytesToAddress(t.Address)
 	return addr == tAddr, nil
+}
+
+func (v *State) incrementTreasurerNonce() error {
+	t, err := v.Treasurer(false)
+	if err != nil {
+		return err
+	}
+	t.Nonce++
+	tBytes, err := proto.Marshal(t)
+	if err != nil {
+		return err
+	}
+	v.Tx.Lock()
+	defer v.Tx.Unlock()
+	return v.Tx.DeepSet([]byte(TreasurerKey), tBytes, ExtraCfg)
 }
 
 // hexPubKeyToTendermintEd25519 decodes a pubKey string to a ed25519 pubKey

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -667,13 +667,16 @@ func (v *State) SetFaucetNonce(key []byte) error {
 	return v.Tx.DeepSet(key, nil, FaucetNonceCfg)
 }
 
-func (v *State) burnAccountBalance(accoutAddress common.Address, value uint64) error {
+func (v *State) substractTxCost(accoutAddress common.Address, value uint64) error {
 	acc, err := v.GetAccount(accoutAddress, false)
 	if err != nil {
 		return err
 	}
+	if acc == nil {
+		return fmt.Errorf("account not found")
+	}
 	acc.Balance -= value
-	return v.setAccount(accoutAddress, acc)
+	return v.SetAccount(accoutAddress, acc)
 }
 
 // hexPubKeyToTendermintEd25519 decodes a pubKey string to a ed25519 pubKey

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -110,6 +110,9 @@ func TestBalanceTransfer(t *testing.T) {
 	addr2 := ethereum.SignKeys{}
 	addr2.Generate()
 
+	s.SetAccountInfoURI(addr1.Address(), "test://")
+	s.SetAccountInfoURI(addr2.Address(), "test://")
+
 	err = s.MintBalance(addr1.Address(), 50)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -119,23 +122,23 @@ func TestBalanceTransfer(t *testing.T) {
 	qt.Assert(t, b1.Balance, qt.Equals, uint64(50))
 	qt.Assert(t, b1.Nonce, qt.Equals, uint32(0))
 
-	err = s.TransferBalance(addr1.Address(), addr2.Address(), 20, 0, false)
+	err = s.TransferBalance(addr1.Address(), addr2.Address(), 20, 0)
 	qt.Assert(t, err, qt.IsNil)
 
 	b2, err := s.GetAccount(addr2.Address(), false)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, b2.Balance, qt.Equals, uint64(20))
 
-	err = s.TransferBalance(addr1.Address(), addr2.Address(), 20, 2, false)
+	err = s.TransferBalance(addr1.Address(), addr2.Address(), 20, 2)
 	qt.Assert(t, err, qt.IsNotNil)
 
-	err = s.TransferBalance(addr1.Address(), addr2.Address(), 40, 1, false)
+	err = s.TransferBalance(addr1.Address(), addr2.Address(), 40, 1)
 	qt.Assert(t, err, qt.IsNotNil)
 
-	err = s.TransferBalance(addr2.Address(), addr1.Address(), 10, 0, false)
+	err = s.TransferBalance(addr2.Address(), addr1.Address(), 10, 0)
 	qt.Assert(t, err, qt.IsNil)
 
-	err = s.TransferBalance(addr2.Address(), addr1.Address(), 5, 1, false)
+	err = s.TransferBalance(addr2.Address(), addr1.Address(), 5, 1)
 	qt.Assert(t, err, qt.IsNil)
 
 	b1, err = s.GetAccount(addr1.Address(), false)

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -160,6 +160,7 @@ func TestBalanceTransfer(t *testing.T) {
 
 	s.Save() // Save to test isQuery value on next call
 	b1, err := s.GetAccount(addr1.Address(), true)
+	qt.Assert(t, b1, qt.IsNotNil)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, b1.Balance, qt.Equals, uint64(50))
 	qt.Assert(t, b1.Nonce, qt.Equals, uint32(0))
@@ -168,6 +169,7 @@ func TestBalanceTransfer(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	b2, err := s.GetAccount(addr2.Address(), false)
+	qt.Assert(t, b2, qt.IsNotNil)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, b2.Balance, qt.Equals, uint64(70))
 
@@ -184,12 +186,14 @@ func TestBalanceTransfer(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	b1, err = s.GetAccount(addr1.Address(), false)
+	qt.Assert(t, b1, qt.IsNotNil)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, b1.Balance, qt.Equals, uint64(35))
 	qt.Assert(t, b1.Nonce, qt.Equals, uint32(1))
 
 	s.Save()
 	b2, err = s.GetAccount(addr2.Address(), true)
+	qt.Assert(t, b2, qt.IsNotNil)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, b2.Balance, qt.Equals, uint64(35))
 	qt.Assert(t, b2.Nonce, qt.Equals, uint32(2))

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -299,14 +300,18 @@ func TestStateTreasurer(t *testing.T) {
 	s.Rollback()
 	s.SetHeight(height)
 
-	treasurer := "0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d"
-	qt.Assert(t, s.setTreasurer(ethcommon.HexToAddress(treasurer)), qt.IsNil)
+	tAddr := common.HexToAddress("0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d")
+	treasurer := &models.Treasurer{
+		Address: tAddr.Bytes(),
+		Nonce:   0,
+	}
+	qt.Assert(t, s.setTreasurer(tAddr), qt.IsNil)
 
 	fetchedTreasurer, err := s.Treasurer(false)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, fetchedTreasurer.String(), qt.CmpEquals(), treasurer)
+	qt.Assert(t, fetchedTreasurer.Address, qt.CmpEquals(), treasurer.Address)
 
-	fetchedTreasurer, err = s.Treasurer(true)
+	_, err = s.Treasurer(true)
 	// key does not exist yet
 	qt.Assert(t, err, qt.IsNotNil)
 
@@ -315,7 +320,7 @@ func TestStateTreasurer(t *testing.T) {
 
 	fetchedTreasurer, err = s.Treasurer(true)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, fetchedTreasurer.String(), qt.CmpEquals(), treasurer)
+	qt.Assert(t, fetchedTreasurer.Address, qt.CmpEquals(), treasurer.Address)
 }
 
 func TestStateIsTreasurer(t *testing.T) {
@@ -328,9 +333,9 @@ func TestStateIsTreasurer(t *testing.T) {
 	s.Rollback()
 	s.SetHeight(height)
 
-	treasurer := "0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d"
-	qt.Assert(t, s.setTreasurer(ethcommon.HexToAddress(treasurer)), qt.IsNil)
-	r, err := s.IsTreasurer(ethcommon.HexToAddress(treasurer))
+	tAddr := common.HexToAddress("0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d")
+	qt.Assert(t, s.setTreasurer(tAddr), qt.IsNil)
+	r, err := s.IsTreasurer(tAddr)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, r, qt.IsTrue)
 

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -110,8 +110,8 @@ func TestBalanceTransfer(t *testing.T) {
 	addr2 := ethereum.SignKeys{}
 	addr2.Generate()
 
-	s.SetAccountInfoURI(addr1.Address(), "test://")
-	s.SetAccountInfoURI(addr2.Address(), "test://")
+	s.SetAccountInfoURI(addr1.Address(), addr1.Address(), "test://")
+	s.SetAccountInfoURI(addr2.Address(), addr1.Address(), "test://")
 
 	err = s.MintBalance(addr1.Address(), 50)
 	qt.Assert(t, err, qt.IsNil)

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/db"
@@ -340,7 +339,23 @@ func TestStateIsTreasurer(t *testing.T) {
 	qt.Assert(t, r, qt.IsTrue)
 
 	notTreasurer := "0x000000000000000000000000000000000000dead"
-	r, err = s.IsTreasurer(ethcommon.HexToAddress(notTreasurer))
+	r, err = s.IsTreasurer(common.HexToAddress(notTreasurer))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, r, qt.IsFalse)
+}
+
+func TestStateSetGetTxCostByTxType(t *testing.T) {
+	log.Init("info", "stdout")
+	s, err := NewState(db.TypePebble, t.TempDir())
+	qt.Assert(t, err, qt.IsNil)
+	defer s.Close()
+
+	var height uint32 = 1
+	s.Rollback()
+	s.SetHeight(height)
+
+	qt.Assert(t, s.SetTxCost(models.TxType_SET_PROCESS_CENSUS, 100), qt.IsNil)
+	cost, err := s.TxCost(models.TxType_SET_PROCESS_CENSUS, false)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, cost, qt.Equals, uint64(100))
 }

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -124,7 +124,8 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 		}
 
 	case *models.Tx_SetProcess:
-		if err := SetProcessTxCheck(vtx.tx, vtx.signedBody, vtx.signature, app.State); err != nil {
+		txSender, err := SetProcessTxCheck(vtx.tx, vtx.signedBody, vtx.signature, app.State)
+		if err != nil {
 			return []byte{}, fmt.Errorf("setProcess: %w", err)
 		}
 		if commit {
@@ -134,17 +135,17 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 				if tx.GetStatus() == models.ProcessStatus_PROCESS_UNKNOWN {
 					return []byte{}, fmt.Errorf("set process status, status unknown")
 				}
-				return vtx.txID[:], app.State.SetProcessStatus(tx.ProcessId, *tx.Status, true)
+				return vtx.txID[:], app.State.SetProcessStatus(tx.ProcessId, *tx.Status, txSender, true)
 			case models.TxType_SET_PROCESS_RESULTS:
 				if tx.GetResults() == nil {
 					return []byte{}, fmt.Errorf("set process results, results is nil")
 				}
-				return vtx.txID[:], app.State.SetProcessResults(tx.ProcessId, tx.Results, true)
+				return vtx.txID[:], app.State.SetProcessResults(tx.ProcessId, tx.Results, txSender, true)
 			case models.TxType_SET_PROCESS_CENSUS:
 				if tx.GetCensusRoot() == nil {
 					return []byte{}, fmt.Errorf("set process census, census root is nil")
 				}
-				return vtx.txID[:], app.State.SetProcessCensus(tx.ProcessId, tx.CensusRoot, tx.GetCensusURI(), true)
+				return vtx.txID[:], app.State.SetProcessCensus(tx.ProcessId, tx.CensusRoot, tx.GetCensusURI(), txSender, true)
 			default:
 				return []byte{}, fmt.Errorf("unknown set process tx type")
 			}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -172,7 +172,22 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 		}
 		if commit {
 			if txValues.Create {
-				return vtx.txID[:], app.State.CreateAccount(txValues.TxSender, vtx.tx.GetSetAccountInfo().GetInfoURI(), make([]common.Address, 0), 0)
+				if txValues.FaucetPayloadSigner == types.EthereumZeroAddressBytes {
+					return vtx.txID[:], app.State.CreateAccount(txValues.TxSender,
+						vtx.tx.GetSetAccountInfo().GetInfoURI(),
+						make([]common.Address, 0),
+						0,
+						common.Address{},
+						0,
+					)
+				}
+				return vtx.txID[:], app.State.CreateAccount(txValues.TxSender,
+					vtx.tx.GetSetAccountInfo().GetInfoURI(),
+					make([]common.Address, 0),
+					txValues.FaucetPayload.Amount,
+					txValues.FaucetPayloadSigner,
+					txValues.FaucetPayload.Identifier,
+				)
 			}
 			return vtx.txID[:], app.State.SetAccountInfoURI(txValues.Account, txValues.TxSender, vtx.tx.GetSetAccountInfo().GetInfoURI())
 		}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -172,7 +172,7 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 		}
 		if commit {
 			if txValues.Create {
-				return vtx.txID[:], app.State.CreateAccount(txValues.Account, vtx.tx.GetSetAccountInfo().GetInfoURI(), make([]common.Address, 0), 0)
+				return vtx.txID[:], app.State.CreateAccount(txValues.TxSender, vtx.tx.GetSetAccountInfo().GetInfoURI(), make([]common.Address, 0), 0)
 			}
 			return vtx.txID[:], app.State.SetAccountInfoURI(txValues.Account, txValues.TxSender, vtx.tx.GetSetAccountInfo().GetInfoURI())
 		}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -165,16 +165,15 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 		}
 
 	case *models.Tx_SetAccountInfo:
-		accountAddr, create, err := SetAccountInfoTxCheck(vtx.tx, vtx.signedBody, vtx.signature, app.State)
+		accountAddr, txSender, create, err := SetAccountInfoTxCheck(vtx.tx, vtx.signedBody, vtx.signature, app.State)
 		if err != nil {
 			return []byte{}, fmt.Errorf("cannot set account: %w", err)
 		}
 		if commit {
 			if create {
-				return vtx.txID[:], app.State.CreateAccount(accountAddr,
-					vtx.tx.GetSetAccountInfo().GetInfoURI(), make([]common.Address, 0), 0)
+				return vtx.txID[:], app.State.CreateAccount(accountAddr, vtx.tx.GetSetAccountInfo().GetInfoURI(), make([]common.Address, 0), 0)
 			}
-			return vtx.txID[:], app.State.SetAccountInfoURI(accountAddr, vtx.tx.GetSetAccountInfo().GetInfoURI())
+			return vtx.txID[:], app.State.SetAccountInfoURI(accountAddr, txSender, vtx.tx.GetSetAccountInfo().GetInfoURI())
 		}
 
 	case *models.Tx_MintTokens:

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -206,6 +206,15 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 			}
 		}
 
+	case *models.Tx_SendTokens:
+		from, to, amount, nonce, err := SendTokensTxCheck(vtx, txBytes, signature, app.State)
+		if err != nil {
+			return []byte{}, fmt.Errorf("sendTokensTx: %w", err)
+		}
+		if commit {
+			return []byte{}, app.State.TransferBalance(from, to, amount, nonce)
+		}
+
 	default:
 		return []byte{}, fmt.Errorf("invalid transaction type")
 	}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -197,9 +197,9 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 			tx := vtx.GetSetAccountDelegateTx()
 			switch tx.Txtype {
 			case models.TxType_ADD_DELEGATE_FOR_ACCOUNT:
-				return []byte{}, app.State.setDelegate(accountAddr, delegate, models.TxType_ADD_DELEGATE_FOR_ACCOUNT)
+				return []byte{}, app.State.SetDelegate(accountAddr, delegate, models.TxType_ADD_DELEGATE_FOR_ACCOUNT)
 			case models.TxType_DEL_DELEGATE_FOR_ACCOUNT:
-				return []byte{}, app.State.setDelegate(accountAddr, delegate, models.TxType_DEL_DELEGATE_FOR_ACCOUNT)
+				return []byte{}, app.State.SetDelegate(accountAddr, delegate, models.TxType_DEL_DELEGATE_FOR_ACCOUNT)
 			default:
 				return []byte{}, fmt.Errorf("unknown set account delegate tx type")
 			}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -189,6 +189,23 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 			return []byte{}, app.State.incrementTreasurerNonce()
 		}
 
+	case *models.Tx_SetAccountDelegateTx:
+		accountAddr, delegate, err := SetAccountDelegateTxCheck(vtx, txBytes, signature, app.State)
+		if err != nil {
+			return []byte{}, fmt.Errorf("setAccountDelegateTx: %w", err)
+		}
+		if commit {
+			tx := vtx.GetSetAccountDelegateTx()
+			switch tx.Txtype {
+			case models.TxType_ADD_DELEGATE_FOR_ACCOUNT:
+				return []byte{}, app.State.setDelegate(accountAddr, delegate, models.TxType_ADD_DELEGATE_FOR_ACCOUNT)
+			case models.TxType_DEL_DELEGATE_FOR_ACCOUNT:
+				return []byte{}, app.State.setDelegate(accountAddr, delegate, models.TxType_DEL_DELEGATE_FOR_ACCOUNT)
+			default:
+				return []byte{}, fmt.Errorf("unknown set account delegate tx type")
+			}
+		}
+
 	default:
 		return []byte{}, fmt.Errorf("invalid transaction type")
 	}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -660,7 +660,7 @@ func SetTransactionCostsTxCheck(vtx *models.Tx, txBytes, signature []byte, state
 	}
 	// check nonce
 	if tx.Nonce != treasurer.Nonce {
-		return 0, fmt.Errorf("invalid nonce %d, expected: %d", tx.Nonce, treasurer.Nonce+1)
+		return 0, fmt.Errorf("invalid nonce %d, expected: %d", tx.Nonce, treasurer.Nonce)
 	}
 	// check valid tx type
 	if _, ok := TxTypeCostToStateKey[tx.Txtype]; !ok {

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -165,15 +165,15 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 		}
 
 	case *models.Tx_SetAccountInfo:
-		accountAddr, txSender, create, err := SetAccountInfoTxCheck(vtx.tx, vtx.signedBody, vtx.signature, app.State)
+		txValues, err := SetAccountInfoTxCheck(vtx.tx, vtx.signedBody, vtx.signature, app.State)
 		if err != nil {
 			return []byte{}, fmt.Errorf("cannot set account: %w", err)
 		}
 		if commit {
-			if create {
-				return vtx.txID[:], app.State.CreateAccount(accountAddr, vtx.tx.GetSetAccountInfo().GetInfoURI(), make([]common.Address, 0), 0)
+			if txValues.Create {
+				return vtx.txID[:], app.State.CreateAccount(txValues.Account, vtx.tx.GetSetAccountInfo().GetInfoURI(), make([]common.Address, 0), 0)
 			}
-			return vtx.txID[:], app.State.SetAccountInfoURI(accountAddr, txSender, vtx.tx.GetSetAccountInfo().GetInfoURI())
+			return vtx.txID[:], app.State.SetAccountInfoURI(txValues.Account, txValues.TxSender, vtx.tx.GetSetAccountInfo().GetInfoURI())
 		}
 
 	case *models.Tx_MintTokens:

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -177,6 +177,18 @@ func (app *BaseApplication) AddTx(vtx *vochainTx, commit bool) ([]byte, error) {
 			return vtx.txID[:], app.State.SetAccountInfoURI(accountAddr, vtx.tx.GetSetAccountInfo().GetInfoURI())
 		}
 
+	case *models.Tx_MintTokens:
+		address, amount, err := MintTokensTxCheck(vtx, txBytes, signature, app.State)
+		if err != nil {
+			return []byte{}, fmt.Errorf("mintTokensTx: %w", err)
+		}
+		if commit {
+			if err := app.State.MintBalance(address, amount); err != nil {
+				return []byte{}, fmt.Errorf("mintTokensTx: %w", err)
+			}
+			return []byte{}, app.State.incrementTreasurerNonce()
+		}
+
 	default:
 		return []byte{}, fmt.Errorf("invalid transaction type")
 	}

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/proto/build/go/models"
 )
@@ -23,6 +24,7 @@ var (
 	ErrProcessNotFound     = fmt.Errorf("process not found")
 	ErrBalanceOverflow     = fmt.Errorf("balance overflow")
 	ErrAccountBalanceZero  = fmt.Errorf("zero balance account not valid")
+	ErrAccountNotFound     = fmt.Errorf("account does not exist")
 	// keys; not constants because of []byte
 	voteCountKey = []byte("voteCount")
 )
@@ -34,6 +36,17 @@ var PrefixDBCacheSize = 0
 type VotePackage struct {
 	Nonce string `json:"nonce,omitempty"`
 	Votes []int  `json:"votes"`
+}
+
+type sendTokensTxCheckValues struct {
+	From, To common.Address
+	Value    uint64
+	Nonce    uint32
+}
+
+type setAccountInfoTxCheckValues struct {
+	Account, TxSender common.Address
+	Create            bool
 }
 
 // UniqID returns a uniq identifier for the VoteTX. It depends on the Type.

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -45,8 +45,9 @@ type sendTokensTxCheckValues struct {
 }
 
 type setAccountInfoTxCheckValues struct {
-	Account, TxSender common.Address
-	Create            bool
+	Account, TxSender, FaucetPayloadSigner common.Address
+	FaucetPayload                          *models.FaucetPayload
+	Create                                 bool
 }
 
 // UniqID returns a uniq identifier for the VoteTX. It depends on the Type.

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -13,8 +13,6 @@ import (
 const (
 	voteCachePurgeThreshold = uint32(60) // in blocks, 10 minutes
 	voteCacheSize           = 50000
-	NewProcessCost          = 0
-	SetProcessCost          = 0
 	costPrefix              = "c_"
 )
 

--- a/vochain/types.go
+++ b/vochain/types.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	ErrVoteDoesNotExist    = fmt.Errorf("vote does not exist")
-	ErrNotEnoughBalance    = fmt.Errorf("not enough balance to transfer")
+	ErrNotEnoughBalance    = fmt.Errorf("not enough balance")
 	ErrAccountNonceInvalid = fmt.Errorf("invalid account nonce")
 	ErrProcessNotFound     = fmt.Errorf("process not found")
 	ErrBalanceOverflow     = fmt.Errorf("balance overflow")

--- a/vochain/types_test.go
+++ b/vochain/types_test.go
@@ -1,0 +1,64 @@
+package vochain
+
+import (
+	"reflect"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+func TestTransactionCostsAsMap(t *testing.T) {
+	txCosts := TransactionCosts{
+		SetProcessStatus:        100,
+		SetProcessCensus:        200,
+		SetProcessResults:       300,
+		SetProcessQuestionIndex: 400,
+		RegisterKey:             500,
+		NewProcess:              600,
+		SendTokens:              700,
+		SetAccountInfo:          800,
+		AddDelegateForAccount:   900,
+		DelDelegateForAccount:   1000,
+		CollectFaucet:           1100,
+	}
+	txCostsBytes := txCosts.AsMap()
+
+	expected := map[models.TxType]uint64{
+		models.TxType_SET_PROCESS_STATUS:         100,
+		models.TxType_SET_PROCESS_CENSUS:         200,
+		models.TxType_SET_PROCESS_RESULTS:        300,
+		models.TxType_SET_PROCESS_QUESTION_INDEX: 400,
+		models.TxType_REGISTER_VOTER_KEY:         500,
+		models.TxType_NEW_PROCESS:                600,
+		models.TxType_SEND_TOKENS:                700,
+		models.TxType_SET_ACCOUNT_INFO:           800,
+		models.TxType_ADD_DELEGATE_FOR_ACCOUNT:   900,
+		models.TxType_DEL_DELEGATE_FOR_ACCOUNT:   1000,
+		models.TxType_COLLECT_FAUCET:             1100,
+	}
+	qt.Assert(t, txCostsBytes, qt.DeepEquals, expected)
+}
+func TestTxCostNameToTxType(t *testing.T) {
+	fields := map[string]models.TxType{
+		"SetProcessStatus":        models.TxType_SET_PROCESS_STATUS,
+		"SetProcessCensus":        models.TxType_SET_PROCESS_CENSUS,
+		"SetProcessResults":       models.TxType_SET_PROCESS_RESULTS,
+		"SetProcessQuestionIndex": models.TxType_SET_PROCESS_QUESTION_INDEX,
+		"RegisterKey":             models.TxType_REGISTER_VOTER_KEY,
+		"NewProcess":              models.TxType_NEW_PROCESS,
+		"SendTokens":              models.TxType_SEND_TOKENS,
+		"SetAccountInfo":          models.TxType_SET_ACCOUNT_INFO,
+		"AddDelegateForAccount":   models.TxType_ADD_DELEGATE_FOR_ACCOUNT,
+		"DelDelegateForAccount":   models.TxType_DEL_DELEGATE_FOR_ACCOUNT,
+		"CollectFaucet":           models.TxType_COLLECT_FAUCET,
+	}
+	for k, v := range fields {
+		qt.Assert(t, TxCostNameToTxType(k), qt.Equals, v)
+
+		// check that TransactionCosts struct does have the fields that we
+		// specify in this test
+		_, found := reflect.TypeOf(TransactionCosts{}).FieldByName(k)
+		qt.Assert(t, found, qt.IsTrue)
+	}
+}

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -73,7 +73,7 @@ func testCSPvote(oracle *ethereum.SignKeys, url string) error {
 	censusOrigin := models.CensusOrigin_OFF_CHAIN_CA
 	duration := 100
 	censusSize := 10
-	startBlock, err := cli.CreateProcess(
+	startBlock, err := cli.TestCreateProcess(
 		oracle,
 		entityID,
 		censusRoot,

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -9,6 +9,7 @@ import (
 	"go.vocdoni.io/dvote/client"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/util"
+	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
@@ -25,7 +26,32 @@ func TestVocone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// set tx cost for Tx: NewProcess
+	if err := vc.app.State.SetTxCost(models.TxType_NEW_PROCESS, 10); err != nil {
+		t.Fatal(err)
+	}
+	// set tx cost for Tx: SetProcessStatus
+	if err := vc.app.State.SetTxCost(models.TxType_SET_PROCESS_STATUS, 10); err != nil {
+		t.Fatal(err)
+	}
+	// set tx cost for Tx: SetProcessResults
+	if err := vc.app.State.SetTxCost(models.TxType_SET_PROCESS_RESULTS, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	acc := &vochain.Account{}
+	acc.Balance = 1000
+	acc.InfoURI = "ipfs://"
+	if err := vc.app.State.SetAccount(
+		oracle.Address(),
+		acc,
+	); err != nil {
+		t.Fatal(err)
+	}
 	vc.SetBlockTimeTarget(time.Millisecond * 500)
+	if _, err := vc.app.State.Save(); err != nil {
+		t.Fatal(err)
+	}
 	go vc.Start()
 	port := 13000 + util.RandomInt(0, 2000)
 	vc.EnableAPI("127.0.0.1", port, "/dvote")
@@ -40,10 +66,8 @@ func testCSPvote(oracle *ethereum.SignKeys, url string) error {
 	if err != nil {
 		return err
 	}
-	cspKey := ethereum.SignKeys{}
-	cspKey.Generate()
-	entityID := util.RandomBytes(20)
-	censusRoot := cspKey.PublicKey()
+	entityID := oracle.Address().Bytes()
+	censusRoot := oracle.PublicKey()
 	processID := util.RandomBytes(32)
 	envelope := new(models.EnvelopeType)
 	censusOrigin := models.CensusOrigin_OFF_CHAIN_CA
@@ -67,7 +91,7 @@ func testCSPvote(oracle *ethereum.SignKeys, url string) error {
 	}
 
 	voterKeys := util.CreateEthRandomKeysBatch(censusSize)
-	proofs, err := cli.GetCSPproofBatch(voterKeys, &cspKey, processID)
+	proofs, err := cli.GetCSPproofBatch(voterKeys, oracle, processID)
 	if err != nil {
 		return err
 	}
@@ -76,11 +100,11 @@ func testCSPvote(oracle *ethereum.SignKeys, url string) error {
 	elapsedTime, err := cli.TestSendVotes(
 		processID,
 		entityID,
-		cspKey.PublicKey(),
+		oracle.PublicKey(),
 		startBlock,
 		voterKeys,
 		censusOrigin,
-		&cspKey,
+		oracle,
 		proofs,
 		false,
 		false,


### PR DESCRIPTION
See: https://www.notion.so/Ethereum-less-vochain-description-67780a73a3e54be5892ed2a2a145b7c7

Changes:
- Adds support for: `MintTokensTx`, `SetAccountDelegate`, `SendTokens`, `CollectFaucetTx` & `SetTransactionCostsTx`.
- Adds support for transaction costs on current and new defined transactions as well as on the genesis.json and `InitChain`.
- Delegates can change account infoURI, create processes and set the process status on behalf of an account, make the proper changes to support this behavior on `NewProcessTx` and `SetProcessStatus`.
- Adds unit and integration tests for the newly defined transactions.
- Refactors current unit and integration tests for making them work with the ethereum-less approach.
- Adapt the remaining code to the new signing schema.
- Adds API Client methods for the new transactions.