### PR TITLE
Fix db WriteTx.Apply when combining db impls

### DIFF
--- a/db/badgerdb/badger.go
+++ b/db/badgerdb/badger.go
@@ -79,7 +79,7 @@ func (tx WriteTx) Delete(k []byte) error {
 
 // Apply implements the db.WriteTx.Apply interface method
 func (tx WriteTx) Apply(other db.WriteTx) (err error) {
-	otherBadger := other.(WriteTx)
+	otherBadger := db.UnwrapWriteTx(other).(WriteTx)
 
 	valueOfTx := reflect.ValueOf(otherBadger.tx)
 	pendingWrites := valueOfTx.Elem().FieldByName("pendingWrites")

--- a/db/badgerdb/badger_test.go
+++ b/db/badgerdb/badger_test.go
@@ -7,6 +7,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/internal/dbtest"
+	"go.vocdoni.io/dvote/db/prefixeddb"
 )
 
 func TestWriteTx(t *testing.T) {
@@ -35,6 +36,23 @@ func TestWriteTxApply(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	dbtest.TestWriteTxApply(t, database)
+}
+
+func TestWriteTxApplyPrefixed(t *testing.T) {
+	database, err := New(db.Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	prefix := []byte("one")
+	dbWithPrefix := prefixeddb.NewPrefixedDatabase(database, prefix)
+
+	dbtest.TestWriteTxApplyPrefixed(t, database, dbWithPrefix)
+}
+
+func TestWriteTxApplyBatch(t *testing.T) {
+	database, err := New(db.Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	dbtest.TestWriteTxApplyBatch(t, database)
 }
 
 func TestBatch(t *testing.T) {

--- a/db/batch.go
+++ b/db/batch.go
@@ -61,6 +61,11 @@ func (t *Batch) Apply(other WriteTx) (err error) {
 	return t.tx.Apply(other)
 }
 
+// Unwrap returns the wrapped WriteTx
+func (t *Batch) Unwrap() WriteTx {
+	return t.tx
+}
+
 // Set implements the WriteTx.Set interface method.  If during this
 // operation, the internal tx becomes too big, all the pending writes will be
 // committed and a new WriteTx will be created to continue with this and

--- a/db/interface.go
+++ b/db/interface.go
@@ -77,3 +77,14 @@ type WriteTx interface {
 	// Commit commits the transaction into the db
 	Commit() error
 }
+
+// UnwrapWriteTx unwraps (if possible) the WriteTx using Unwrap method
+func UnwrapWriteTx(tx WriteTx) WriteTx {
+	for {
+		wtx, ok := tx.(interface{ Unwrap() WriteTx })
+		if !ok {
+			return tx
+		}
+		tx = wtx.Unwrap()
+	}
+}

--- a/db/internal/dbtest/dbtest.go
+++ b/db/internal/dbtest/dbtest.go
@@ -173,3 +173,39 @@ func TestWriteTxApply(t *testing.T, d db.Database) {
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, gV, qt.DeepEquals, []byte(strconv.Itoa(3)))
 }
+
+func TestWriteTxApplyPrefixed(t *testing.T, d, dbWithPrefix db.Database) {
+	wTxWithPrefix := dbWithPrefix.WriteTx()
+	defer wTxWithPrefix.Discard()
+	wTx := d.WriteTx()
+	defer wTx.Discard()
+
+	qt.Assert(t, wTxWithPrefix.Set([]byte("a"), []byte("a")), qt.IsNil)
+	qt.Assert(t, wTx.Set([]byte("b"), []byte("b")), qt.IsNil)
+
+	// try to put the contents from the normal wTx into the wTxWithPrefix
+	err := wTxWithPrefix.Apply(wTx)
+	qt.Assert(t, err, qt.IsNil)
+
+	// try to put the contents from wTxWithPrefix into the normal wTx
+	err = wTx.Apply(wTxWithPrefix)
+	qt.Assert(t, err, qt.IsNil)
+}
+
+func TestWriteTxApplyBatch(t *testing.T, d db.Database) {
+	batch := db.NewBatch(d)
+	defer batch.Discard()
+	wTx := d.WriteTx()
+	defer wTx.Discard()
+
+	qt.Assert(t, batch.Set([]byte("a"), []byte("a")), qt.IsNil)
+	qt.Assert(t, wTx.Set([]byte("b"), []byte("b")), qt.IsNil)
+
+	// try to put the contents from the normal wTx into the batch
+	err := batch.Apply(wTx)
+	qt.Assert(t, err, qt.IsNil)
+
+	// try to put the contents from batch into the normal wTx
+	err = wTx.Apply(batch)
+	qt.Assert(t, err, qt.IsNil)
+}

--- a/db/pebbledb/pebledb.go
+++ b/db/pebbledb/pebledb.go
@@ -69,7 +69,7 @@ func (tx WriteTx) Delete(k []byte) error {
 
 // Apply implements the db.WriteTx.Apply interface method
 func (tx WriteTx) Apply(other db.WriteTx) (err error) {
-	otherPebble := other.(WriteTx)
+	otherPebble := db.UnwrapWriteTx(other).(WriteTx)
 	return tx.batch.Apply(otherPebble.batch, nil)
 }
 

--- a/db/pebbledb/pebledb_test.go
+++ b/db/pebbledb/pebledb_test.go
@@ -6,6 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/internal/dbtest"
+	"go.vocdoni.io/dvote/db/prefixeddb"
 )
 
 func TestWriteTx(t *testing.T) {
@@ -20,6 +21,30 @@ func TestIterate(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	dbtest.TestIterate(t, database)
+}
+
+func TestWriteTxApply(t *testing.T) {
+	database, err := New(db.Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	dbtest.TestWriteTxApply(t, database)
+}
+
+func TestWriteTxApplyPrefixed(t *testing.T) {
+	database, err := New(db.Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	prefix := []byte("one")
+	dbWithPrefix := prefixeddb.NewPrefixedDatabase(database, prefix)
+
+	dbtest.TestWriteTxApplyPrefixed(t, database, dbWithPrefix)
+}
+
+func TestWriteTxApplyBatch(t *testing.T) {
+	database, err := New(db.Options{Path: t.TempDir()})
+	qt.Assert(t, err, qt.IsNil)
+
+	dbtest.TestWriteTxApplyBatch(t, database)
 }
 
 // NOTE: This test fails.  pebble.Batch doesn't detect conflicts.  Moreover,

--- a/db/prefixeddb/prefixeddb.go
+++ b/db/prefixeddb/prefixeddb.go
@@ -133,6 +133,11 @@ func (t *PrefixedWriteTx) Apply(other db.WriteTx) error {
 	return t.tx.Apply(other)
 }
 
+// Unwrap returns the wrapped WriteTx
+func (t *PrefixedWriteTx) Unwrap() db.WriteTx {
+	return t.tx
+}
+
 // Commit implements the db.WriteTx.Commit interface method.  Notice that this
 // method also commits the wrapped db.WriteTx.
 func (t *PrefixedWriteTx) Commit() error {


### PR DESCRIPTION
The `WriteTx.Apply` method was giving panic when combining WriteTxs from
different implementations (batch, prefixeddb, pebbledb, badgerdb).  For
example, in pebbledb, the method `Apply` was assuming that the given
`other db.WriteTx` would be from the type `pebbledb.WriteTx`, in order
to access to the private parameter `.batch`, and when the `other` comes
from a `prefixeddb.PrefixedWriteTx` does not match the
`pebbledb.WriteTx` and the panic appears.  The same happens when using
badger, and also when using Batch implementation instead prefixeddb.

This problem was reported in https://github.com/vocdoni/arbo/issues/27,
and reproduced in the db package tests of the current commit.
@mvdan pointed out the way to solve it using the Unwrap approach done in this
commit.

This PR should resolve https://github.com/vocdoni/arbo/issues/27