### PR TITLE
dvotenode: new flag --ipfsSyncLogLevel

### DIFF
--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -120,6 +120,8 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 		"enable IPFS cluster synchronization using the given secret key")
 	globalCfg.Ipfs.SyncPeers = *flag.StringSlice("ipfsSyncPeers", []string{},
 		"use custom ipfsSync peers/bootnodes for accessing the DHT (comma-separated)")
+	globalCfg.Ipfs.SyncLogLevel = *flag.String("ipfsSyncLogLevel", "",
+		"log level for ipfsSync component (debug, info, warn, error, fatal) (by default, inherits --logLevel)")
 	// vochain
 	globalCfg.VochainConfig.P2PListen = *flag.String("vochainP2PListen", "0.0.0.0:26656",
 		"p2p host and port to listent for the voting chain")
@@ -232,6 +234,7 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 	viper.BindPFlag("ipfs.NoInit", flag.Lookup("ipfsNoInit"))
 	viper.BindPFlag("ipfs.SyncKey", flag.Lookup("ipfsSyncKey"))
 	viper.BindPFlag("ipfs.SyncPeers", flag.Lookup("ipfsSyncPeers"))
+	viper.BindPFlag("ipfs.SyncLogLevel", flag.Lookup("ipfsSyncLogLevel"))
 
 	// vochain
 	viper.Set("vochainConfig.DataDir", globalCfg.DataDir+"/vochain")

--- a/cmd/ipfsSync/ipfsSync.go
+++ b/cmd/ipfsSync/ipfsSync.go
@@ -111,6 +111,7 @@ func main() {
 	} else {
 		is.Bootnodes = *bootnodes
 	}
+	is.SetLogger(log.Logger())
 	is.Start()
 	for _, peer := range *peers {
 		time.Sleep(2 * time.Second)

--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,8 @@ type IPFSCfg struct {
 	NoInit    bool
 	SyncKey   string
 	SyncPeers []string
+	// LogLevel used by ipfssync code. Inherits global if unset
+	SyncLogLevel string
 }
 
 // EthCfg stores global configs for ethereum bockchain

--- a/ipfssync/subpub/crypto.go
+++ b/ipfssync/subpub/crypto.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"io"
 
-	"go.vocdoni.io/dvote/log"
 	"golang.org/x/crypto/nacl/secretbox"
 )
 

--- a/ipfssync/subpub/discovery.go
+++ b/ipfssync/subpub/discovery.go
@@ -12,7 +12,6 @@ import (
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
 	multiaddr "github.com/multiformats/go-multiaddr"
-	"go.vocdoni.io/dvote/log"
 )
 
 // setupDiscovery creates a DHT discovery service and attaches it to the libp2p Host.

--- a/ipfssync/subpub/gossipsub.go
+++ b/ipfssync/subpub/gossipsub.go
@@ -6,7 +6,6 @@ import (
 	"git.sr.ht/~sircmpwn/go-bare"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"go.vocdoni.io/dvote/log"
 )
 
 // GossipBufSize is the number of incoming messages to buffer for each topic.

--- a/ipfssync/subpub/stream.go
+++ b/ipfssync/subpub/stream.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/libp2p/go-libp2p-core/network"
 	libpeer "github.com/libp2p/go-libp2p-core/peer"
-	"go.vocdoni.io/dvote/log"
 )
 
 // bufioWithMutex is a *bufio.Writer with methods Lock() and Unlock()

--- a/ipfssync/subpub/subpub.go
+++ b/ipfssync/subpub/subpub.go
@@ -19,9 +19,11 @@ import (
 	libpeer "github.com/libp2p/go-libp2p-core/peer"
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"go.uber.org/zap"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/log"
 )
+
+var log *zap.SugaredLogger = zap.NewNop().Sugar()
 
 // UnicastBufSize is the number of unicast incoming messages to buffer.
 const UnicastBufSize = 128
@@ -105,6 +107,11 @@ func NewSubPub(hexKey string, groupKey []byte, port int32, private bool) *SubPub
 	bare.MaxUnmarshalBytes(bareMaxUnmarshalBytes)
 
 	return ps
+}
+
+// SetLogger allows a logger with different options to be set
+func (ps *SubPub) SetLogger(logger *zap.SugaredLogger) {
+	log = logger
 }
 
 // Start connects the SubPub networking stack

--- a/service/storage.go
+++ b/service/storage.go
@@ -48,6 +48,11 @@ func IPFS(ipfsconfig *config.IPFSCfg, signer *ethereum.SignKeys,
 				log.Debugf("using custom ipfs sync bootnodes %s", ipfsconfig.SyncPeers)
 				storageSync.Transport.BootNodes = ipfsconfig.SyncPeers
 			}
+			if ipfsconfig.SyncLogLevel != "" {
+				storageSync.SetLogger(log.LoggerWithLevel(ipfsconfig.SyncLogLevel))
+			} else {
+				storageSync.SetLogger(log.Logger())
+			}
 			storageSync.Start()
 		}
 	}


### PR DESCRIPTION
This addresses issue #460

it's not the most flexible or extendable solution, but i believe it's the most elegant (in terms of lines changed)

please review, especially if the approach is too hacky or non-idiomatic :grin: 

in terms of behaviour, what happens now is:
* running `dvotenode --logLevel=debug --ipfsSyncLogLevel=info` achieves what @p4u wanted, getting debug messages for everything except ipfssync code
* note that due to how zap is implemented, the opposite is not possible, running `dvotenode --logLevel=info --ipfsSyncLogLevel=debug` will start with a warning and just print info messages for everything. but i believe this is not a problem.
* not specifying `--ipfsSyncLogLevel` behaves like before, ipfssync inherits global `--logLevel`

in any case, ipfssync messages are also now tagged with `[ipfssync]` (using zap mechanisms), which i believe makes it very easy to filter in or out with `| grep` or `| grep -v`, FWIW