### PR TITLE
WIP: log: allow more granular logging with --logLevel=component:level

### DIFF
--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -71,8 +71,9 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 		"use developer mode (less security)")
 	globalCfg.PprofPort = *flag.Int("pprof", 0,
 		"pprof port for runtime profiling data (zero is disabled)")
-	globalCfg.LogLevel = *flag.StringP("logLevel", "l", "info",
-		"log level (debug, info, warn, error, fatal)")
+	globalCfg.LogLevel = *flag.StringSliceP("logLevel", "l", []string{"info"},
+		"log level for each subsystem, in format [<subsystem|*>:]<debug|info|warn|error|fatal>\n"+
+			"subsystems: "+strings.Join(log.GetSubsystems(), ","))
 	globalCfg.LogOutput = *flag.String("logOutput", "stdout",
 		"log output (stdout, stderr or filepath)")
 	globalCfg.LogErrorFile = *flag.String("logErrorFile", "",
@@ -361,7 +362,7 @@ func main() {
 	if globalCfg == nil {
 		log.Fatal("cannot read configuration")
 	}
-	log.Init(globalCfg.LogLevel, globalCfg.LogOutput)
+	log.Init(strings.Join(globalCfg.LogLevel, ","), globalCfg.LogOutput)
 	if path := globalCfg.LogErrorFile; path != "" {
 		if err := log.SetFileErrorLog(path); err != nil {
 			log.Fatal(err)

--- a/cmd/ipfsSync/ipfsSync.go
+++ b/cmd/ipfsSync/ipfsSync.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -34,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 	userDir := home + "/.ipfs"
-	logLevel := flag.String("logLevel", "info", "log level")
+	logLevel := flag.StringSlice("logLevel", []string{"info"}, "log level")
 	dataDir := flag.String("dataDir", userDir, "directory for storing data")
 	key := flag.String("key", "vocdoni", "secret shared group key for the sync cluster")
 	nodeKey := flag.String("nodeKey", "", "custom private hexadecimal 256 bit key for p2p identity")
@@ -54,7 +55,7 @@ func main() {
 	flag.CommandLine.SetNormalizeFunc(deprecatedFlagsFunc)
 	flag.Parse()
 
-	log.Init(*logLevel, "stdout")
+	log.Init(strings.Join(*logLevel, ","), "stdout")
 	ipfsStore := data.IPFSNewConfig(*dataDir)
 	storage, err := data.Init(data.StorageIDFromString("IPFS"), ipfsStore)
 	if err != nil {

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -483,7 +483,6 @@ func mkTreeAnonVoteTest(host,
 	keysfile string,
 	useLastCensus bool,
 	forceGatewaysGotCensus bool) {
-	// log.Init("debug", "stdout")
 
 	var censusKeys []*ethereum.SignKeys
 	var proofs []*client.Proof

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ type DvoteCfg struct {
 	// Metrics config options
 	Metrics *MetricsCfg
 	// LogLevel logging level
-	LogLevel string
+	LogLevel []string
 	// LogOutput logging output
 	LogOutput string
 	// ErrorLogFile for logging warning, error and fatal messages

--- a/httprouter/httprouter.go
+++ b/httprouter/httprouter.go
@@ -24,6 +24,9 @@ import (
 	"golang.org/x/net/http2"
 )
 
+// register subsystem name to allow setting its logLevel
+var _ = log.Named("httprouter.req")
+
 const (
 	desiredSoMaxConn = 4096
 )
@@ -84,7 +87,7 @@ func (r *HTTProuter) Init(host string, port int) error {
 	// If we want rich logging (e.g. with fields), we could implement our
 	// own version of DefaultLogFormatter.
 	r.Mux.Use(middleware.RequestLogger(&middleware.DefaultLogFormatter{
-		Logger:  stdLogger{log.Logger()},
+		Logger:  stdLogger{log.Named("httprouter.req")},
 		NoColor: true,
 	}))
 	r.Mux.Use(middleware.Recoverer)

--- a/ipfs/ipfs.go
+++ b/ipfs/ipfs.go
@@ -14,8 +14,10 @@ import (
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 
-	"go.vocdoni.io/dvote/log"
+	logger "go.vocdoni.io/dvote/log"
 )
+
+var log = logger.Named("ipfs")
 
 var ConfigRoot string
 

--- a/ipfs/ipfsInit.go
+++ b/ipfs/ipfsInit.go
@@ -10,8 +10,6 @@ import (
 	config "github.com/ipfs/go-ipfs-config"
 	"github.com/ipfs/go-ipfs/plugin/loader"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
-
-	"go.vocdoni.io/dvote/log"
 )
 
 var pluginOnce sync.Once

--- a/ipfssync/ipfssync.go
+++ b/ipfssync/ipfssync.go
@@ -20,9 +20,11 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.vocdoni.io/dvote/data"
-	"go.vocdoni.io/dvote/log"
+	logger "go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/statedblegacy/gravitonstate"
 )
+
+var log = logger.Named("ipfssync")
 
 const (
 	MaxKeySize = 64

--- a/ipfssync/ipfssync.go
+++ b/ipfssync/ipfssync.go
@@ -353,8 +353,6 @@ func (is *IPFSsync) unicastMsg(address string, imsg *models.IpfsSync) error {
 
 // Start initializes and start an IPFSsync instance
 func (is *IPFSsync) Start() {
-	var err error
-
 	// Init pin storage
 	log.Infof("initializing new pin storage")
 	dbDir := path.Join(is.DataDir, "db")
@@ -362,10 +360,10 @@ func (is *IPFSsync) Start() {
 		log.Fatal(err)
 	}
 	is.state = &gravitonstate.GravitonState{}
-	if err = is.state.Init(dbDir, "disk"); err != nil {
+	if err := is.state.Init(dbDir, "disk"); err != nil {
 		log.Fatal(err)
 	}
-	if err = is.state.AddTree("ipfsSync"); err != nil {
+	if err := is.state.AddTree("ipfsSync"); err != nil {
 		log.Fatal(err)
 	}
 	is.hashTree = is.state.Tree("ipfsSync")

--- a/ipfssync/subpub/crypto.go
+++ b/ipfssync/subpub/crypto.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"io"
 
-	"go.vocdoni.io/dvote/log"
 	"golang.org/x/crypto/nacl/secretbox"
 )
 

--- a/ipfssync/subpub/discovery.go
+++ b/ipfssync/subpub/discovery.go
@@ -12,7 +12,6 @@ import (
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
 	multiaddr "github.com/multiformats/go-multiaddr"
-	"go.vocdoni.io/dvote/log"
 )
 
 // setupDiscovery creates a DHT discovery service and attaches it to the libp2p Host.

--- a/ipfssync/subpub/gossipsub.go
+++ b/ipfssync/subpub/gossipsub.go
@@ -6,7 +6,6 @@ import (
 	"git.sr.ht/~sircmpwn/go-bare"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"go.vocdoni.io/dvote/log"
 )
 
 // GossipBufSize is the number of incoming messages to buffer for each topic.

--- a/ipfssync/subpub/stream.go
+++ b/ipfssync/subpub/stream.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/libp2p/go-libp2p-core/network"
 	libpeer "github.com/libp2p/go-libp2p-core/peer"
-	"go.vocdoni.io/dvote/log"
 )
 
 // bufioWithMutex is a *bufio.Writer with methods Lock() and Unlock()

--- a/ipfssync/subpub/subpub.go
+++ b/ipfssync/subpub/subpub.go
@@ -20,8 +20,10 @@ import (
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/log"
+	logger "go.vocdoni.io/dvote/log"
 )
+
+var log = logger.Named("ipfssync")
 
 // UnicastBufSize is the number of unicast incoming messages to buffer.
 const UnicastBufSize = 128

--- a/ipfssync/subpub/subpub_test.go
+++ b/ipfssync/subpub/subpub_test.go
@@ -10,7 +10,6 @@ import (
 
 	libpeer "github.com/libp2p/go-libp2p-core/peer"
 	"go.vocdoni.io/dvote/ipfssync/subpub"
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
 )
 
@@ -51,8 +50,6 @@ func startNodes(ctx context.Context, num int, bootNodes []*subpub.SubPub) (nodes
 }
 
 func TestSubPub(t *testing.T) {
-	log.Init("warn", "stdout")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 

--- a/log/core.go
+++ b/log/core.go
@@ -1,0 +1,127 @@
+package log
+
+import (
+	"reflect"
+	"sync"
+
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var _ zapcore.Core = (*lockedMultiCore)(nil)
+
+type lockedMultiCore struct {
+	mu    sync.RWMutex // guards mutations to cores slice
+	cores []zapcore.Core
+}
+
+func (l *lockedMultiCore) With(fields []zapcore.Field) zapcore.Core {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	sub := &lockedMultiCore{
+		cores: make([]zapcore.Core, len(l.cores)),
+	}
+	for i := range l.cores {
+		sub.cores[i] = l.cores[i].With(fields)
+	}
+	return sub
+}
+
+func (l *lockedMultiCore) Enabled(lvl zapcore.Level) bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	for i := range l.cores {
+		if l.cores[i].Enabled(lvl) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *lockedMultiCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	for i := range l.cores {
+		ce = l.cores[i].Check(ent, ce)
+	}
+	return ce
+}
+
+func (l *lockedMultiCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	var err error
+	for i := range l.cores {
+		err = multierr.Append(err, l.cores[i].Write(ent, fields))
+	}
+	return err
+}
+
+func (l *lockedMultiCore) Sync() error {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	var err error
+	for i := range l.cores {
+		err = multierr.Append(err, l.cores[i].Sync())
+	}
+	return err
+}
+
+func (l *lockedMultiCore) AddCore(core zapcore.Core) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.cores = append(l.cores, core)
+}
+
+func (l *lockedMultiCore) DeleteCore(core zapcore.Core) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	w := 0
+	for i := 0; i < len(l.cores); i++ {
+		if reflect.DeepEqual(l.cores[i], core) {
+			continue
+		}
+		l.cores[w] = l.cores[i]
+		w++
+	}
+	l.cores = l.cores[:w]
+}
+
+func (l *lockedMultiCore) ReplaceCore(original, replacement zapcore.Core) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for i := 0; i < len(l.cores); i++ {
+		if reflect.DeepEqual(l.cores[i], original) {
+			l.cores[i] = replacement
+		}
+	}
+}
+
+func newCore(format LogFormat, ws zapcore.WriteSyncer, level zapcore.Level) zapcore.Core {
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	encCfg.EncodeName = bracketedFullNameEncoder
+
+	var encoder zapcore.Encoder
+	switch format {
+	case PlaintextOutput:
+		encCfg.EncodeLevel = zapcore.CapitalLevelEncoder
+		encoder = zapcore.NewConsoleEncoder(encCfg)
+	case JSONOutput:
+		encoder = zapcore.NewJSONEncoder(encCfg)
+	default:
+		encCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+		encoder = zapcore.NewConsoleEncoder(encCfg)
+	}
+
+	return zapcore.NewCore(encoder, ws, zap.NewAtomicLevelAt(level))
+}
+
+// bracketedFullNameEncoder serializes the logger name enclosed in brackets.
+func bracketedFullNameEncoder(name string, enc zapcore.PrimitiveArrayEncoder) {
+	enc.AppendString("[" + name + "]")
+}

--- a/log/protobuf.go
+++ b/log/protobuf.go
@@ -1,0 +1,16 @@
+package log
+
+import (
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// FormatProto turns a ProtoMessage into a human-readable string
+func FormatProto(arg protoreflect.ProtoMessage) string {
+	pj := protojson.MarshalOptions{
+		AllowPartial:    true,
+		Multiline:       false,
+		EmitUnpopulated: true,
+	}
+	return pj.Format(arg)
+}

--- a/log/setup.go
+++ b/log/setup.go
@@ -1,0 +1,235 @@
+package log
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"sync"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var config Config
+
+type LogFormat int
+
+const (
+	ColorizedOutput LogFormat = iota
+	PlaintextOutput
+	JSONOutput
+)
+
+type Config struct {
+	// Format overrides the format of the log output. Defaults to ColorizedOutput
+	Format LogFormat
+
+	// Level is the default minimum enabled logging level.
+	Level zapcore.Level
+
+	// SubsystemLevels are the default levels per-subsystem. When unspecified, defaults to Level.
+	SubsystemLevels map[string]zapcore.Level
+
+	// Output can be either "stdout", "stderr" or "/path/to/file".
+	Output string
+
+	// Labels is a set of key-values to apply to all loggers
+	Labels map[string]string
+}
+
+// ErrNoSuchLogger is returned when the util pkg is asked for a non existant logger
+var ErrNoSuchLogger = errors.New("error: No such logger")
+
+var loggerMutex sync.RWMutex // guards access to global logger state
+
+// loggers is the set of loggers in the system
+var loggers = make(map[string]*zap.SugaredLogger)
+var levels = make(map[string]zap.AtomicLevel)
+
+// primaryCore is the primary logging core
+var primaryCore zapcore.Core
+
+// loggerCore is the base for all loggers created by this package
+var loggerCore = &lockedMultiCore{}
+
+// SetupLogging will initialize the logger backend and set the flags.
+// TODO calling this in `init` pushes all configuration to env variables
+// - move it out of `init`? then we need to change all the code (js-ipfs, go-ipfs) to call this explicitly
+// - have it look for a config file? need to define what that is
+func SetupLogging(cfg Config) {
+	loggerMutex.Lock()
+	defer loggerMutex.Unlock()
+
+	config = cfg
+
+	ws, _, err := zap.Open(cfg.Output)
+	if err != nil {
+		panic(fmt.Sprintf("unable to open logging output: %v", err))
+	}
+
+	newPrimaryCore := newCore(cfg.Format, ws, zapcore.DebugLevel) // the main core needs to log everything.
+
+	for k, v := range cfg.Labels {
+		newPrimaryCore = newPrimaryCore.With([]zap.Field{zap.String(k, v)})
+	}
+
+	setPrimaryCore(newPrimaryCore)
+	setAllLoggers(cfg.Level)
+
+	for name, level := range cfg.SubsystemLevels {
+		if leveler, ok := levels[name]; ok {
+			leveler.SetLevel(zapcore.Level(level))
+		} else {
+			levels[name] = zap.NewAtomicLevelAt(zapcore.Level(level))
+		}
+	}
+}
+
+// SetPrimaryCore changes the primary logging core. If the SetupLogging was
+// called then the previously configured core will be replaced.
+func SetPrimaryCore(core zapcore.Core) {
+	loggerMutex.Lock()
+	defer loggerMutex.Unlock()
+
+	setPrimaryCore(core)
+}
+
+func setPrimaryCore(core zapcore.Core) {
+	if primaryCore != nil {
+		loggerCore.ReplaceCore(primaryCore, core)
+	} else {
+		loggerCore.AddCore(core)
+	}
+	primaryCore = core
+}
+
+// SetAllLoggers changes the logging level of all loggers to lvl
+func SetAllLoggers(lvl zapcore.Level) {
+	loggerMutex.RLock()
+	defer loggerMutex.RUnlock()
+
+	setAllLoggers(lvl)
+}
+
+func setAllLoggers(lvl zapcore.Level) {
+	for _, l := range levels {
+		l.SetLevel(lvl)
+	}
+}
+
+// levelFromString accepts a lowercase "debug", "info", "warn", "error", "fatal"
+// and returns the corresponding zapcore.Level
+func levelFromString(logLevel string) (zapcore.Level, error) {
+	switch logLevel {
+	case "debug":
+		return zapcore.DebugLevel, nil
+	case "info":
+		return zapcore.InfoLevel, nil
+	case "warn":
+		return zapcore.WarnLevel, nil
+	case "error":
+		return zapcore.ErrorLevel, nil
+	case "fatal":
+		return zapcore.FatalLevel, nil
+	default:
+		return zapcore.InfoLevel, fmt.Errorf("couldn't parse log level '%s'", logLevel)
+	}
+}
+
+// SetLogLevel changes the log level of a specific subsystem
+// name=="*" changes all subsystems
+func SetLogLevel(name, level string) error {
+	lvl, err := levelFromString(level)
+	if err != nil {
+		return err
+	}
+
+	// wildcard, change all
+	if name == "*" {
+		SetAllLoggers(zapcore.Level(lvl))
+		return nil
+	}
+
+	loggerMutex.RLock()
+	defer loggerMutex.RUnlock()
+
+	// Check if we have a logger by that name
+	if _, ok := levels[name]; !ok {
+		return ErrNoSuchLogger
+	}
+
+	levels[name].SetLevel(zapcore.Level(lvl))
+	return nil
+}
+
+// SetLogLevelRegex sets all loggers to level `l` that match expression `e`.
+// An error is returned if `e` fails to compile.
+func SetLogLevelRegex(e, l string) error {
+	lvl, err := levelFromString(l)
+	if err != nil {
+		return err
+	}
+
+	rem, err := regexp.Compile(e)
+	if err != nil {
+		return err
+	}
+
+	loggerMutex.Lock()
+	defer loggerMutex.Unlock()
+	for name := range loggers {
+		if rem.MatchString(name) {
+			levels[name].SetLevel(zapcore.Level(lvl))
+		}
+	}
+	return nil
+}
+
+// GetSubsystems returns a sorted slice containing the
+// names of the current loggers
+func GetSubsystems() []string {
+	loggerMutex.RLock()
+	defer loggerMutex.RUnlock()
+	subs := make([]string, 0, len(loggers))
+
+	for k := range loggers {
+		subs = append(subs, k)
+	}
+	sort.Strings(subs)
+	return subs
+}
+
+// Named returns a named logger.
+func Named(name string) *zap.SugaredLogger {
+	loggerMutex.Lock()
+	defer loggerMutex.Unlock()
+	log, ok := loggers[name]
+	if !ok {
+		level, ok := levels[name]
+		if !ok {
+			level = zap.NewAtomicLevelAt(config.Level)
+			levels[name] = level
+		}
+		log = zap.New(loggerCore).
+			WithOptions(
+				zap.IncreaseLevel(level),
+				zap.AddCaller(),
+			).
+			Named(name).
+			Sugar()
+
+		loggers[name] = log
+	}
+
+	return log
+}
+
+// GetLogLevel returns the configured log level of a specific subsystem
+func GetLogLevel(name string) (level string, found bool) {
+	loggerMutex.RLock()
+	defer loggerMutex.RUnlock()
+
+	l, found := config.SubsystemLevels[name]
+	return l.String(), found
+}

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -30,7 +30,7 @@ import (
 	"go.vocdoni.io/dvote/crypto/zk"
 	"go.vocdoni.io/dvote/db/lru"
 	"go.vocdoni.io/dvote/db/metadb"
-	"go.vocdoni.io/dvote/log"
+	logger "go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	models "go.vocdoni.io/proto/build/go/models"
 )
@@ -565,7 +565,7 @@ func (app *BaseApplication) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.
 	defer app.State.TxCounterAdd()
 	tx := new(VochainTx)
 	if err = tx.Unmarshal(req.Tx, app.ChainID()); err == nil {
-		log.Debugf("deliver tx: %s", log.FormatProto(tx.Tx))
+		log.Debugf("deliver tx: %s", logger.FormatProto(tx.Tx))
 		if data, err = app.AddTx(tx, true); err != nil {
 			log.Debugf("rejected tx: %v", err)
 			return abcitypes.ResponseDeliverTx{Code: 1, Data: []byte(err.Error())}

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -12,7 +12,6 @@ import (
 
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"

--- a/vochain/cache.go
+++ b/vochain/cache.go
@@ -3,7 +3,6 @@ package vochain
 import (
 	"time"
 
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )

--- a/vochain/census.go
+++ b/vochain/census.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/arbo"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/statedb"
 	models "go.vocdoni.io/proto/build/go/models"
 )

--- a/vochain/genesis.go
+++ b/vochain/genesis.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"go.vocdoni.io/dvote/crypto/zk/artifacts"
-	"go.vocdoni.io/dvote/log"
 )
 
 type VochainGenesis struct {

--- a/vochain/process.go
+++ b/vochain/process.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/vocdoni/arbo"
 	"go.vocdoni.io/dvote/crypto/zk/artifacts"
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/statedb"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/proto/build/go/models"

--- a/vochain/proof.go
+++ b/vochain/proof.go
@@ -7,7 +7,6 @@ import (
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/saltedkey"
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/tree"
 	"google.golang.org/protobuf/proto"
 

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -8,7 +8,7 @@ import (
 	"go.vocdoni.io/dvote/censustree"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/db/metadb"
-	"go.vocdoni.io/dvote/log"
+	logger "go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	models "go.vocdoni.io/proto/build/go/models"
@@ -61,7 +61,7 @@ func TestMerkleTreeProof(t *testing.T) {
 		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
 		BlockCount:   1024,
 	}
-	t.Logf("adding process %s", log.FormatProto(process))
+	t.Logf("adding process %s", logger.FormatProto(process))
 	if err := app.State.AddProcess(process); err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -23,8 +23,10 @@ import (
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
-	"go.vocdoni.io/dvote/log"
+	logger "go.vocdoni.io/dvote/log"
 )
+
+var log = logger.Named("vochain")
 
 const downloadZkVKsTimeout = 1 * time.Minute
 

--- a/vochain/state.go
+++ b/vochain/state.go
@@ -21,7 +21,6 @@ import (
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/metadb"
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/statedb"
 
 	"go.vocdoni.io/dvote/types"

--- a/vochain/state_test.go
+++ b/vochain/state_test.go
@@ -9,7 +9,6 @@ import (
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/db"
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	models "go.vocdoni.io/proto/build/go/models"
 )
@@ -34,7 +33,6 @@ func TestStateReopen(t *testing.T) {
 
 func TestStateBasic(t *testing.T) {
 	rng := testutil.NewRandom(0)
-	log.Init("info", "stdout")
 	s, err := NewState(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +99,6 @@ func TestStateBasic(t *testing.T) {
 }
 
 func TestBalanceTransfer(t *testing.T) {
-	log.Init("info", "stdout")
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -174,7 +171,6 @@ func (l *Listener) Commit(height uint32) (err error) {
 func (l *Listener) Rollback() {}
 
 func TestOnProcessStart(t *testing.T) {
-	log.Init("info", "stdout")
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -230,7 +226,6 @@ func TestOnProcessStart(t *testing.T) {
 // database transaction in the StateDB in a real scenario.
 func TestBlockMemoryUsage(t *testing.T) {
 	rng := testutil.NewRandom(0)
-	log.Init("info", "stdout")
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -289,7 +284,6 @@ func TestBlockMemoryUsage(t *testing.T) {
 }
 
 func TestStateTreasurer(t *testing.T) {
-	log.Init("info", "stdout")
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -323,7 +317,6 @@ func TestStateTreasurer(t *testing.T) {
 }
 
 func TestStateIsTreasurer(t *testing.T) {
-	log.Init("info", "stdout")
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -345,7 +338,6 @@ func TestStateIsTreasurer(t *testing.T) {
 }
 
 func TestIncrementTreasurerNonce(t *testing.T) {
-	log.Init("info", "stdout")
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -368,7 +360,6 @@ func TestIncrementTreasurerNonce(t *testing.T) {
 }
 
 func TestStateSetGetTxCostByTxType(t *testing.T) {
-	log.Init("info", "stdout")
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -13,7 +13,6 @@ import (
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/nacl"
 	"go.vocdoni.io/dvote/crypto/zk"
-	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	models "go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestVocone(t *testing.T) {
-	//log.Init("info", "stdout")
 	dir := t.TempDir()
 
 	oracle := ethereum.SignKeys{}


### PR DESCRIPTION
note that this commit doesn't change any of the current logging behaviour,
keeping backwards compatibility for code using log.Init()

to use granular logging, call log.InitWithLevels()
    
* fix Logger() since it was returning an unwrapped logger with CallerSkip(1)
* if using log.Named("somename"), prefix [somename] in logs
    
this addresses issue #460 "Reduce ipfsSync log messages", in an extensible way

supersedes #469, implementing @mvdan suggestion https://github.com/vocdoni/vocdoni-node/pull/469#issuecomment-1033037869
