### PR TITLE
Add getCensusWeight handler

### DIFF
--- a/census/handler.go
+++ b/census/handler.go
@@ -323,6 +323,19 @@ func (m *Manager) Handler(ctx context.Context, r *api.APIrequest,
 		resp.Size = &sizeInt64
 		return resp, nil
 
+	case "getCensusWeight":
+		resp.Weight = &types.BigInt{}
+		getWeightCallback := func(key, value []byte) bool {
+			weight := tr.BytesToBigInt(value)
+			resp.Weight = resp.Weight.Add((*types.BigInt)(weight), resp.Weight)
+			return true
+		}
+		err := tr.IterateLeaves(getWeightCallback)
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+
 	case "dumpPlain":
 		return nil, fmt.Errorf("dumpPlain is deprecated, dump should be used instead")
 

--- a/census/handler.go
+++ b/census/handler.go
@@ -324,16 +324,11 @@ func (m *Manager) Handler(ctx context.Context, r *api.APIrequest,
 		return resp, nil
 
 	case "getCensusWeight":
-		resp.Weight = &types.BigInt{}
-		getWeightCallback := func(key, value []byte) bool {
-			weight := tr.BytesToBigInt(value)
-			resp.Weight = resp.Weight.Add((*types.BigInt)(weight), resp.Weight)
-			return true
-		}
-		err := tr.IterateLeaves(getWeightCallback)
+		weight, err := tr.GetCensusWeight()
 		if err != nil {
 			return nil, err
 		}
+		resp.Weight = (*types.BigInt)(weight)
 		return resp, nil
 
 	case "dumpPlain":

--- a/censustree/censustree_test.go
+++ b/censustree/censustree_test.go
@@ -1,6 +1,8 @@
 package censustree
 
 import (
+	"math/big"
+	"strconv"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -14,7 +16,6 @@ import (
 
 func TestPublish(t *testing.T) {
 	db := metadb.NewTest(t)
-
 	censusTree, err := New(Options{Name: "test", ParentDB: db, MaxLevels: 256,
 		CensusType: models.Census_ARBO_BLAKE2B})
 	qt.Assert(t, err, qt.IsNil)
@@ -26,5 +27,106 @@ func TestPublish(t *testing.T) {
 
 	censusTree.Unpublish()
 	qt.Assert(t, censusTree.IsPublic(), qt.IsFalse)
+}
 
+func TestGetCensusWeight(t *testing.T) {
+	db := metadb.NewTest(t)
+	tree, err := New(Options{Name: "test", ParentDB: db, MaxLevels: 256,
+		CensusType: models.Census_ARBO_BLAKE2B})
+	qt.Assert(t, err, qt.IsNil)
+
+	w, err := tree.GetCensusWeight()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, w.String(), qt.Equals, "0")
+
+	weight := tree.BigIntToBytes(big.NewInt(17))
+	err = tree.Add([]byte("key"), weight)
+	qt.Assert(t, err, qt.IsNil)
+
+	w, err = tree.GetCensusWeight()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, w.String(), qt.Equals, "17")
+
+	// test CensusWeight after doing a loop of censustree.Add
+	for i := 0; i < 100; i++ {
+		weight := tree.BigIntToBytes(big.NewInt(int64(i)))
+		err = tree.Add([]byte{byte(i)}, weight)
+		qt.Assert(t, err, qt.IsNil)
+	}
+
+	w, err = tree.GetCensusWeight()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, w.String(), qt.Equals, "4967") // = 17 + (0+1+2+...+99)
+
+	// test CensusWeight after using censustree.AddBatch
+	// prepare inputs
+	var keys, values [][]byte
+	for i := 0; i < 100; i++ {
+		weight := tree.BigIntToBytes(big.NewInt(int64(i)))
+		// use 100+i, as the first 99 keys are already used
+		keys = append(keys, []byte{byte(100 + i)})
+		values = append(values, weight)
+	}
+
+	invalids, err := tree.AddBatch(keys, values)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, len(invalids), qt.Equals, 0)
+
+	w, err = tree.GetCensusWeight()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, w.String(), qt.Equals, "9917") // = 4967 + (0+1+2+...+99)
+
+	// test CensusWeight after using censustree.AddBatch, but this time
+	// with some invalid keys, which weight should not be counted
+	keys = [][]byte{}
+	values = [][]byte{}
+	for i := 0; i < 100; i++ {
+		weight := tree.BigIntToBytes(big.NewInt(int64(i)))
+		// use 200+i, in order to get 56 correct keys, and 44
+		// incorrect, as on 256 the byte used in the key will overflow
+		// and go back to 0, and the keys from 0 to 198 are already
+		// used by previous additions to the tree, so when trying to
+		// add them will get an invalid code.
+		keys = append(keys, []byte{byte(200 + i)})
+		values = append(values, weight)
+	}
+
+	invalids, err = tree.AddBatch(keys, values)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, len(invalids), qt.Equals, 44)
+
+	w, err = tree.GetCensusWeight()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, w.String(), qt.Equals, "11457") // = 9917 + (0+1+2+...+56) = 9917 + 1540
+
+	// try to add keys with empty values
+	keys = [][]byte{}
+	for i := 0; i < 100; i++ {
+		keys = append(keys, []byte("keysWithoutWeight"+strconv.Itoa(i)))
+	}
+
+	invalids, err = tree.AddBatch(keys, nil)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, len(invalids), qt.Equals, 0)
+
+	w, err = tree.GetCensusWeight()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, w.String(), qt.Equals, "11457") // = 9917 + (0+1+2+...+56) = 9917 + 1540
+
+	// dump the leaves & import them into a new empty tree, and check that
+	// the censusWeight is correctly recomputed
+	db2 := metadb.NewTest(t)
+	tree2, err := New(Options{Name: "test2", ParentDB: db2, MaxLevels: 256,
+		CensusType: models.Census_ARBO_BLAKE2B})
+	qt.Assert(t, err, qt.IsNil)
+
+	dump, err := tree.Dump()
+	qt.Assert(t, err, qt.IsNil)
+
+	err = tree2.ImportDump(dump)
+	qt.Assert(t, err, qt.IsNil)
+
+	w, err = tree2.GetCensusWeight()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, w.String(), qt.Equals, "11457") // same than in the original tree
 }

--- a/rpcapi/handlers.go
+++ b/rpcapi/handlers.go
@@ -47,6 +47,7 @@ func (r *RPCAPI) EnableCensusAPI(cm *census.Manager) error {
 	r.RegisterPublic("getRoot", false, r.censusLocal)
 	r.RegisterPrivate("dump", r.censusLocal)
 	r.RegisterPublic("getSize", false, r.censusLocal)
+	r.RegisterPublic("getCensusWeight", false, r.censusLocal)
 	r.RegisterPublic("genProof", false, r.censusLocal)
 	r.RegisterPublic("checkProof", false, r.censusLocal)
 	if r.allowPrivate {


### PR DESCRIPTION
Adds getCensusWeight handler, tests as well

This handler uses the arbo tree `IterateLeaves()` method. @arnaucube performance-wise, is this method realistic to use with large census sizes? 

Closes #463 

