### PR TITLE
Enable maxValue to be set to 0

### DIFF
--- a/vochain/process.go
+++ b/vochain/process.go
@@ -389,8 +389,8 @@ func (app *BaseApplication) NewProcessTxCheck(vtx *models.Tx, txBytes,
 	if tx.Process.VoteOptions == nil || tx.Process.EnvelopeType == nil || tx.Process.Mode == nil {
 		return nil, fmt.Errorf("missing required fields (voteOptions, envelopeType or processMode)")
 	}
-	if tx.Process.VoteOptions.MaxCount == 0 || tx.Process.VoteOptions.MaxValue == 0 {
-		return nil, fmt.Errorf("missing vote options parameters (maxCount or maxValue)")
+	if tx.Process.VoteOptions.MaxCount == 0 {
+		return nil, fmt.Errorf("missing vote maxCount parameter")
 	}
 	// check signature available
 	if signature == nil || tx == nil || txBytes == nil {


### PR DESCRIPTION
Right now the vochain checks to ensure that the maxValue for a process is not set to 0. This is wrong, because `maxValue == 0` is valid for a question with only one option, whose index is `0`. 