### PR TITLE
voconed --treasurer, --txCosts flag

### DIFF
--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -36,6 +36,7 @@ import (
 const (
 	DefaultTxsPerBlock     = 500
 	DefaultBlockTimeTarget = time.Second * 5
+	DefaultTxCosts         = 10
 	mempoolSize            = 100 << 10
 )
 


### PR DESCRIPTION
Having these flags should let one easily substitute vocone for dvotenode in integration test suites.