### PR TITLE
Add chainID param to SignVocdoniTx, remove from signer

### DIFF
--- a/benchmark/vochain_benchmark_test.go
+++ b/benchmark/vochain_benchmark_test.go
@@ -156,7 +156,7 @@ func BenchmarkVochain(b *testing.B) {
 	if err != nil {
 		b.Fatal("cannot marshal process")
 	}
-	stx.Signature, err = dvoteServer.Signer.SignVocdoniTx(stx.Tx)
+	stx.Signature, err = dvoteServer.Signer.SignVocdoniTx(stx.Tx, dvoteServer.VochainAPP.ChainID())
 	if err != nil {
 		b.Fatalf("cannot sign oracle tx: %s", err)
 	}
@@ -262,7 +262,7 @@ func voteBench(b *testing.B, cl *client.Client, s *ethereum.SignKeys,
 	if err != nil {
 		b.Fatal(err)
 	}
-	stx.Signature, err = s.SignVocdoniTx(stx.Tx)
+	stx.Signature, err = s.SignVocdoniTx(stx.Tx, "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -590,7 +590,11 @@ func (c *Client) TestPreRegisterKeys(
 			return 0, err
 		}
 
-		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+		chainID, err := c.GetChainID()
+		if err != nil {
+			return 0, err
+		}
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx, chainID); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -637,7 +641,11 @@ func (c *Client) TestPreRegisterKeys(
 			if err != nil {
 				return 0, err
 			}
-			if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+			chainID, err := c.GetChainID()
+			if err != nil {
+				return 0, err
+			}
+			if stx.Signature, err = s.SignVocdoniTx(stx.Tx, chainID); err != nil {
 				return 0, err
 			}
 			if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -787,8 +795,11 @@ func (c *Client) TestSendVotes(
 		if err != nil {
 			return 0, err
 		}
-
-		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+		chainID, err := c.GetChainID()
+		if err != nil {
+			return 0, err
+		}
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx, chainID); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -958,8 +969,11 @@ func (c *Client) TestSendAnonVotes(
 		if err != nil {
 			return 0, err
 		}
-
-		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+		chainID, err := c.GetChainID()
+		if err != nil {
+			return 0, err
+		}
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx, chainID); err != nil {
 			return 0, err
 		}
 		if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1101,7 +1115,11 @@ func (c *Client) CreateProcess(oracle *ethereum.SignKeys,
 	if err != nil {
 		return 0, err
 	}
-	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
+	chainID, err := c.GetChainID()
+	if err != nil {
+		return 0, err
+	}
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx, chainID); err != nil {
 		return 0, err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1144,7 +1162,11 @@ func (c *Client) EndProcess(oracle *ethereum.SignKeys, pid []byte) error {
 	if err != nil {
 		return err
 	}
-	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
+	chainID, err := c.GetChainID()
+	if err != nil {
+		return err
+	}
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx, chainID); err != nil {
 		return err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {
@@ -1416,7 +1438,11 @@ func (c *Client) SubmitRawTx(signer *ethereum.SignKeys, stx *models.SignedTx) (*
 	var err error
 	var req api.APIrequest
 	req.Method = "submitRawTx"
-	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
+	chainID, err := c.GetChainID()
+	if err != nil {
+		return nil, err
+	}
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx, chainID); err != nil {
 		return nil, err
 	}
 	if req.Payload, err = proto.Marshal(stx); err != nil {

--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -540,9 +540,6 @@ func main() {
 			log.Infof("[vochain info] replaying height %d at %d blocks/s",
 				h, (h-hPrev)/5)
 		}
-		if signer != nil {
-			signer.VocdoniChainID = vochainApp.ChainID()
-		}
 		log.Infof("vochain chainID %s", vochainApp.ChainID())
 	}
 

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -296,12 +296,6 @@ func mkTreeVoteTest(host,
 	}
 	defer mainClient.Close()
 
-	// Get the chain ID for signing the transactions
-	oracleKey.VocdoniChainID, err = mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
@@ -367,12 +361,6 @@ func mkTreeVoteTest(host,
 		log.Infof("all gateways retrieved the census! let's start voting")
 	}
 
-	// Get chainID
-	chID, err := mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Send votes
 	i := 0
 	p := len(censusKeys) / len(clients)
@@ -397,9 +385,6 @@ func mkTreeVoteTest(host,
 			copy(gwSigners, censusKeys[i:i+p])
 			gwProofs = make([]*client.Proof, p)
 			copy(gwProofs, proofs[i:i+p])
-		}
-		for _, gws := range gwSigners {
-			gws.VocdoniChainID = chID
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -532,12 +517,6 @@ func mkTreeAnonVoteTest(host,
 	}
 	defer mainClient.Close()
 
-	// Get the chain ID for signing the transactions
-	oracleKey.VocdoniChainID, err = mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
@@ -603,12 +582,6 @@ func mkTreeAnonVoteTest(host,
 		log.Infof("all gateways retrieved the census! let's start voting")
 	}
 
-	// Get chainID
-	chID, err := mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Pre-register keys zkCensusKey
 	i := 0
 	p := len(censusKeys) / len(clients)
@@ -633,9 +606,6 @@ func mkTreeAnonVoteTest(host,
 			copy(gwSigners, censusKeys[i:i+p])
 			gwProofs = make([]*client.Proof, p)
 			copy(gwProofs, proofs[i:i+p])
-		}
-		for _, gws := range gwSigners {
-			gws.VocdoniChainID = chID
 		}
 		log.Infof("%s will receive %d register keys", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -717,9 +687,6 @@ func mkTreeAnonVoteTest(host,
 		} else {
 			gwSigners = make([]*ethereum.SignKeys, p)
 			copy(gwSigners, censusKeys[i:i+p])
-		}
-		for _, gws := range gwSigners {
-			gws.VocdoniChainID = chID
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -835,12 +802,6 @@ func cspVoteTest(
 	}
 	defer mainClient.Close()
 
-	// Get the chain ID for signing the transactions
-	oracleKey.VocdoniChainID, err = mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Create process
 	pid := client.Random(32)
 	log.Infof("creating process with entityID: %s", entityKey.AddressString())
@@ -886,12 +847,6 @@ func cspVoteTest(
 		clients = append(clients, cl)
 	}
 
-	// Get chainID
-	chID, err := mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Send votes
 	i := 0
 	p := len(voters) / len(clients)
@@ -911,9 +866,6 @@ func cspVoteTest(
 		} else {
 			gwSigners = make([]*ethereum.SignKeys, p)
 			copy(gwSigners, voters[i:i+p])
-		}
-		for _, gws := range gwSigners {
-			gws.VocdoniChainID = chID
 		}
 		log.Infof("%s will receive %d votes", cl.Addr, len(gwSigners))
 		gw, cl := gw, cl
@@ -1000,14 +952,6 @@ func testTokenTransactions(
 		log.Fatal(err)
 	}
 	defer mainClient.Close()
-
-	chainId, err := mainClient.GetChainID()
-	if err != nil {
-		log.Fatal(err)
-	}
-	treasurerSigner.VocdoniChainID = chainId
-	mainSigner.VocdoniChainID = chainId
-	otherSigner.VocdoniChainID = chainId
 
 	// check set transaction cost
 	if err := testSetTxCost(mainClient, treasurerSigner); err != nil {

--- a/crypto/ethereum/ethereum.go
+++ b/crypto/ethereum/ethereum.go
@@ -29,11 +29,10 @@ const SigningPrefix = "\u0019Ethereum Signed Message:\n"
 // SignKeys represents an ECDSA pair of keys for signing.
 // Authorized addresses is a list of Ethereum like addresses which are checked on Verify
 type SignKeys struct {
-	Public         ecdsa.PublicKey
-	Private        ecdsa.PrivateKey
-	Authorized     map[ethcommon.Address]bool
-	Lock           sync.RWMutex
-	VocdoniChainID string
+	Public     ecdsa.PublicKey
+	Private    ecdsa.PrivateKey
+	Authorized map[ethcommon.Address]bool
+	Lock       sync.RWMutex
 }
 
 // NewSignKeys creates an ECDSA pair of keys for signing
@@ -133,11 +132,11 @@ func (k *SignKeys) SignEthereum(message []byte) ([]byte, error) {
 }
 
 // SignVocdoniTx signs a vocdoni transaction. TxData is the full transaction payload (no HexString nor a Hash)
-func (k *SignKeys) SignVocdoniTx(txData []byte) ([]byte, error) {
+func (k *SignKeys) SignVocdoniTx(txData []byte, chainID string) ([]byte, error) {
 	if k.Private.D == nil {
 		return nil, errors.New("no private key available")
 	}
-	signature, err := ethcrypto.Sign(Hash(BuildVocdoniTransaction(txData, k.VocdoniChainID)), &k.Private)
+	signature, err := ethcrypto.Sign(Hash(BuildVocdoniTransaction(txData, chainID)), &k.Private)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/ethereum/vocdoni_test.go
+++ b/crypto/ethereum/vocdoni_test.go
@@ -33,8 +33,7 @@ func TestVocdoniSignature(t *testing.T) {
 	qt.Assert(t, fmt.Sprintf("%x", extractedPubKey), qt.DeepEquals, pub)
 
 	t.Logf("Transaction to sign: %s", message)
-	s.VocdoniChainID = "chain-123"
-	signature, err = s.SignVocdoniTx(message)
+	signature, err = s.SignVocdoniTx(message, "chain-123")
 	qt.Assert(t, err, qt.IsNil)
 	t.Logf("Signature for transaction is %x", signature)
 

--- a/ethereum/ethevents/handlers.go
+++ b/ethereum/ethevents/handlers.go
@@ -141,7 +141,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal newProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -181,7 +181,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal setProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -235,7 +235,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal setProcess tx: %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -277,7 +277,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal admin tx (addOracle): %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}
@@ -324,7 +324,7 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 		if err != nil {
 			return fmt.Errorf("cannot marshal admin tx (removeOracle): %w", err)
 		}
-		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx)
+		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
 		if err != nil {
 			return fmt.Errorf("cannot sign oracle tx: %w", err)
 		}

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -92,7 +92,7 @@ func (o *Oracle) NewProcess(process *models.Process) error {
 	if err != nil {
 		return fmt.Errorf("cannot marshal newProcess tx: %w", err)
 	}
-	stx.Signature, err = o.signer.SignVocdoniTx(stx.Tx)
+	stx.Signature, err = o.signer.SignVocdoniTx(stx.Tx, o.VochainApp.ChainID())
 	if err != nil {
 		return fmt.Errorf("cannot sign oracle tx: %w", err)
 	}
@@ -175,7 +175,7 @@ func (o *Oracle) OnComputeResults(results *indexertypes.Results, proc *indexerty
 		log.Errorf("cannot marshal setProcessResults tx: %v", err)
 		return
 	}
-	if stx.Signature, err = o.signer.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = o.signer.SignVocdoniTx(stx.Tx, o.VochainApp.ChainID()); err != nil {
 		log.Errorf("cannot sign oracle tx: %v", err)
 		return
 	}

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -585,7 +585,7 @@ func sendTx(app *BaseApplication, signer *ethereum.SignKeys, stx *models.SignedT
 	var detxresp abcitypes.ResponseDeliverTx
 	var err error
 
-	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		return err
 	}
 	stxBytes, err := proto.Marshal(stx)

--- a/vochain/admintx_test.go
+++ b/vochain/admintx_test.go
@@ -61,7 +61,7 @@ func testAddOracle(t *testing.T,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		t.Fatal(err)
 	}
 
@@ -136,7 +136,7 @@ func testRemoveOracle(t *testing.T, oracle *ethereum.SignKeys,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -96,7 +96,7 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 		if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: tx}}); err != nil {
 			b.Fatal(err)
 		}
-		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 			b.Fatal(err)
 		}
 		voters = append(voters, &stx)

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -484,7 +484,7 @@ func (k *KeyKeeper) signAndSendTx(tx *models.AdminTx) error {
 	if stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Admin{Admin: tx}}); err != nil {
 		return err
 	}
-	if stx.Signature, err = k.signer.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = k.signer.SignVocdoniTx(stx.Tx, k.vochain.ChainID()); err != nil {
 		return err
 	}
 	vtxBytes, err := proto.Marshal(stx)

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -187,7 +187,7 @@ func testSetProcessStatus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		t.Fatal(err)
 	}
 
@@ -335,7 +335,7 @@ func testSetProcessResults(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		t.Fatal(err)
 	}
 	if cktx.Tx, err = proto.Marshal(&stx); err != nil {
@@ -465,7 +465,7 @@ func testSetProcessCensus(t *testing.T, pid []byte, oracle *ethereum.SignKeys,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = oracle.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof_erc20_test.go
+++ b/vochain/proof_erc20_test.go
@@ -103,7 +103,7 @@ func testEthSendVotes(t *testing.T, s testStorageProof,
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof_minime_test.go
+++ b/vochain/proof_minime_test.go
@@ -123,7 +123,7 @@ func testMinimeSendVotes(t *testing.T, s ethstorageproof.StorageProof, addr comm
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -100,7 +100,7 @@ func TestMerkleTreeProof(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if stx.Signature, err = s.SignVocdoniTx(stx.Tx); err != nil {
+		if stx.Signature, err = s.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 			t.Fatal(err)
 		}
 
@@ -147,7 +147,7 @@ func TestMerkleTreeProof(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if stx.Signature, err = lastKey.SignVocdoniTx(stx.Tx); err != nil {
+		if stx.Signature, err = lastKey.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 			t.Fatal(err)
 		}
 
@@ -379,7 +379,7 @@ func testCASendVotes(t *testing.T, pid []byte, vp []byte, signer *ethereum.SignK
 		t.Fatal(err)
 	}
 
-	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx); err != nil {
+	if stx.Signature, err = signer.SignVocdoniTx(stx.Tx, app.chainId); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
The `SignVocdoniTx` uses the `signer.ChainID`, but there's no guarantee this variable will be set. It's easy to miss and hard to debug when missing, in my experience. This PR adds chainID as a parameter to SignVocdoniTx, forcing integrators of this code to keep track of the ChainID if they want to use this method. Additionally, if they want to use a signer for other methods (like `SignEthereum`), they don't need to worry about ChainID at all. 