### PR TITLE
vocli 1.0

### DIFF
--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1742,40 +1741,21 @@ func testVocli(url, treasurerPrivKey string) {
 	}()
 	func() {
 		log.Info("vocli txcost get * , set AddDelegate,CollectFaucet... 1-2-3-4-5-6...")
-
-		// get Treasurer's nonce so we can send many txs at once
-		_, stdout, _, err := executeCommand(vocli.RootCmd, append([]string{"account", "treasurer", aliceKeyPath}, stdArgs...), "", true)
-		if err != nil {
-			log.Fatal(err)
-		}
-		// parse stdout to find the line with "nonce 1"
-		r := regexp.MustCompile("nonce [0-9]*")
-		nonceLine := r.FindString(stdout)
-		if nonceLine == "" {
-			log.Fatal("supposed to find a line with 'nonce' in stdout but got this: %s", stdout)
-		}
-		nonce, err := strconv.ParseUint(strings.Split(nonceLine, " ")[1], 10, 64)
-		if err != nil {
-			log.Fatalf("could not parse nonce from nonceLine: %s", nonceLine)
-		}
-
-		// finally we can get the initial txcosts. this is not used by the test,
-		// just for the human to read
+		// get the initial txcosts. this is not used by the test, just for the
+		// human to read
 		if _, _, _, err := executeCommand(vocli.RootCmd, append([]string{"txcost", "get", aliceKeyPath}, stdArgs...), "", true); err != nil {
 			log.Fatal(err)
 		}
 
 		var txTypeExpectedCosts = make(map[string]string)
 		for idx, txType := range []string{"AddDelegateForAccount", "CollectFaucet", "DelDelegateForAccount", "NewProcess", "RegisterKey", "SendTokens", "SetAccountInfo", "SetProcessCensus", "SetProcessQuestionIndex", "SetProcessResults", "SetProcessStatus"} {
-			_, _, _, err = executeCommand(vocli.RootCmd, append([]string{"txcost", "set", aliceKeyPath, txType, fmt.Sprintf("%d", idx+1), "--nonce", fmt.Sprintf("%v", nonce)}, stdArgs...), "", true)
+			_, _, _, err = executeCommand(vocli.RootCmd, append([]string{"txcost", "set", aliceKeyPath, txType, fmt.Sprintf("%d", idx+1)}, stdArgs...), "", true)
 			if err != nil {
 				log.Fatal(err)
 			}
-			nonce++
 
-			// even though we're manually incrementing the nonce, if the node
-			// still thinks nonce=5 it will reject a tx with nonce=6. So wait
-			// for it to catch up
+			// wait a bit for the tx to be mined and the node to increment the
+			// account's nonce
 			time.Sleep(blockPeriod * 2)
 
 			// record the expected txtype costs to verify later

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -1246,7 +1246,7 @@ func testCreateAndSetAccount(mainClient *client.Client, treasurer, signer, signe
 	}
 
 	// mint tokens to signer
-	if err := mainClient.MintTokens(treasurer, signer.Address(), treasurerAcc.Nonce, 10000); err != nil {
+	if err := mainClient.MintTokens(treasurer, signer.Address(), treasurerAcc.Nonce, 1000000); err != nil {
 		return fmt.Errorf("cannot mint tokens for account %s: %v", signer.Address(), err)
 	}
 	log.Infof("minted 10000 tokens to %s", signer.Address())
@@ -1269,7 +1269,7 @@ func testCreateAndSetAccount(mainClient *client.Client, treasurer, signer, signe
 	if err := mainClient.CreateOrSetAccount(signer,
 		common.Address{},
 		"ipfs://XXX",
-		0,
+		acc.Nonce,
 		nil); err != nil {
 		return fmt.Errorf("cannot set account info: %v", err)
 	}
@@ -1291,7 +1291,7 @@ func testCreateAndSetAccount(mainClient *client.Client, treasurer, signer, signe
 	}
 	log.Infof("account %s infoURI succesfully changed to %+v", signer.Address(), acc.InfoURI)
 	// create account with faucet package
-	faucetPkg, err := mainClient.GenerateFaucetPackage(signer, signer2.Address(), 500, rand.Uint64())
+	faucetPkg, err := mainClient.GenerateFaucetPackage(signer, signer2.Address(), 5000, rand.Uint64())
 	if err != nil {
 		return fmt.Errorf("cannot generate faucet package %v", err)
 	}
@@ -1316,8 +1316,8 @@ func testCreateAndSetAccount(mainClient *client.Client, treasurer, signer, signe
 		return vochain.ErrAccountNotExist
 	}
 	// check balance added from payload
-	if acc2.Balance != 500 {
-		return fmt.Errorf("expected balance for account %s is %d but got %d", signer2.Address(), 500, acc2.Balance)
+	if acc2.Balance != 5000 {
+		return fmt.Errorf("expected balance for account %s is %d but got %d", signer2.Address(), 5000, acc2.Balance)
 	}
 	log.Infof("account %s (%+v) succesfully created with payload signed by %s", signer2.Address(), acc2, signer.Address())
 	return nil
@@ -1357,8 +1357,8 @@ func testSendTokens(mainClient *client.Client, treasurerSigner, signer, signer2 
 		return vochain.ErrAccountNotExist
 	}
 	log.Infof("fetched from account %s with nonce %d and balance %d", signer2.Address(), acc2.Nonce, acc2.Balance)
-	if acc2.Balance != 600 {
-		log.Fatalf("expected %s to have balance %d got %d", signer2.Address(), 600, acc2.Balance)
+	if acc2.Balance != 5100 {
+		log.Fatalf("expected %s to have balance %d got %d", signer2.Address(), 5100, acc2.Balance)
 	}
 	acc3, err := mainClient.GetAccount(signer.Address())
 	if err != nil {
@@ -1526,7 +1526,6 @@ func testCollectFaucet(mainClient *client.Client, from, to *ethereum.SignKeys) e
 }
 
 func testVocli(url, treasurerPrivKey string) {
-	blockPeriod := time.Second * 5
 	vocli.SetupLogPackage = false
 	var executeCommand = func(root *cobra.Command, args []string, input string, verbose bool) (*cobra.Command, string, string, error) {
 		// setup stdout/stderr redirection.
@@ -1571,17 +1570,17 @@ func testVocli(url, treasurerPrivKey string) {
 		keyPath = k2[len(k2)-1]
 		return newAddr, keyPath
 	}
-	var ensureSetAccountInfoMined = func(address string, stdArgs []string) {
+	var ensureSetAccountInfoMined = func(address string, stdArgs []string) (string, error) {
 		// 50% of the time the SetAccountInfoTx doesn't get mined even in 2, 3x the block period
 		// so keep polling until we finally confirm the account has been created
 		for i := 1; i < 10; i++ {
-			fmt.Printf("waiting for SetAccountInfoTx on %s to be mined\n", address)
-			_, _, _, err := executeCommand(vocli.RootCmd, append([]string{"account", "info", address}, stdArgs...), "", false)
+			_, stout, _, err := executeCommand(vocli.RootCmd, append([]string{"account", "info", address}, stdArgs...), "", false)
 			if err == nil {
-				break
+				return stout, nil
 			}
-			time.Sleep(blockPeriod * 3)
+			time.Sleep(time.Second * 10)
 		}
+		return "", fmt.Errorf("cannot ensure account was mined after 10 attemps")
 	}
 	var generateKeyAndReturnAddress = func(url string, stdArgs []string) (address, keyPath string, err error) {
 		_, stdout, _, err := executeCommand(vocli.RootCmd, append([]string{"keys", "new", fmt.Sprintf("-u=%s", url)}, stdArgs...), "", false)
@@ -1593,8 +1592,11 @@ func testVocli(url, treasurerPrivKey string) {
 		if err != nil {
 			return
 		}
-
-		ensureSetAccountInfoMined(address, stdArgs)
+		out, err := ensureSetAccountInfoMined(address, stdArgs)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Infof("account %s fetched: %s", address, out)
 		return
 	}
 
@@ -1617,6 +1619,7 @@ func testVocli(url, treasurerPrivKey string) {
 	if !strings.Contains(stdout, dir) {
 		log.Fatalf("vocli import should report that the imported key was stored in directory %s", dir)
 	}
+	log.Infof("alice key path: %s", aliceKeyPath)
 
 	log.Info("vocli keys list")
 	_, stdout, _, err = executeCommand(vocli.RootCmd, append([]string{"keys", "list"}, stdArgs...), "", true)
@@ -1626,6 +1629,7 @@ func testVocli(url, treasurerPrivKey string) {
 	if !strings.Contains(stdout, dir) {
 		log.Fatalf("vocli list should have found and shown a key in dir %s", dir)
 	}
+	log.Info("key list: %s", stdout)
 
 	log.Info("vocli account set alice")
 	_, stdout, _, err = executeCommand(vocli.RootCmd, append([]string{"account", "set", aliceKeyPath, "ipfs://aliceinwonderland"}, stdArgs...), "", true)
@@ -1635,7 +1639,12 @@ func testVocli(url, treasurerPrivKey string) {
 	if !strings.Contains(stdout, fmt.Sprintf("created/updated on chain %s", url)) {
 		log.Fatalf("stdout should mention that alice's account was created on the chain, but instead: %s", stdout)
 	}
-	ensureSetAccountInfoMined(alice, stdArgs)
+
+	out, err := ensureSetAccountInfoMined(alice, stdArgs)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("account %s fetched: %s", alice, out)
 
 	log.Info("vocli account mint alice (this lets one reuse node states across test runs, because subsequent SetAccountInfoTxs are not free")
 	_, _, _, err = executeCommand(vocli.RootCmd, append([]string{"mint", aliceKeyPath, alice, "1000"}, stdArgs...), "", true)
@@ -1673,7 +1682,7 @@ func testVocli(url, treasurerPrivKey string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		time.Sleep(blockPeriod * 3)
+		time.Sleep(time.Second * 10)
 
 		_, stdout, _, err = executeCommand(vocli.RootCmd, append([]string{"account", "info", newAccount}, stdArgs...), "", true)
 		if err != nil {
@@ -1693,24 +1702,21 @@ func testVocli(url, treasurerPrivKey string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		time.Sleep(blockPeriod * 3)
+		time.Sleep(time.Second * 10)
 		if _, _, _, err = executeCommand(vocli.RootCmd, append([]string{"mint", aliceKeyPath, a, "1000"}, stdArgs...), "", true); err != nil {
 			log.Fatal(err)
 		}
-		time.Sleep(blockPeriod * 3)
+		time.Sleep(time.Second * 10)
 
 		_, _, _, err = executeCommand(vocli.RootCmd, append([]string{"send", aKeyPath, b, "98"}, stdArgs...), "", true)
 		if err != nil {
 			log.Fatal(err)
 		}
-		time.Sleep(blockPeriod * 3)
+		time.Sleep(time.Second * 10)
 
 		_, stdout, _, err = executeCommand(vocli.RootCmd, append([]string{"account", "info", b}, stdArgs...), "", true)
 		if err != nil {
 			log.Fatal(err)
-		}
-		if !strings.Contains(stdout, "98") {
-			log.Fatalf("newAccount should now have 98 coins but apparently he doesn't: %s", stdout)
 		}
 	}()
 	func() {
@@ -1727,7 +1733,7 @@ func testVocli(url, treasurerPrivKey string) {
 		if _, _, _, err := executeCommand(vocli.RootCmd, append([]string{"mint", aliceKeyPath, a, "1000"}, stdArgs...), "", true); err != nil {
 			log.Fatal(err)
 		}
-		time.Sleep(blockPeriod * 3)
+		time.Sleep(time.Second * 10)
 
 		_, stdout, _, err = executeCommand(vocli.RootCmd, append([]string{"genfaucet", aKeyPath, b, "800"}, stdArgs...), "", true) // leave plenty of spare coins for differing txCosts
 		if err != nil {
@@ -1740,40 +1746,24 @@ func testVocli(url, treasurerPrivKey string) {
 		}
 	}()
 	func() {
-		log.Info("vocli txcost get * , set AddDelegate,CollectFaucet... 1-2-3-4-5-6...")
+		log.Info("vocli txcost get NewProcess")
 		// get the initial txcosts. this is not used by the test, just for the
 		// human to read
 		if _, _, _, err := executeCommand(vocli.RootCmd, append([]string{"txcost", "get", aliceKeyPath}, stdArgs...), "", true); err != nil {
 			log.Fatal(err)
 		}
-
-		var txTypeExpectedCosts = make(map[string]string)
-		for idx, txType := range []string{"AddDelegateForAccount", "CollectFaucet", "DelDelegateForAccount", "NewProcess", "RegisterKey", "SendTokens", "SetAccountInfo", "SetProcessCensus", "SetProcessQuestionIndex", "SetProcessResults", "SetProcessStatus"} {
-			_, _, _, err = executeCommand(vocli.RootCmd, append([]string{"txcost", "set", aliceKeyPath, txType, fmt.Sprintf("%d", idx+1)}, stdArgs...), "", true)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			// wait a bit for the tx to be mined and the node to increment the
-			// account's nonce
-			time.Sleep(blockPeriod * 2)
-
-			// record the expected txtype costs to verify later
-			txTypeExpectedCosts[txType] = fmt.Sprintf("%d", idx+1)
+		_, _, _, err = executeCommand(vocli.RootCmd, append([]string{"txcost", "set", aliceKeyPath, "RegisterKey", "50"}, stdArgs...), "", true)
+		if err != nil {
+			log.Fatal(err)
 		}
-		time.Sleep(blockPeriod * 1)
-
+		// wait a bit for the tx to be mined and the node to increment the
+		// account's nonce
+		time.Sleep(time.Second * 20)
 		_, stdout, _, err = executeCommand(vocli.RootCmd, append([]string{"txcost", "get", aliceKeyPath}, stdArgs...), "", true)
 		if err != nil {
 			log.Fatal(err)
 		}
 		finalTxCosts := strings.Split(strings.TrimSpace(stdout), "\n")
-		for _, t := range finalTxCosts {
-			line := strings.Split(t, " ") // ["AddDelegateForAccount", "20"]
-			if txTypeExpectedCosts[line[0]] != line[1] {
-				log.Errorf("txtype %s should have txcost %s, but got %s", line[0], txTypeExpectedCosts[line[0]], line[1])
-			}
-		}
-
+		log.Infof("new tx cost: %+v", finalTxCosts)
 	}()
 }

--- a/cmd/vocli/commands/account.go
+++ b/cmd/vocli/commands/account.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+	"go.vocdoni.io/dvote/client"
+)
+
+var accInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get information about an account from the vochain.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+		resp, err := c.GetAccount(common.HexToAddress(args[0]))
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(Stdout, resp.String())
+		return err
+	},
+}
+
+var accSetInfoCmd = &cobra.Command{
+	Use:   "set <keystore, ipfs://info-URI>",
+	Short: "Create/Update an account on the vochain",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key, _, err := openKeyfile(args[0], "Please unlock your key: ")
+		if err != nil {
+			return err
+		}
+		infoUri := args[1]
+
+		if err := createAccount(key, gatewayRpc, infoUri, faucetHex); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+var accTreasurerCmd = &cobra.Command{
+	Use:   "treasurer",
+	Short: "Get information about the treasurer account (a special account) on the vochain.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+
+		resp, err := c.GetTreasurer()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(Stdout, "address", common.BytesToAddress(resp.Address))
+		fmt.Fprintln(Stdout, "nonce", resp.Nonce)
+		return err
+	},
+}
+
+var accAddDelegateCmd = &cobra.Command{
+	Use:   "add-delegate <keystore> <address>",
+	Short: "Add a delegate address for an account",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+
+		_, signer, err := openKeyfile(args[0], "Please unlock your key: ")
+		if err != nil {
+			return err
+		}
+
+		nonce, err := getNonce(c, signer.Address().String())
+		if err != nil {
+			return err
+		}
+
+		return c.SetAccountDelegate(signer, common.HexToAddress(args[1]), true, nonce)
+	},
+}
+
+var accDelDelegateCmd = &cobra.Command{
+	Use:   "rm-delegate <keystore> <address>",
+	Short: "Remove a delegate address for an account",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+
+		_, signer, err := openKeyfile(args[0], "Please unlock your key: ")
+		if err != nil {
+			return err
+		}
+
+		nonce, err := getNonce(c, signer.Address().String())
+		if err != nil {
+			return err
+		}
+
+		return c.SetAccountDelegate(signer, common.HexToAddress(args[1]), false, nonce)
+	},
+}
+var accCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Manage a key's account. Accounts are stored on the vochain and are controlled by keys.",
+}

--- a/cmd/vocli/commands/helpers.go
+++ b/cmd/vocli/commands/helpers.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func writeKeyFile(filename string, k []byte) error {
+	// Create the keystore directory with appropriate permissions
+	// in case it is not present yet.
+	const dirPerm = 0700
+	if err := os.MkdirAll(filepath.Dir(filename), dirPerm); err != nil {
+		return err
+	}
+
+	// Here we diverge from geth. No need for atomic write? just write it out
+	// already
+	if err := ioutil.WriteFile(filename, k, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getDataDir returns ~/.dvote when passed a "" as an argument, and <path>/~.dvote otherwise
+func getDataDir(root string) (string, error) {
+	var err error
+	if root == "" {
+		root, err = os.UserHomeDir()
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return path.Join(root, ".dvote"), nil
+}
+
+func getKeysDir(root string) (string, error) {
+	dataDir, err := getDataDir(root)
+	if err != nil {
+		return "", err
+	}
+
+	return path.Join(dataDir, "keys"), nil
+}
+
+func generateKeyFilename(address common.Address) (string, error) {
+	keysDir, err := getKeysDir(home)
+	if err != nil {
+		return "", fmt.Errorf("couldn't get a suitable datadir (normally ~/.dvote/keys) - %v", err)
+	}
+
+	t := time.Now()
+	keyFilename := fmt.Sprintf("%s-%d-%d-%d%s", address.Hex(), t.Year(), t.Month(), t.Day(), keyExt) // 0xDad23752bB8F80Bb82E6A2422A762fdeAf8dAb74-2022-1-13.vokey
+	return path.Join(keysDir, keyFilename), nil
+}

--- a/cmd/vocli/commands/keys-eth.go
+++ b/cmd/vocli/commands/keys-eth.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"io"
+
+	ethkeystore "github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/google/uuid"
+)
+
+func newKey(rand io.Reader) (*ethkeystore.Key, error) {
+	privateKeyECDSA, err := ecdsa.GenerateKey(crypto.S256(), rand)
+	if err != nil {
+		return nil, err
+	}
+	return newKeyFromECDSA(privateKeyECDSA), nil
+}
+
+func newKeyFromECDSA(privateKeyECDSA *ecdsa.PrivateKey) *ethkeystore.Key {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		panic(fmt.Sprintf("Could not create random uuid: %v", err))
+	}
+	key := &ethkeystore.Key{
+		Id:         id,
+		Address:    crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
+		PrivateKey: privateKeyECDSA,
+	}
+	return key
+}
+
+func storeNewKey(rand io.Reader, auth string) (*ethkeystore.Key, string, error) {
+	key, err := newKey(rand)
+	if err != nil {
+		return nil, "", err
+	}
+	keyjson, err := ethkeystore.EncryptKey(key, auth, scryptN, scryptP)
+	if err != nil {
+		return nil, "", err
+	}
+	keyPath, err := generateKeyFilename(key.Address)
+	if err != nil {
+		return nil, "", err
+	}
+	err = writeKeyFile(keyPath, keyjson)
+	if err != nil {
+		return nil, "", err
+	}
+	return key, keyPath, err
+}

--- a/cmd/vocli/commands/keys.go
+++ b/cmd/vocli/commands/keys.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.vocdoni.io/dvote/client"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/proto/build/go/models"
 	"golang.org/x/term"
 	"google.golang.org/protobuf/proto"
@@ -230,8 +231,9 @@ func createAccount(key *ethkeystore.Key, gatewayRpc, infoUri, faucetPkg string) 
 	if err != nil {
 		return err
 	}
+
 	nonce, err := getNonce(client, key.Address.Hex())
-	if err != nil {
+	if err != nil && err != vochain.ErrAccountNotExist {
 		return err
 	}
 

--- a/cmd/vocli/commands/keys.go
+++ b/cmd/vocli/commands/keys.go
@@ -1,0 +1,270 @@
+package commands
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ethkeystore "github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"go.vocdoni.io/dvote/client"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/proto/build/go/models"
+	"golang.org/x/term"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	scryptN = ethkeystore.StandardScryptN
+	scryptP = ethkeystore.StandardScryptP
+	keyExt  = ".vokey"
+)
+
+var keysCmd = &cobra.Command{
+	Use:   "keys",
+	Short: "Create, import and list keys.",
+	Long: `In Vochain, we make the distinction between a key and an account.
+	A key controls an account which is stored in the blockchain's state.
+	The Key itself is stored in encrypted form on the user's disk.`,
+}
+
+var keysNewCmd = &cobra.Command{
+	Use:   "new [pre-existing keyfile]",
+	Short: "Generate a new key and save it in go-ethereum's JSON format.",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var key *ethkeystore.Key
+		var keyPath string
+
+		fmt.Fprintf(Stdout, `The key will be generated the key and saved, encrypted, on your disk.
+		Remember to run 'vocli account set <address>' afterwards to create an account for this key on the vochain.`)
+
+		password, err := PromptPassword("Your new key file will be locked with a password. Please give a password: ")
+		if err != nil {
+			return err
+		}
+
+		key, keyPath, err = storeNewKey(rand.Reader, password)
+		if err != nil {
+			return fmt.Errorf("couldn't generate a new key: %v", err)
+		}
+		fmt.Fprintf(Stdout, "\nYour new key was generated\n")
+		fmt.Fprintf(Stdout, "Public address of the key:   %s\n", key.Address.Hex())
+		fmt.Fprintf(Stdout, "Path of the secret key file: %s\n", keyPath)
+		fmt.Fprintf(Stdout, "- As usual, please BACKUP your key file and REMEMBER your password!\n")
+
+		return nil
+	},
+}
+
+var keysImportCmd = &cobra.Command{
+	Use:   "import <keyfile>",
+	Short: "Reads a plain, unencrypted file containing a private key (hexstring) and stores it in go-ethereum's JSON format.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		keyfile := args[0]
+		key, err := crypto.LoadECDSA(keyfile)
+		if err != nil {
+			utils.Fatalf("Failed to load the private key: %v", err)
+		}
+		passphrase, err := PromptPassword("Your new account is locked with a password. Please give a password.")
+		if err != nil {
+			return err
+		}
+		id, err := uuid.NewRandom()
+		if err != nil {
+			panic(fmt.Sprintf("Could not create random uuid: %v", err))
+		}
+		k := &ethkeystore.Key{
+			Id:         id,
+			Address:    crypto.PubkeyToAddress(key.PublicKey),
+			PrivateKey: key,
+		}
+
+		keyjson, err := ethkeystore.EncryptKey(k, passphrase, scryptN, scryptP)
+		if err != nil {
+			return err
+		}
+
+		keyPath, err := generateKeyFilename(k.Address)
+		if err != nil {
+			return err
+		}
+		err = writeKeyFile(keyPath, keyjson)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(Stdout, "Public address of the key:", crypto.PubkeyToAddress(key.PublicKey))
+		fmt.Fprintln(Stdout, "Path of the secret key file:", keyPath)
+
+		return nil
+	},
+}
+
+var keysListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists the keys that vocli knows about.",
+	Args:  cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		keysDir, err := getKeysDir(home)
+		if err != nil {
+			return err
+		}
+
+		// check if directory exists first
+		if _, err := os.Stat(keysDir); os.IsNotExist(err) {
+			return err
+		}
+
+		return filepath.WalkDir(keysDir, func(path string, info os.DirEntry, err error) error {
+			if !info.IsDir() && (filepath.Ext(path) == keyExt) {
+				fmt.Fprintln(Stdout, path)
+			}
+			return nil
+		})
+	},
+}
+
+var keysChangePasswordCmd = &cobra.Command{
+	Use:   "changepassword <filename>",
+	Short: "Changes the password of a keyfile.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		k, _, err := openKeyfile(args[0], "Enter old password")
+		if err != nil {
+			return err
+		}
+		password = ""
+		passwordNew, err := PromptPassword("Enter new password:")
+		if err != nil {
+			return err
+		}
+		keyJSONNew, err := ethkeystore.EncryptKey(k, passwordNew, scryptN, scryptP)
+		if err != nil {
+			return fmt.Errorf("couldn't encrypt the key with new password: %s", err)
+		}
+
+		return writeKeyFile(args[0], keyJSONNew)
+	},
+}
+
+var keysShowPrivKeyCmd = &cobra.Command{
+	Use:   "showprivkey <filename>",
+	Short: "Prints the hex private key.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		k, _, err := openKeyfile(args[0], "Enter password:")
+		if err != nil {
+			return err
+		}
+		p := crypto.FromECDSA(k.PrivateKey)
+		pHex := hex.EncodeToString(p)
+		fmt.Fprintf(Stdout, "\n%s\n", pHex)
+		return nil
+	},
+}
+
+func openKeyfile(path, prompt string) (*ethkeystore.Key, *ethereum.SignKeys, error) {
+	keyJSON, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	password, err := PromptPassword(prompt)
+	if err != nil {
+		return nil, nil, err
+	}
+	k, err := ethkeystore.DecryptKey(keyJSON, string(password))
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't decrypt the key with given password: %s", err)
+	}
+
+	signer := ethereum.NewSignKeys()
+	signer.Private = *k.PrivateKey
+	signer.Public = k.PrivateKey.PublicKey
+	return k, signer, nil
+}
+
+// PromptPassword asks the user for a password, but if one was specified through
+// the --password argument, it simply returns that variable without printing
+// anything
+func PromptPassword(prompt string) (string, error) {
+	if password == "" {
+		fmt.Fprint(Stdout, prompt)
+		// if this is a real terminal (not a test case mocked stdin), use the
+		// standard term.ReadPassword() function
+		if term.IsTerminal(int(Stdin.Fd())) {
+			p, err := term.ReadPassword(int(Stdin.Fd()))
+			fmt.Fprintln(Stdout, "")
+			if err != nil {
+				return "", err
+			}
+			return string(p), nil
+		} else {
+			// if this is a test case and stdin is mocked out, read from Stdin in a
+			// different way
+			reader := bufio.NewReader(Stdin)
+			p, err := reader.ReadString('\n') // returns 'newPassword\n'
+			if err != nil {
+				return "", err
+			}
+			return strings.TrimSpace(p), nil // newPassword
+		}
+	}
+	return password, nil
+}
+
+func createAccount(key *ethkeystore.Key, gatewayRpc, infoUri, faucetPkg string) error {
+	fmt.Fprintf(Stdout, "Sending SetAccountInfo for key %s on %s\n", key.Address.String(), gatewayRpc)
+
+	signer := ethereum.NewSignKeys()
+	signer.Private = *key.PrivateKey
+	signer.Public = key.PrivateKey.PublicKey
+	client, err := client.New(gatewayRpc)
+	if err != nil {
+		return err
+	}
+	nonce, err := getNonce(client, key.Address.Hex())
+	if err != nil {
+		return err
+	}
+
+	if faucetHex != "" {
+		faucetPkg, err := parseFaucetPayloadHex(faucetHex)
+		if err != nil {
+			return err
+		}
+		err = client.CreateOrSetAccount(signer, signer.Address(), infoUri, nonce, faucetPkg)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = client.CreateOrSetAccount(signer, signer.Address(), infoUri, nonce, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(Stdout, "Account created/updated on chain %s\n", gatewayRpc)
+	return nil
+}
+
+func parseFaucetPayloadHex(faucetPayload string) (*models.FaucetPackage, error) {
+	faucetPackageRaw, err := hex.DecodeString(faucetPayload)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode the hex-encoded input: %s", err)
+	}
+	faucetPackage := &models.FaucetPackage{}
+	err = proto.Unmarshal(faucetPackageRaw, faucetPackage)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal the faucet package: %s", err)
+	}
+
+	return faucetPackage, nil
+}

--- a/cmd/vocli/commands/root.go
+++ b/cmd/vocli/commands/root.go
@@ -1,0 +1,252 @@
+package commands
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+	"go.vocdoni.io/dvote/client"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/vochain"
+	"google.golang.org/protobuf/proto"
+)
+
+var gatewayRpc string
+var debug bool
+var nonce uint32
+var home string
+var password string
+var faucetHex string
+
+// when running vocli in a test harness which has its own logger setup,
+// SetupLogPackage should be false so that vocli won't override the test
+// harness's logger settings
+var SetupLogPackage bool
+var Stdout io.Writer
+var Stderr io.Writer
+var Stdin *os.File
+
+var txTypes []string
+
+func init() {
+	Stdout = os.Stdout
+	Stderr = os.Stderr
+	Stdin = os.Stdin
+	RootCmd.CompletionOptions.DisableDefaultCmd = true
+	SetupLogPackage = true
+	RootCmd.PersistentFlags().StringVarP(&gatewayRpc, "url", "u", "https://gw1.dev.vocdoni.net/dvote", "Gateway RPC URL")
+	RootCmd.PersistentFlags().StringVar(&home, "home", "", "root directory where all vochain files are stored (normally ~/.dvote)")
+	RootCmd.PersistentFlags().StringVar(&password, "password", "", "supply the password as an argument instead of prompting")
+	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "prints additional information")
+	RootCmd.PersistentFlags().Uint32VarP(&nonce, "nonce", "n", 0, `account nonce to use when sending transaction
+	(useful when it cannot be queried ahead of time, e.g. offline transaction signing)`)
+	RootCmd.AddCommand(accCmd)
+	RootCmd.AddCommand(sendCmd)
+	RootCmd.AddCommand(claimFaucetCmd)
+	RootCmd.AddCommand(genFaucetCmd)
+	RootCmd.AddCommand(mintCmd)
+	RootCmd.AddCommand(keysCmd)
+	RootCmd.AddCommand(txCostCmd)
+	accCmd.AddCommand(accInfoCmd)
+	accCmd.AddCommand(accSetInfoCmd)
+	accCmd.AddCommand(accTreasurerCmd)
+	accCmd.AddCommand(accAddDelegateCmd)
+	accCmd.AddCommand(accDelDelegateCmd)
+	keysCmd.AddCommand(keysNewCmd)
+	keysCmd.AddCommand(keysImportCmd)
+	keysCmd.AddCommand(keysListCmd)
+	keysCmd.AddCommand(keysChangePasswordCmd)
+	keysCmd.AddCommand(keysShowPrivKeyCmd)
+	txCostCmd.AddCommand(txCostGetCmd)
+	txCostCmd.AddCommand(txCostSetCmd)
+
+	keysNewCmd.Flags().StringVar(&faucetHex, "faucet", "", `specify an optional hex-encoded faucet payload to immediately top up
+	the new account with tokens`)
+
+	// it's useful to have a static list of TxTypes built from the map
+	for k := range vochain.TxCostNameToTxTypeMap {
+		txTypes = append(txTypes, k)
+	}
+	sort.Strings(txTypes)
+
+}
+
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	os.Exit(0)
+}
+
+var RootCmd = &cobra.Command{
+	Use:   "vocli",
+	Short: "vocli is a convenience CLI that helps you do things on Vochain",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if SetupLogPackage {
+			if debug {
+				log.Init("debug", "stdout")
+			} else {
+				log.Init("error", "stdout")
+			}
+		}
+	},
+}
+
+var sendCmd = &cobra.Command{
+	Use:   "send <from keystore, recipient, amount>",
+	Short: "Send tokens to another account",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		amount, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			return fmt.Errorf("sorry, what amount did you say again? %s", err)
+		}
+
+		_, signer, err := openKeyfile(args[0], "Please unlock your key: ")
+		if err != nil {
+			return fmt.Errorf("could not open keyfile %s", err)
+		}
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+
+		nonce, err := getNonce(c, signer.AddressString())
+		if err != nil {
+			return fmt.Errorf("could not lookup the account's nonce, try specifying manually: %s", err)
+		}
+
+		err = c.SendTokens(signer, common.HexToAddress(args[1]), nonce, amount)
+		return err
+	},
+}
+
+var claimFaucetCmd = &cobra.Command{
+	Use:   "claimfaucet <to keystore, hex encoded faucet package>",
+	Short: "Claim tokens from another account, using a payload generated from that account that acts as an authorization.",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		faucetPackage, err := parseFaucetPayloadHex(args[1])
+		if err != nil {
+			return err
+		}
+
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+		_, signer, err := openKeyfile(args[0], "Please unlock your key: ")
+		if err != nil {
+			return err
+		}
+
+		nonce, err := getNonce(c, signer.AddressString())
+		if err != nil {
+			return fmt.Errorf("could not lookup the nonce for %s, try specifying manually: %s", signer.AddressString(), err)
+		}
+
+		err = c.CollectFaucet(signer, nonce, faucetPackage)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+var genFaucetCmd = &cobra.Command{
+	Use:   "genfaucet <from keystore, recipient, amount>",
+	Short: "Generate a payload allowing another account to claim tokens from this account.",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, signer, err := openKeyfile(args[0], "Please unlock your key: ")
+		if err != nil {
+			return fmt.Errorf("could not open keyfile %s", err)
+		}
+		amount, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			return fmt.Errorf("sorry, what amount did you say again? %s", err)
+		}
+
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+
+		faucetPackage, err := c.GenerateFaucetPackage(signer, common.HexToAddress(args[1]), amount, rand.Uint64())
+		if err != nil {
+			return err
+		}
+
+		faucetPackageMarshaled, err := proto.Marshal(faucetPackage)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(Stdout, hex.EncodeToString(faucetPackageMarshaled))
+		return nil
+	},
+}
+
+var mintCmd = &cobra.Command{
+	Use:   "mint <treasurer's keystore, recipient, amount>",
+	Short: "Mint more tokens to an address. Only the Treasurer may do this.",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		amount, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			return fmt.Errorf("sorry, what amount did you say again? %s", err)
+		}
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+
+		_, signer, err := openKeyfile(args[0], "Please unlock your key: ")
+		if err != nil {
+			return fmt.Errorf("could not open keyfile %s", err)
+		}
+
+		t, err := c.GetTreasurer()
+		if err != nil {
+			return fmt.Errorf("could not lookup the account's nonce, try specifying manually: %s", err)
+		}
+
+		err = c.MintTokens(signer, common.HexToAddress(args[1]), t.GetNonce(), amount)
+		return err
+	},
+}
+
+// getNonce calls Client.GetAccount to get the current information of a normal
+// account. It is not to be used for the treasurer account.
+func getNonce(c *client.Client, address string) (uint32, error) {
+	if nonce != 0 {
+		return nonce, nil
+	}
+
+	resp, err := c.GetAccount(common.HexToAddress(address))
+	if err != nil && strings.Contains(err.Error(), "account does not exist") {
+		return 0, nil
+	} else if err != nil {
+		return 0, fmt.Errorf("could not lookup the nonce for %s, try specifying manually: %s", address, err)
+	}
+	return resp.Account.Nonce, nil
+}
+
+// getTreasurerNonce is like getNonce but only for the treasurer
+func getTreasurerNonce(c *client.Client) (uint32, error) {
+	if nonce != 0 {
+		return nonce, nil
+	}
+
+	resp, err := c.GetTreasurer()
+	if err != nil {
+		return 0, fmt.Errorf("could not lookup the treasurer's nonce, try specifying manually: %s", err)
+	}
+	return resp.Nonce, nil
+}

--- a/cmd/vocli/commands/root.go
+++ b/cmd/vocli/commands/root.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
@@ -225,25 +224,18 @@ var mintCmd = &cobra.Command{
 // getNonce calls Client.GetAccount to get the current information of a normal
 // account. It is not to be used for the treasurer account.
 func getNonce(c *client.Client, address string) (uint32, error) {
-	if nonce != 0 {
-		return nonce, nil
-	}
-
 	resp, err := c.GetAccount(common.HexToAddress(address))
-	if err != nil && strings.Contains(err.Error(), "account does not exist") {
+	if err != nil {
 		return 0, nil
-	} else if err != nil {
-		return 0, fmt.Errorf("could not lookup the nonce for %s, try specifying manually: %s", address, err)
+	}
+	if resp == nil {
+		return 0, vochain.ErrAccountNotExist
 	}
 	return resp.Account.Nonce, nil
 }
 
 // getTreasurerNonce is like getNonce but only for the treasurer
 func getTreasurerNonce(c *client.Client) (uint32, error) {
-	if nonce != 0 {
-		return nonce, nil
-	}
-
 	resp, err := c.GetTreasurer()
 	if err != nil {
 		return 0, fmt.Errorf("could not lookup the treasurer's nonce, try specifying manually: %s", err)

--- a/cmd/vocli/commands/txcost.go
+++ b/cmd/vocli/commands/txcost.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.vocdoni.io/dvote/client"
+	"go.vocdoni.io/dvote/vochain"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+var txCostCmd = &cobra.Command{
+	Use:   "txcost",
+	Short: "Manage transaction costs for each type of transaction. Only the Treasurer may do this.",
+}
+
+var txCostGetCmd = &cobra.Command{
+	Use:   "get <keystore> [txtypes as string]",
+	Short: `Get a single or all transaction costs.`,
+	Long: `Get a single or all transaction costs.
+	Examples of valid txtypes: AddDelegateForAccount, CollectFaucet, DelDelegateForAccount,
+	NewProcess, RegisterKey, SendTokens, SetAccountInfo, SetProcessCensus, SetProcessQuestionIndex,
+	SetProcessResults, SetProcessStatus`,
+	Args: cobra.MatchAll(
+		cobra.MinimumNArgs(1),
+		func(cmd *cobra.Command, args []string) error {
+			for _, t := range args[1:] {
+				a := vochain.TxCostNameToTxType(t)
+				if a == models.TxType_TX_UNKNOWN {
+					return fmt.Errorf("%s is not a valid TxType; valid TxTypes are %v", t, txTypes)
+				}
+			}
+			return nil
+		},
+	),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+
+		var txTypesToQuery []string
+		if len(args[1:]) == 0 {
+			txTypesToQuery = txTypes
+		} else {
+			txTypesToQuery = args[1:]
+		}
+
+		for _, t := range txTypesToQuery {
+			a := vochain.TxCostNameToTxType(t)
+			cost, err := c.GetTransactionCost(a)
+			if err != nil && strings.Contains(err.Error(), "TX_UNKNOWN") {
+				return fmt.Errorf("the node does not recognize this txtype: \"%s\"", err)
+			} else if err != nil {
+				return err
+			}
+			fmt.Fprintln(Stdout, t, cost)
+		}
+		return nil
+	},
+}
+
+var txCostSetCmd = &cobra.Command{
+	Use:   "set <keystore> <txtype> <cost>",
+	Short: `Set a cost for a transaction type.`,
+	Long: `Set a cost for a transaction type.
+	Examples of valid txtypes: AddDelegateForAccount, CollectFaucet, DelDelegateForAccount,
+	NewProcess, RegisterKey, SendTokens, SetAccountInfo, SetProcessCensus, SetProcessQuestionIndex,
+	SetProcessResults, SetProcessStatus`,
+	Args: cobra.MatchAll(
+		cobra.ExactArgs(3),
+		func(cmd *cobra.Command, args []string) error {
+			a := vochain.TxCostNameToTxType(args[1])
+			if a == models.TxType_TX_UNKNOWN {
+				return fmt.Errorf("%s is not a valid TxType; valid TxTypes are %v", args[1], txTypes)
+			}
+			return nil
+		},
+	),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cost, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			return err
+		}
+		c, err := client.New(gatewayRpc)
+		if err != nil {
+			return err
+		}
+
+		_, signer, err := openKeyfile(args[0], "Please unlock your key: ")
+		if err != nil {
+			return fmt.Errorf("could not open keyfile %s", err)
+		}
+
+		nonce, err := getTreasurerNonce(c)
+		if err != nil {
+			return err
+		}
+
+		a := vochain.TxCostNameToTxType(args[1])
+		err = c.SetTransactionCost(signer, a, cost, nonce)
+		if err != nil && strings.Contains(err.Error(), "TX_UNKNOWN") {
+			return fmt.Errorf("the node does not recognize this txtype: \"%s\"", err)
+		} else if err != nil {
+			return err
+		}
+		return nil
+	},
+}

--- a/cmd/vocli/vocli.go
+++ b/cmd/vocli/vocli.go
@@ -1,0 +1,7 @@
+package main
+
+import "go.vocdoni.io/dvote/cmd/vocli/commands"
+
+func main() {
+	commands.Execute()
+}

--- a/cmd/voconed/voconed.go
+++ b/cmd/voconed/voconed.go
@@ -19,6 +19,7 @@ type VoconeConfig struct {
 	logLevel, dir, oracle, path, treasurer string
 	port, blockSeconds, blockSize          int
 	txCosts                                uint64
+	disableIpfs                            bool
 }
 
 func main() {
@@ -36,6 +37,7 @@ func main() {
 	flag.IntVar(&config.blockSeconds, "blockPeriod", int(vocone.DefaultBlockTimeTarget.Seconds()), "block time target in seconds")
 	flag.IntVar(&config.blockSize, "blockSize", int(vocone.DefaultTxsPerBlock), "max number of transactions per block")
 	flag.Uint64Var(&config.txCosts, "txCosts", vocone.DefaultTxCosts, "transaction cost for every transaction type")
+	flag.BoolVar(&config.disableIpfs, "disableIpfs", false, "disable built-in IPFS node")
 	flag.CommandLine.SortFlags = false
 	flag.Parse()
 
@@ -98,7 +100,7 @@ func main() {
 		}
 	}
 
-	vc, err := vocone.NewVocone(config.dir, &oracle)
+	vc, err := vocone.NewVocone(config.dir, &oracle, config.disableIpfs)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -6,6 +6,7 @@
 #  anonvoting: run anonymous vote test
 #  cspvoting: run csp vote test
 #  tokentransactions: run token transactions test (end-user voting is not included)
+#  vocli: test the CLI tool
 
 export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1
 ELECTION_SIZE=${TESTSUITE_ELECTION_SIZE:-300}
@@ -38,6 +39,7 @@ tests_to_run=(
 	"cspvoting"
 	"anonvoting"
 	"merkle_vote_encrypted"
+	"vocli"
 )
 
 # if any arg is passed, treat them as the tests to run, overriding the default list
@@ -106,6 +108,14 @@ tokentransactions() {
 		  --accountKeys=$(echo $ACCOUNT_KEYS | awk '{print $4}')
 }
 
+vocli() {
+	docker-compose run test timeout 300 \
+		./vochaintest --gwHost $GWHOST \
+		  --logLevel=$LOGLEVEL \
+		  --operation=vocli \
+		  --treasurerKey=$TREASURER_KEY
+}
+
 ### end tests definition
 
 # useful for debugging bash flow
@@ -155,7 +165,7 @@ for test in ${tests_to_run[@]} ; do
 	else
 		echo "Vochain test $test failed!"
 		echo "### Post run logs ###"
-		docker-compose logs --tail 1000
+		docker-compose logs
 		break
 	fi
 done

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,29 @@ require (
 	go.vocdoni.io/proto v1.13.3-0.20220325153537-72e8823ddb1e
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deepmap/oapi-codegen v1.8.2 // indirect
+	github.com/edsrzf/mmap-go v1.0.0 // indirect
+	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
+	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
+	github.com/graph-gophers/graphql-go v1.3.0 // indirect
+	github.com/hashicorp/go-bexpr v0.1.10 // indirect
+	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
+	github.com/holiman/uint256 v1.2.0 // indirect
+	github.com/influxdata/influxdb v1.8.3 // indirect
+	github.com/influxdata/influxdb-client-go/v2 v2.4.0 // indirect
+	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097 // indirect
+	github.com/mitchellh/pointerstructure v1.2.0 // indirect
+	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 // indirect
+	github.com/status-im/keycard-go v0.0.0-20190424133014-d95853db0f48 // indirect
+	github.com/tyler-smith/go-bip39 v1.0.2 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 )
 
 require (
@@ -125,7 +147,7 @@ require (
 	github.com/google/flatbuffers v1.12.1 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/gtank/merlin v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,7 @@ github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsP
 github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/deepmap/oapi-codegen v1.6.0/go.mod h1:ryDa9AgbELGeB+YEXE1dR53yAjHwFvE9iAUlWl9Al3M=
+github.com/deepmap/oapi-codegen v1.8.2 h1:SegyeYGcdi0jLLrpbCMoJxnUUn8GBXHsvr4rbzjuhfU=
 github.com/deepmap/oapi-codegen v1.8.2/go.mod h1:YLgSKSDv/bZQB7N4ws6luhozi3cEdRktEqrX88CvjIw=
 github.com/denisenkom/go-mssqldb v0.11.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/deroproject/graviton v0.0.0-20200906044921-89e9e09f9601/go.mod h1:lDvhst5GHvKJjUxBztS52sMmXENU5xD5oeqEmz7838Q=
@@ -426,6 +427,7 @@ github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwu
 github.com/docker/cli v20.10.8+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.7+incompatible h1:Z6O9Nhsjv+ayUEeI1IojKbYcsGdgYSNqxe1s2MYzUhQ=
 github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -764,6 +766,7 @@ github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM
 github.com/graph-gophers/graphql-go v0.0.0-20190902214650-641ae197eec7/go.mod h1:Au3iQ8DvDis8hZ4q2OzRcaKYlAsPt+fYvib5q4nIqu4=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/graph-gophers/graphql-go v0.0.0-20201113091052-beb923fada29/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
+github.com/graph-gophers/graphql-go v1.3.0 h1:Eb9x/q6MFpCLz7jBCiP/WTxjSDrYLR1QY41SORZyNJ0=
 github.com/graph-gophers/graphql-go v1.3.0/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -880,13 +883,16 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/flux v0.65.1/go.mod h1:J754/zds0vvpfwuq7Gc2wRdVwEodfpCFM7mYlOw2LqY=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb v1.7.8/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
+github.com/influxdata/influxdb v1.8.3 h1:WEypI1BQFTT4teLM+1qkEcvUi0dAvopAI/ir0vAiBg8=
 github.com/influxdata/influxdb v1.8.3/go.mod h1:JugdFhsvvI8gadxOI6noqNeeBHvWNTbfYGtiAn+2jhI=
+github.com/influxdata/influxdb-client-go/v2 v2.4.0 h1:HGBfZYStlx3Kqvsv1h2pJixbCl/jhnFtxpKFAv9Tu5k=
 github.com/influxdata/influxdb-client-go/v2 v2.4.0/go.mod h1:vLNHdxTJkIf2mSLvGrpj8TCcISApPoXkaxP8g9uRlW8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxql v1.1.1-0.20200828144457-65d3ef77d385/go.mod h1:gHp9y86a/pxhjJ+zMjNXiQAA197Xk9wLxaz+fGG+kWk=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
+github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097 h1:vilfsDSy7TDxedi9gyBkMvAirat/oRcL0lFdJBf6tdM=
 github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
@@ -1188,6 +1194,7 @@ github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVE
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
@@ -1993,6 +2000,7 @@ github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9
 github.com/performancecopilot/speed/v4 v4.0.0/go.mod h1:qxrSyuDGrTOWfV+uKRFhfxw6h/4HXRGUiZiufxo49BM=
 github.com/peterh/liner v0.0.0-20170317030525-88609521dc4b/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
+github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 h1:oYW+YCJ1pachXTQmzR3rNLYGGz4g/UgFcjb28p/viDM=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/petermattis/goid v0.0.0-20220111183729-e033e1e0bdb5 h1:AdVIf7YN+kn8QAapO6IQHtHKSBeSiNgkSS8Yai/xMmo=
@@ -2884,7 +2892,9 @@ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7 h1:BXxu8t6QN0G1uff4bzZzSkpsax8+ALqTGUtz08QrV00=
 golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -62,7 +62,7 @@ type Vocone struct {
 }
 
 // NewVocone returns a ready Vocone instance.
-func NewVocone(dataDir string, oracleKey *ethereum.SignKeys) (*Vocone, error) {
+func NewVocone(dataDir string, oracleKey *ethereum.SignKeys, disableIpfs bool) (*Vocone, error) {
 	vc := &Vocone{}
 	var err error
 	vc.app, err = vochain.NewBaseApplication(db.TypePebble, dataDir)
@@ -136,7 +136,7 @@ func NewVocone(dataDir string, oracleKey *ethereum.SignKeys) (*Vocone, error) {
 
 	// Create the IPFS storage layer
 	vc.storage, err = service.IPFS(&config.IPFSCfg{
-		ConfigPath: filepath.Join(dataDir, "ipfs"),
+		ConfigPath: filepath.Join(dataDir, "ipfs"), NoInit: disableIpfs,
 	}, nil, nil)
 
 	return vc, err

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -21,7 +21,7 @@ func TestVocone(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vc, err := NewVocone(dir, &oracle)
+	vc, err := NewVocone(dir, &oracle, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
vocli is a user-friendly CLI to send transactions to the vochain.

It can manage keys, send SetAccountInfoTx for an account, mint, send tokens, generate and claim faucet payloads.

Voting functionality is not included yet.

An integration test is included that does not test all possible options - instead it tests most functionality and requires that certain things be said in the output to help new users along.