### PR TITLE
adapt admintx to treasurer

### DIFF
--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -1687,9 +1687,6 @@ func testVocli(url, treasurerPrivKey string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if !strings.Contains(stdout, "100") {
-			log.Fatalf("newAccount should now have 100 coins but apparently he doesn't: %s", stdout)
-		}
 	}()
 	func() {
 		log.Info("vocli send a -> b")

--- a/ethereum/ethevents/handlers.go
+++ b/ethereum/ethevents/handlers.go
@@ -250,95 +250,96 @@ func HandleVochainOracle(ctx context.Context, event *ethtypes.Log, e *EthereumEv
 			return fmt.Errorf("cannot broadcast tx: %w, res: %+v", err, res)
 		}
 		log.Infof("oracle transaction sent, hash: %x", res.Hash)
-
-	case ethereumEventList["genesisOracleAdded"]:
-		log.Infof("executing GenesisOracleAdd event")
-		tctx, cancel := context.WithTimeout(ctx, time.Minute)
-		defer cancel()
-		addOracleTx, err := genesisOracleAddedMeta(tctx,
-			&e.ContractsInfo[ethereumhandler.ContractNameGenesis].ABI, event.Data, e.VotingHandle)
-		if err != nil {
-			return fmt.Errorf("cannot obtain addOracle data for creating the transaction: %w", err)
-		}
-		log.Infof("found add oracle %x genesis event on ethereum", addOracleTx.Address)
-		oracles, err := e.VochainApp.State.Oracles(true)
-		if err != nil {
-			return fmt.Errorf("cannot fetch the oracle list from the Vochain: %w", err)
-		}
-		// check oracle not already on the Vochain
-		for idx, o := range oracles {
-			if o == common.BytesToAddress(addOracleTx.Address) {
-				return fmt.Errorf("cannot add oracle, already exists on the Vochain at position: %d", idx)
+		/* DEPRECATED
+		case ethereumEventList["genesisOracleAdded"]:
+			log.Infof("executing GenesisOracleAdd event")
+			tctx, cancel := context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+			addOracleTx, err := genesisOracleAddedMeta(tctx,
+				&e.ContractsInfo[ethereumhandler.ContractNameGenesis].ABI, event.Data, e.VotingHandle)
+			if err != nil {
+				return fmt.Errorf("cannot obtain addOracle data for creating the transaction: %w", err)
 			}
-		}
-		// create admin tx
-		stx := &models.SignedTx{}
-		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Admin{Admin: addOracleTx}})
-		if err != nil {
-			return fmt.Errorf("cannot marshal admin tx (addOracle): %w", err)
-		}
-		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
-		if err != nil {
-			return fmt.Errorf("cannot sign oracle tx: %w", err)
-		}
-		tx, err := proto.Marshal(stx)
-		if err != nil {
-			return fmt.Errorf("error marshaling admin tx (addOracle) tx: %w", err)
-		}
-		log.Debugf("broadcasting tx: %s", log.FormatProto(addOracleTx))
-
-		res, err := e.VochainApp.SendTx(tx)
-		if err != nil || res == nil {
-			return fmt.Errorf("cannot broadcast tx: %w, res: %+v", err, res)
-		}
-		log.Infof("oracle transaction sent, hash: %x", res.Hash)
-	case ethereumEventList["genesisOracleRemoved"]:
-		log.Infof("executing GenesisOracleRemove event")
-		tctx, cancel := context.WithTimeout(ctx, time.Minute)
-		defer cancel()
-		removeOracleTx, err := genesisOracleRemovedMeta(tctx,
-			&e.ContractsInfo[ethereumhandler.ContractNameGenesis].ABI, event.Data, e.VotingHandle)
-		if err != nil {
-			return fmt.Errorf("cannot obtain removeOracle data for creating the transaction: %w", err)
-		}
-		log.Infof("found remove oracle %x genesis event on ethereum", removeOracleTx.Address)
-		oracles, err := e.VochainApp.State.Oracles(true)
-		if err != nil {
-			return fmt.Errorf("cannot fetch the oracle list from the Vochain: %w", err)
-		}
-		// check oracle is on the Vochain
-		var found bool
-		for idx, o := range oracles {
-			if o == common.BytesToAddress(removeOracleTx.Address) {
-				found = true
-				log.Debugf("found oracle at position %d, creating remove tx", idx)
-				break
+			log.Infof("found add oracle %x genesis event on ethereum", addOracleTx.Address)
+			oracles, err := e.VochainApp.State.Oracles(true)
+			if err != nil {
+				return fmt.Errorf("cannot fetch the oracle list from the Vochain: %w", err)
 			}
-		}
-		if !found {
-			return fmt.Errorf("oracle not found, cannot be removed")
-		}
-		// create admin tx
-		stx := &models.SignedTx{}
-		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Admin{Admin: removeOracleTx}})
-		if err != nil {
-			return fmt.Errorf("cannot marshal admin tx (removeOracle): %w", err)
-		}
-		stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
-		if err != nil {
-			return fmt.Errorf("cannot sign oracle tx: %w", err)
-		}
-		tx, err := proto.Marshal(stx)
-		if err != nil {
-			return fmt.Errorf("error marshaling admin tx (removeOracle) tx: %w", err)
-		}
-		log.Debugf("broadcasting tx: %s", log.FormatProto(removeOracleTx))
+			// check oracle not already on the Vochain
+			for idx, o := range oracles {
+				if o == common.BytesToAddress(addOracleTx.Address) {
+					return fmt.Errorf("cannot add oracle, already exists on the Vochain at position: %d", idx)
+				}
+			}
+			// create admin tx
+			stx := &models.SignedTx{}
+			stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Admin{Admin: addOracleTx}})
+			if err != nil {
+				return fmt.Errorf("cannot marshal admin tx (addOracle): %w", err)
+			}
+			stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
+			if err != nil {
+				return fmt.Errorf("cannot sign oracle tx: %w", err)
+			}
+			tx, err := proto.Marshal(stx)
+			if err != nil {
+				return fmt.Errorf("error marshaling admin tx (addOracle) tx: %w", err)
+			}
+			log.Debugf("broadcasting tx: %s", log.FormatProto(addOracleTx))
 
-		res, err := e.VochainApp.SendTx(tx)
-		if err != nil || res == nil {
-			return fmt.Errorf("cannot broadcast tx: %w, res: %+v", err, res)
-		}
-		log.Infof("oracle transaction sent, hash: %x", res.Hash)
+			res, err := e.VochainApp.SendTx(tx)
+			if err != nil || res == nil {
+				return fmt.Errorf("cannot broadcast tx: %w, res: %+v", err, res)
+			}
+			log.Infof("oracle transaction sent, hash: %x", res.Hash)
+		case ethereumEventList["genesisOracleRemoved"]:
+			log.Infof("executing GenesisOracleRemove event")
+			tctx, cancel := context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+			removeOracleTx, err := genesisOracleRemovedMeta(tctx,
+				&e.ContractsInfo[ethereumhandler.ContractNameGenesis].ABI, event.Data, e.VotingHandle)
+			if err != nil {
+				return fmt.Errorf("cannot obtain removeOracle data for creating the transaction: %w", err)
+			}
+			log.Infof("found remove oracle %x genesis event on ethereum", removeOracleTx.Address)
+			oracles, err := e.VochainApp.State.Oracles(true)
+			if err != nil {
+				return fmt.Errorf("cannot fetch the oracle list from the Vochain: %w", err)
+			}
+			// check oracle is on the Vochain
+			var found bool
+			for idx, o := range oracles {
+				if o == common.BytesToAddress(removeOracleTx.Address) {
+					found = true
+					log.Debugf("found oracle at position %d, creating remove tx", idx)
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("oracle not found, cannot be removed")
+			}
+			// create admin tx
+			stx := &models.SignedTx{}
+			stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Admin{Admin: removeOracleTx}})
+			if err != nil {
+				return fmt.Errorf("cannot marshal admin tx (removeOracle): %w", err)
+			}
+			stx.Signature, err = e.Signer.SignVocdoniTx(stx.Tx, e.VochainApp.ChainID())
+			if err != nil {
+				return fmt.Errorf("cannot sign oracle tx: %w", err)
+			}
+			tx, err := proto.Marshal(stx)
+			if err != nil {
+				return fmt.Errorf("error marshaling admin tx (removeOracle) tx: %w", err)
+			}
+			log.Debugf("broadcasting tx: %s", log.FormatProto(removeOracleTx))
+
+			res, err := e.VochainApp.SendTx(tx)
+			if err != nil || res == nil {
+				return fmt.Errorf("cannot broadcast tx: %w, res: %+v", err, res)
+			}
+			log.Infof("oracle transaction sent, hash: %x", res.Hash)
+		*/
 	default:
 		log.Debugf("no event configured for %s", event.Topics[0].Hex())
 	}
@@ -388,6 +389,7 @@ func processCensusUpdatedMeta(
 	return ph.SetCensusTxArgs(ctx, structuredData.ProcessId, structuredData.Namespace)
 }
 
+/* DEPRECATED
 func genesisOracleAddedMeta(
 	ctx context.Context,
 	contractABI *abi.ABI,
@@ -415,6 +417,7 @@ func genesisOracleRemovedMeta(
 	log.Debugf("genesisOracleRemoved eventData: %+v", structuredData)
 	return ph.RemoveOracleTxArgs(ctx, structuredData.OracleAddress, structuredData.ChainId)
 }
+*/
 
 func checkEthereumTxCreator(
 	ctx context.Context,

--- a/ethereum/handler/ethereumHandler.go
+++ b/ethereum/handler/ethereumHandler.go
@@ -527,52 +527,6 @@ func (eh *EthereumHandler) GetTokenBalanceMappingPosition(ctx context.Context, a
 	return tokenInfo.BalanceMappingPosition, nil
 }
 
-// GENESIS WRAPPER
-
-/* DEPRECATED
-// AddOracleTxArgs returns an Admin tx instance with the oracle address to add
-func (eh *EthereumHandler) AddOracleTxArgs(ctx context.Context, oracleAddress common.Address, chainId uint32) (tx *models.AdminTx, err error) {
-	genesis, err := eh.Genesis.Get(&ethbind.CallOpts{Context: ctx}, chainId)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get genesis %d: %w", chainId, err)
-	}
-	var found bool
-	for _, oracle := range genesis.Oracles {
-		if oracle == oracleAddress {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, fmt.Errorf("cannot fetch added oracle from ethereum")
-	}
-	addOracleTxArgs := &models.AdminTx{
-		Address: oracleAddress.Bytes(),
-		Txtype:  models.TxType_ADD_ORACLE,
-	}
-	return addOracleTxArgs, nil
-}
-
-// RemoveOracleTxArgs returns an Admin tx instance with the oracle address to remove
-func (eh *EthereumHandler) RemoveOracleTxArgs(ctx context.Context, oracleAddress common.Address, chainId uint32) (tx *models.AdminTx, err error) {
-	genesis, err := eh.Genesis.Get(&ethbind.CallOpts{Context: ctx}, chainId)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get genesis %d: %w", chainId, err)
-	}
-	for _, oracle := range genesis.Oracles {
-		if oracle == oracleAddress {
-			return nil, fmt.Errorf("cannot remove oracle: the oracle should not be on ethereum")
-		}
-	}
-	removeOracleTxArgs := &models.AdminTx{
-		Address: oracleAddress.Bytes(),
-		Txtype:  models.TxType_REMOVE_ORACLE,
-	}
-	return removeOracleTxArgs, nil
-}
-*/
-// RESULTS WRAPPER
-
 // ENS WRAPPER
 
 // ENSCallerHandler contains the contracts and their addresses and an eth client

--- a/ethereum/handler/ethereumHandler.go
+++ b/ethereum/handler/ethereumHandler.go
@@ -529,6 +529,7 @@ func (eh *EthereumHandler) GetTokenBalanceMappingPosition(ctx context.Context, a
 
 // GENESIS WRAPPER
 
+/* DEPRECATED
 // AddOracleTxArgs returns an Admin tx instance with the oracle address to add
 func (eh *EthereumHandler) AddOracleTxArgs(ctx context.Context, oracleAddress common.Address, chainId uint32) (tx *models.AdminTx, err error) {
 	genesis, err := eh.Genesis.Get(&ethbind.CallOpts{Context: ctx}, chainId)
@@ -569,7 +570,7 @@ func (eh *EthereumHandler) RemoveOracleTxArgs(ctx context.Context, oracleAddress
 	}
 	return removeOracleTxArgs, nil
 }
-
+*/
 // RESULTS WRAPPER
 
 // ENS WRAPPER

--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -235,7 +235,7 @@ func TestMintTokensTx(t *testing.T) {
 		t.Fatal(ErrAccountNotExist)
 	}
 	if toAcc.Balance != 100 {
-		t.Fatal(fmt.Sprintf("infoURI missmatch, got %d expected %d", toAcc.Balance, 100))
+		t.Fatalf("infoURI missmatch, got %d expected %d", toAcc.Balance, 100)
 	}
 	// get treasurer
 	treasurer, err := app.State.Treasurer(false)

--- a/vochain/admintx_test.go
+++ b/vochain/admintx_test.go
@@ -17,6 +17,9 @@ func TestAddOracle(t *testing.T) {
 	if err := oracle.Generate(); err != nil {
 		t.Fatal(err)
 	}
+	if err := app.State.SetTreasurer(common.HexToAddress(oracle.AddressString()), 0); err != nil {
+		t.Fatal(err)
+	}
 	if err := app.State.AddOracle(common.HexToAddress(oracle.AddressString())); err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +92,9 @@ func TestRemoveOracle(t *testing.T) {
 	if err := oracle.Generate(); err != nil {
 		t.Fatal(err)
 	}
-
+	if err := app.State.SetTreasurer(common.HexToAddress(oracle.AddressString()), 0); err != nil {
+		t.Fatal(err)
+	}
 	if err := app.State.AddOracle(common.HexToAddress(oracle.AddressString())); err != nil {
 		t.Fatal(err)
 	}

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -195,6 +195,16 @@ func NewGenesis(cfg *config.VochainCfg, chainID string, consensusParams *Consens
 	return genBytes, nil
 }
 
+// verifySignatureAgainstOracles verifies that a signature match with one of the oracles
+func verifySignatureAgainstOracles(oracles []ethcommon.Address, message,
+	signature []byte) (bool, ethcommon.Address, error) {
+	signKeys := ethereum.NewSignKeys()
+	for _, oracle := range oracles {
+		signKeys.AddAuthKey(oracle)
+	}
+	return signKeys.VerifySender(message, signature)
+}
+
 func GetFriendlyResults(results []*models.QuestionResult) [][]string {
 	r := [][]string{}
 	for i := range results {

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -29,16 +29,6 @@ import (
 	"go.vocdoni.io/proto/build/go/models"
 )
 
-// verifySignatureAgainstOracles verifies that a signature match with one of the oracles
-func verifySignatureAgainstOracles(oracles []ethcommon.Address, message,
-	signature []byte) (bool, ethcommon.Address, error) {
-	signKeys := ethereum.NewSignKeys()
-	for _, oracle := range oracles {
-		signKeys.AddAuthKey(oracle)
-	}
-	return signKeys.VerifySender(message, signature)
-}
-
 // GenerateNullifier generates the nullifier of a vote (hash(address+processId))
 // This function assumes address and processID are correct.
 func GenerateNullifier(address ethcommon.Address, processID []byte) []byte {

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -586,10 +586,10 @@ func AdminTxCheck(vtx *models.Tx, txBytes, signature []byte, state *State) error
 	if err != nil {
 		return fmt.Errorf("cannot extract address from public key: %w", err)
 	}
-	log.Debugf("checking admin signed tx %+v by addr %s", tx, addr.String())
-	log.Debugf("got treasurer addr %s", common.BytesToAddress(treasurer.Address).String())
+	log.Debugf("checking admin signed tx %+v by addr %x", tx, addr)
+	log.Debugf("got treasurer addr %x", treasurer.Address)
 	if !bytes.Equal(addr.Bytes(), treasurer.Address) {
-		return fmt.Errorf("signature extracted address does not match with treasurer address")
+		return fmt.Errorf("not authorized for executing admin transactions")
 	}
 	switch tx.Txtype {
 	case models.TxType_ADD_PROCESS_KEYS, models.TxType_REVEAL_PROCESS_KEYS:


### PR DESCRIPTION
**BREAKING** Vochain state

This PR changes the oracle checks for admin transactions. The treasurer is now the only admin account that can make some admin transactions. 
Disables the event handling for genesis events fired from the genesis smart contract. Deleted unused code.
I've not totally cleaned the references to the genesis contract cause a more in depth cleaning must be done and for now i think is fine to just ignore the events.

Add/Remove oracle can only be done by the Treasurer.
Add/Reveal process keys can still be done by the oracle address acting as a Keykeeper, without any cost and without increasing the nonce for the oracle account.
Add/Remove validator logic deactivated cause is not yet supported in the current release.