### PR TITLE
vochain: implements deterministic process ID type

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -181,6 +181,7 @@ type APIresponse struct {
 	Files                []byte                           `json:"files,omitempty"`
 	Final                *bool                            `json:"final,omitempty"`
 	Finished             *bool                            `json:"finished,omitempty"`
+	Hash                 types.HexBytes                   `json:"hash,omitempty"`
 	Health               int32                            `json:"health,omitempty"`
 	Height               *uint32                          `json:"height,omitempty"`
 	InvalidClaims        []int                            `json:"invalidClaims,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -64,10 +64,10 @@ require (
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.19.1
-	go.vocdoni.io/proto v1.13.3-0.20220325153537-72e8823ddb1e
+	go.vocdoni.io/proto v1.13.3-0.20220427175359-1eda30cea4bc
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
 	google.golang.org/protobuf v1.27.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2508,8 +2508,8 @@ go.vocdoni.io/proto v0.1.8/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M
 go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
 go.vocdoni.io/proto v1.13.3-0.20211019215004-0ca7d4436553/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
-go.vocdoni.io/proto v1.13.3-0.20220325153537-72e8823ddb1e h1:TK6ImPFz0pcwQwT989GUhtAuGnEyShMp6xA+ZtPDr/I=
-go.vocdoni.io/proto v1.13.3-0.20220325153537-72e8823ddb1e/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
+go.vocdoni.io/proto v1.13.3-0.20220427175359-1eda30cea4bc h1:t46M4g7zFFGk+Hep4u5iNdqsDfZiceFzD764qbOzr/U=
+go.vocdoni.io/proto v1.13.3-0.20220427175359-1eda30cea4bc/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20200411211856-f5505b9728dd/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=
 go4.org v0.0.0-20201209231011-d4a079459e60 h1:iqAGo78tVOJXELHQFRjR6TMwItrvXH4hrGJ32I/NFF8=
@@ -2892,10 +2892,10 @@ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7 h1:BXxu8t6QN0G1uff4bzZzSkpsax8+ALqTGUtz08QrV00=
 golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 h1:EH1Deb8WZJ0xc0WK//leUHXcX9aLE5SymusoTmMZye8=
+golang.org/x/term v0.0.0-20220411215600-e5f449aeb171/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/rpcapi/votehandlers.go
+++ b/rpcapi/votehandlers.go
@@ -29,7 +29,8 @@ func (r *RPCAPI) submitRawTx(request *api.APIrequest) (*api.APIresponse, error) 
 	}
 	log.Debugf("broadcasting tx hash:%s", res.Hash)
 	// return nullifier or other info
-	return &api.APIresponse{Payload: fmt.Sprintf("%x", res.Data)}, nil
+	// TODO @pau: replace Payload by something else more descriptive and using types.HexBytes
+	return &api.APIresponse{Payload: fmt.Sprintf("%x", res.Data), Hash: res.Hash.Bytes()}, nil
 }
 
 func (a *RPCAPI) submitEnvelope(request *api.APIrequest) (*api.APIresponse, error) {

--- a/vochain/process_id.go
+++ b/vochain/process_id.go
@@ -1,0 +1,178 @@
+package vochain
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+// ProcessID is a 32 bytes identifier that holds the following information about the voting process:
+//
+// - chainID: a 6 bytes trunked hash of the blockchain identifier
+//
+// - organization: hex address of the wallet creating the process
+//
+// - census origin: kind of census used for the process (from protobuf models)
+//
+// - envelope type: ballot properties configuration
+//
+// - nonce: an incremental uint32 number
+//
+// processID: 395b41cc9abcd8da6bf26964af9d7eed9e03e53415d37aa96045000600000001 represents
+// chID:vocdoni-azeno addr:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 pt:arbo nc:1
+type ProcessID struct {
+	chainID          string
+	organizationAddr common.Address
+	censusOrigin     uint8
+	envType          uint8
+	nonce            uint32
+}
+
+// Marshal encodes to bytes
+func (p *ProcessID) Marshal() []byte {
+	// processID =
+	//  chainID[6bytes] + organizationAddress[20bytes] + proofType[1byte] + envelopeType[1byte] + nonce[4bytes]
+	chainID := ethereum.HashRaw([]byte(p.chainID))
+
+	nonce := make([]byte, 4)
+	binary.BigEndian.PutUint32(nonce, uint32(p.nonce))
+
+	proofType := make([]byte, 2)
+	binary.BigEndian.PutUint16(proofType, uint16(p.censusOrigin))
+
+	envType := make([]byte, 2)
+	binary.BigEndian.PutUint16(envType, uint16(p.envType))
+
+	id := make([]byte, 32)
+	id = append(chainID[:6], p.organizationAddr.Bytes()[:20]...)
+	id = append(id, proofType[1:]...)
+	id = append(id, envType[1:]...)
+	return append(id, nonce[:4]...)
+}
+
+// MarshalBinary implements the BinaryMarshaler interface
+func (p *ProcessID) MarshalBinary() (data []byte, err error) {
+	return p.Marshal(), nil
+}
+
+// UnmarshalBinary implements the BinaryMarshaler interface
+func (p *ProcessID) UnmarshalBinary(data []byte) error {
+	return p.Unmarshal(data)
+}
+
+// Unmarshal decodes a 32 byte payload into the process ID fields
+func (p *ProcessID) Unmarshal(pid []byte) error {
+	if len(pid) != 32 {
+		return fmt.Errorf("processID lenght not correct")
+	}
+
+	p.chainID = fmt.Sprintf("%x", pid[:4])
+
+	baddr := make([]byte, 20)
+	copy(baddr[:], pid[6:26])
+	p.organizationAddr = common.BytesToAddress(baddr)
+
+	p.censusOrigin = uint8(binary.BigEndian.Uint16(append([]byte{0x00}, pid[26:27]...)))
+	if p.censusOrigin == 0 {
+		return fmt.Errorf("cannot unmarshal processID: census origin is invalid")
+	}
+
+	p.envType = uint8(binary.BigEndian.Uint16(append([]byte{0x00}, pid[27:28]...)))
+	if types.ProcessesContractMaxEnvelopeType < p.envType {
+		return fmt.Errorf("cannot unmarshal processID: overflow on envelope type %d", p.envType)
+	}
+
+	p.nonce = binary.BigEndian.Uint32(pid[28:32])
+	return nil
+}
+
+// String returns a human readable representation of process ID
+func (p *ProcessID) String() string {
+	return fmt.Sprintf("[chID:%s/addr:%s/co:%d/et:%d/nc:%d]",
+		p.chainID, p.organizationAddr.Hex(), p.censusOrigin, p.envType, p.nonce)
+
+}
+
+// SetChainID sets the blockchain identifier
+func (p *ProcessID) SetChainID(chID string) {
+	p.chainID = chID
+}
+
+// ChainID returns blockchain identifier
+func (p *ProcessID) ChainID() string {
+	return p.chainID
+}
+
+// SetAddr sets the organizer address (20 bytes)
+func (p *ProcessID) SetAddr(addr common.Address) {
+	p.organizationAddr = common.BytesToAddress(addr.Bytes())
+}
+
+// Addr returns the organizer address
+func (p *ProcessID) Addr() common.Address {
+	return common.BytesToAddress(p.organizationAddr.Bytes())
+}
+
+// SetNonce sets the nonce number that identifies the process
+func (p *ProcessID) SetNonce(nonce uint32) {
+	p.nonce = nonce
+}
+
+// Nonce returns the process ID identifier number
+func (p *ProcessID) Nonce() uint32 {
+	return p.nonce
+}
+
+// SetCensusOrigin sets the census origin type
+func (p *ProcessID) SetCensusOrigin(csOrg models.CensusOrigin) error {
+	if csOrg == 0 || csOrg > 255 {
+		return fmt.Errorf("cannot set census origin for processID: invalid value")
+	}
+	p.censusOrigin = uint8(csOrg)
+	return nil
+}
+
+// CensusOrigin returns the encoded census origin
+func (p *ProcessID) CensusOrigin() models.CensusOrigin {
+	return models.CensusOrigin(p.censusOrigin)
+}
+
+// SetEnvelopeType sets the envelope type for the process
+func (p *ProcessID) SetEnvelopeType(et *models.EnvelopeType) error {
+	if et == nil {
+		return fmt.Errorf("invalid envelope type: (%s)", log.FormatProto(et))
+	}
+	p.envType = 0
+	if et.Serial {
+		p.envType = p.envType | byte(0b00000001)
+	}
+	if et.Anonymous {
+		p.envType = p.envType | byte(0b00000010)
+	}
+	if et.EncryptedVotes {
+		p.envType = p.envType | byte(0b00000100)
+	}
+	if et.UniqueValues {
+		p.envType = p.envType | byte(0b00001000)
+	}
+	if et.CostFromWeight {
+		p.envType = p.envType | byte(0b00010000)
+	}
+	return nil
+}
+
+// EnvelopeType returns the envelope type encoded into the process ID
+func (p *ProcessID) EnvelopeType() *models.EnvelopeType {
+	return &models.EnvelopeType{
+		Serial:         p.envType&byte(0b00000001) > 0,
+		Anonymous:      p.envType&byte(0b00000010) > 0,
+		EncryptedVotes: p.envType&byte(0b00000100) > 0,
+		UniqueValues:   p.envType&byte(0b00001000) > 0,
+		CostFromWeight: p.envType&byte(0b00010000) > 0,
+	}
+}

--- a/vochain/process_id.go
+++ b/vochain/process_id.go
@@ -176,3 +176,22 @@ func (p *ProcessID) EnvelopeType() *models.EnvelopeType {
 		CostFromWeight: p.envType&byte(0b00010000) > 0,
 	}
 }
+
+func (a *BaseApplication) BuildProcessID(proc *models.Process) (*ProcessID, error) {
+	pid := new(ProcessID)
+	pid.SetChainID(a.ChainID())
+	if err := pid.SetEnvelopeType(proc.EnvelopeType); err != nil {
+		return nil, err
+	}
+	if err := pid.SetCensusOrigin(proc.CensusOrigin); err != nil {
+		return nil, err
+	}
+	addr := common.BytesToAddress(proc.EntityId)
+	acc, err := a.State.GetAccount(addr, false)
+	if err != nil {
+		return nil, err
+	}
+	pid.SetAddr(addr)
+	pid.SetNonce(acc.GetProcessIndex())
+	return pid, nil
+}

--- a/vochain/process_id_test.go
+++ b/vochain/process_id_test.go
@@ -1,0 +1,59 @@
+package vochain
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+const test_vbAddr = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+const test_chID = "vocdoni-azeno"
+
+func TestProcessID(t *testing.T) {
+	pid := ProcessID{}
+	pid.SetAddr(common.HexToAddress(test_vbAddr))
+	pid.SetNonce(1)
+	pid.SetChainID(test_chID)
+	csOrg := models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED
+	pid.SetCensusOrigin(csOrg)
+	pid.SetNonce(1)
+	pid.SetEnvelopeType(&models.EnvelopeType{Serial: true, CostFromWeight: true, EncryptedVotes: true})
+
+	et := pid.EnvelopeType()
+	qt.Assert(t, et.Serial, qt.Equals, true)
+	qt.Assert(t, et.CostFromWeight, qt.Equals, true)
+	qt.Assert(t, et.UniqueValues, qt.Equals, false)
+	qt.Assert(t, et.EncryptedVotes, qt.Equals, true)
+	qt.Assert(t, et.Anonymous, qt.Equals, false)
+
+	pid2 := ProcessID{}
+	b, err := hex.DecodeString("395b41cc9abcd8da6bf26964af9d7eed9e03e53415d37aa96045021300000002")
+	qt.Assert(t, err, qt.IsNil)
+	err = pid2.Unmarshal(b)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, pid2.Nonce(), qt.Equals, uint32(2))
+	qt.Assert(t, pid2.CensusOrigin(), qt.Equals, models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED)
+	qt.Assert(t, pid2.envType, qt.Equals, uint8(0x13))
+
+	// 0x13 = 10011
+	et = pid2.EnvelopeType()
+	qt.Assert(t, et.Serial, qt.Equals, true)
+	qt.Assert(t, et.CostFromWeight, qt.Equals, true)
+	qt.Assert(t, et.UniqueValues, qt.Equals, false)
+	qt.Assert(t, et.EncryptedVotes, qt.Equals, false)
+	qt.Assert(t, et.Anonymous, qt.Equals, true)
+
+	csOrg = models.CensusOrigin_ERC20
+	err = pid.SetCensusOrigin(csOrg)
+	qt.Assert(t, err, qt.IsNil)
+	err = pid2.Unmarshal(pid.Marshal())
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, pid2.CensusOrigin(), qt.Equals, models.CensusOrigin_ERC20)
+	qt.Assert(t, pid2.Addr().Hex(), qt.Equals, test_vbAddr)
+
+	err = pid.SetCensusOrigin(777)
+	qt.Assert(t, err, qt.IsNotNil)
+}

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -44,17 +44,15 @@ func testCSPvote(oracle *ethereum.SignKeys, url string) error {
 	cspKey.Generate()
 	entityID := util.RandomBytes(20)
 	censusRoot := cspKey.PublicKey()
-	processID := util.RandomBytes(32)
 	envelope := new(models.EnvelopeType)
 	censusOrigin := models.CensusOrigin_OFF_CHAIN_CA
 	duration := 100
 	censusSize := 10
-	startBlock, err := cli.CreateProcess(
+	startBlock, processID, err := cli.CreateProcess(
 		oracle,
 		entityID,
 		censusRoot,
 		"",
-		processID,
 		envelope,
 		nil,
 		censusOrigin,
@@ -65,7 +63,6 @@ func testCSPvote(oracle *ethereum.SignKeys, url string) error {
 	if err != nil {
 		return err
 	}
-
 	voterKeys := util.CreateEthRandomKeysBatch(censusSize)
 	proofs, err := cli.GetCSPproofBatch(voterKeys, &cspKey, processID)
 	if err != nil {


### PR DESCRIPTION
Introduce a new type `ProcessID` with Marshal and Unmarshal methods.

The new identifier holds information about the process
- chainID: a 6 bytes trunked hash of the blockchain identifier
- organization: hex address of the wallet creating the process
- census proof type: kind of census used for the process (from protobuf models)
- envelope type: flags for configuring the ballot counting mode
- nonce: an incremental uint32 number

So processID: 395b41cc9abcd8da6bf26964af9d7eed9e03e53415d37aa96045062100000001  represents
- chID: vocdoni-azeno
- addr: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
- proof: arbo
- envelopetype: 0x21
- nonce: 1

This commit only introduces the new type, not the required changes on the blockchain logic.

Discussion: https://github.com/vocdoni/protocol/discussions/28

Signed-off-by: p4u <pau@dabax.net>