### PR TITLE
WIP: import state from snapshot

### DIFF
--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -160,6 +160,10 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 		"enables the process archiver component")
 	globalCfg.VochainConfig.ProcessArchiveKey = *flag.String("processArchiveKey", "",
 		"IPFS base64 encoded private key for process archive IPNS")
+	globalCfg.VochainConfig.SnapshotURL = *flag.String("snapshotURL", "",
+		"starts the vochain importing a vochain state snapshot from the given local path or remote")
+	globalCfg.VochainConfig.ForceResync = *flag.Bool("vochainForceResync", false,
+		"if enabled overrides the node data with the content fetched from --snapshotURL")
 
 	// metrics
 	globalCfg.Metrics.Enabled = *flag.Bool("metricsEnabled", false, "enable prometheus metrics")
@@ -256,6 +260,8 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 	viper.Set("vochainConfig.ProcessArchiveDataDir", globalCfg.DataDir+"/archive")
 	viper.BindPFlag("vochainConfig.ProcessArchive", flag.Lookup("processArchive"))
 	viper.BindPFlag("vochainConfig.ProcessArchiveKey", flag.Lookup("processArchiveKey"))
+	viper.BindPFlag("vochainConfig.SnapshotURL", flag.Lookup("snapshotURL"))
+	viper.BindPFlag("vochainConfig.ForceResync", flag.Lookup("vochainForceResync"))
 
 	// metrics
 	viper.BindPFlag("metrics.Enabled", flag.Lookup("metricsEnabled"))

--- a/config/config.go
+++ b/config/config.go
@@ -198,6 +198,12 @@ type VochainCfg struct {
 	Scrutinizer ScrutinizerCfg
 	// IsSeedNode specifies if the node is configured to act as a seed node
 	IsSeedNode bool
+	// SnapshotURL imports a compressed file that contains a snapshot
+	// of the state
+	SnapshotURL string
+	// ForceResync forces the node to start with the data fetched from SnapshotURL.
+	// Overrides the node data
+	ForceResync bool
 }
 
 // ScrutinizerCfg handles the configuration options of the scrutinizer

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	git.sr.ht/~sircmpwn/go-bare v0.0.0-20210406120253-ab86bc2846d9
 	github.com/766b/chi-prometheus v0.0.0-20211217152057-87afa9aa2ca8
 	github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211204171003-644e7408753f
+	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cockroachdb/pebble v0.0.0-20220224015757-894b57aa32be
 	github.com/cosmos/iavl v0.15.3
 	github.com/deroproject/graviton v0.0.0-20201218180342-ab474f4c94d2

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/casbin/casbin/v2 v2.37.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
+github.com/cavaliergopher/grab/v3 v3.0.1 h1:4z7TkBfmPjmLAAmkkAZNX/6QJ1nNFdv3SdIHXju0Fr4=
+github.com/cavaliergopher/grab/v3 v3.0.1/go.mod h1:1U/KNnD+Ft6JJiYoYBAimKH2XrYptb8Kl3DFGmsjpq4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -302,13 +302,8 @@ func Untar(src string, destination string) error {
 
 // FetchFile downloads a file from a given URL
 func FetchFile(destDir, url string) (string, error) {
-	// check if dest dir exists
-	if _, err := os.Stat(destDir); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(destDir, 0o777); err != nil {
-			return "", fmt.Errorf("cannot create destination directory: %w", err)
-		}
-	} else if err != nil {
-		return "", fmt.Errorf("cannot check if destination directory exists")
+	if err := os.MkdirAll(destDir, 0o777); err != nil {
+		return "", fmt.Errorf("cannot create destination directory: %w", err)
 	}
 	client := grab.NewClient()
 	req, _ := grab.NewRequest(destDir, url)
@@ -322,7 +317,7 @@ loop:
 		case <-t.C:
 			log.Infof("transferred %d / %d bytes (%.2f%%)",
 				resp.BytesComplete(),
-				resp.Size,
+				resp.Size(),
 				100*resp.Progress(),
 			)
 
@@ -334,5 +329,6 @@ loop:
 	if err := resp.Err(); err != nil {
 		return "", fmt.Errorf("download failed: %w", err)
 	}
+	log.Infof("%s saved at %s", filepath.Base(resp.Filename), destDir)
 	return resp.Filename, nil
 }

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -64,9 +64,9 @@ func NewVochain(vochaincfg *config.VochainCfg, genesis []byte) *BaseApplication 
 		log.Infof("importing snapshot...")
 		snapshotPath, err := FetchFile(filepath.Join(vochaincfg.DataDir, "snapshot"), vochaincfg.SnapshotURL)
 		if err != nil {
-			log.Fatalf("cannot import snapshot: %s", err)
+			log.Fatalf("cannot download snapshot: %s", err)
 		}
-		log.Infof("snapshot successfully imported !")
+		log.Infof("snapshot successfully downloaded!")
 		if vochaincfg.ForceResync {
 			if err := restoreStateFromSnapshot(filepath.Join(vochaincfg.DataDir, "data"), snapshotPath); err != nil {
 				log.Fatalf("cannot restore state from snapshot: %s", err)
@@ -660,13 +660,9 @@ func AminoPubKey(pubkey []byte) ([]byte, error) {
 
 // restoreStateFromSnapshot overrides the node data with a given snapshot
 func restoreStateFromSnapshot(dataDir, src string) error {
-	log.Infof("deleting old datadir ... %s", dataDir)
-	if _, err := os.Stat(dataDir); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("cannot check if destination directory exists")
-	} else if err != nil {
-		if err := os.RemoveAll(dataDir); err != nil {
-			return fmt.Errorf("cannot clean directory before applying the snapshot")
-		}
+	log.Infof("cleaning up old datadir %s before applying the snapshot", dataDir)
+	if err := os.RemoveAll(dataDir); err != nil {
+		return fmt.Errorf("cannot clean old datadir: %w", err)
 	}
 	log.Infof("decompressing snapshot ...")
 	if err := Untar(


### PR DESCRIPTION
add --snapshotURL and --vochainForceResync flags
and the underlying functionality

The former is used for passing an URL from which to
download a state snapshot compressed file.
If forceResync is set to true all existing
vochain data will be wiped and replaced by
the decompressed one extracted from the
downloaded snapshot, otherwise the downloaded
state snapshot compressed file will just be saved.