### PR TITLE
import state from snapshot (release-1.3)

### DIFF
--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -158,6 +158,10 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 		"enables the process archiver component")
 	globalCfg.VochainConfig.ProcessArchiveKey = *flag.String("processArchiveKey", "",
 		"IPFS base64 encoded private key for process archive IPNS")
+	globalCfg.VochainConfig.SnapshotURL = *flag.String("snapshotURL", "",
+		"starts the vochain importing a vochain state snapshot from the given local path or remote")
+	globalCfg.VochainConfig.ForceResync = *flag.Bool("vochainForceResync", false,
+		"if enabled overrides the node data with the content fetched from --snapshotURL")
 
 	// metrics
 	globalCfg.Metrics.Enabled = *flag.Bool("metricsEnabled", false, "enable prometheus metrics")
@@ -255,6 +259,8 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 	viper.Set("vochainConfig.ProcessArchiveDataDir", globalCfg.DataDir+"/archive")
 	viper.BindPFlag("vochainConfig.ProcessArchive", flag.Lookup("processArchive"))
 	viper.BindPFlag("vochainConfig.ProcessArchiveKey", flag.Lookup("processArchiveKey"))
+	viper.BindPFlag("vochainConfig.SnapshotURL", flag.Lookup("snapshotURL"))
+	viper.BindPFlag("vochainConfig.ForceResync", flag.Lookup("vochainForceResync"))
 
 	// metrics
 	viper.BindPFlag("metrics.Enabled", flag.Lookup("metricsEnabled"))

--- a/config/config.go
+++ b/config/config.go
@@ -180,6 +180,12 @@ type VochainCfg struct {
 	ProcessArchiveDataDir string
 	// Scrutinizer holds the configuration regarding the scrutinizer component
 	Scrutinizer ScrutinizerCfg
+	// SnapshotURL imports a compressed file that contains a snapshot
+	// of the state
+	SnapshotURL string
+	// ForceResync forces the node to start with the data fetched from SnapshotURL.
+	// Overrides the node data
+	ForceResync bool
 }
 
 // ScrutinizerCfg handles the configuration options of the scrutinizer

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace github.com/timshannon/badgerhold/v3 => github.com/vocdoni/badgerhold/v3 
 require (
 	git.sr.ht/~sircmpwn/go-bare v0.0.0-20210227202403-5dae5c48f917
 	github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210203222605-876755a714c3
+	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cosmos/iavl v0.15.3
 	github.com/deroproject/graviton v0.0.0-20200906044921-89e9e09f9601
 	github.com/dgraph-io/badger/v2 v2.2007.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/cavaliergopher/grab/v3 v3.0.1 h1:4z7TkBfmPjmLAAmkkAZNX/6QJ1nNFdv3SdIHXju0Fr4=
+github.com/cavaliergopher/grab/v3 v3.0.1/go.mod h1:1U/KNnD+Ft6JJiYoYBAimKH2XrYptb8Kl3DFGmsjpq4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -1927,10 +1929,6 @@ go.vocdoni.io/dvote v1.0.0/go.mod h1:C9wjSWCzy33Bl2sNiF/2ie/oxcERR3uRD2G2c/NDeH0
 go.vocdoni.io/proto v0.1.7/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.8/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
-go.vocdoni.io/proto v1.0.4-0.20210719161241-4f28acf85d46 h1:YDoWyKTNIa8bCkUYOujon16SBZlKovhfk+RWoYjEumE=
-go.vocdoni.io/proto v1.0.4-0.20210719161241-4f28acf85d46/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
-go.vocdoni.io/proto v1.0.4-0.20211115202546-b57641192858 h1:DYWDYdXglxYzIeYtkgP62R6mhseTWH1fGdOFALRmUGg=
-go.vocdoni.io/proto v1.0.4-0.20211115202546-b57641192858/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
 go.vocdoni.io/proto v1.0.4-0.20211213155419-54f0e2bb6dd6 h1:V+jTYsEJL/KVVHN0rESDb9Cxr5860VT1afaxSA1oJ2U=
 go.vocdoni.io/proto v1.0.4-0.20211213155419-54f0e2bb6dd6/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -337,13 +337,8 @@ func Untar(src string, destination string) error {
 
 // FetchFile downloads a file from a given URL
 func FetchFile(destDir, url string) (string, error) {
-	// check if dest dir exists
-	if _, err := os.Stat(destDir); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(destDir, 0o777); err != nil {
-			return "", fmt.Errorf("cannot create destination directory: %w", err)
-		}
-	} else if err != nil {
-		return "", fmt.Errorf("cannot check if destination directory exists")
+	if err := os.MkdirAll(destDir, 0o777); err != nil {
+		return "", fmt.Errorf("cannot create destination directory: %w", err)
 	}
 	client := grab.NewClient()
 	req, _ := grab.NewRequest(destDir, url)
@@ -369,5 +364,6 @@ loop:
 	if err := resp.Err(); err != nil {
 		return "", fmt.Errorf("download failed: %w", err)
 	}
+	log.Infof("%s saved at %s", filepath.Base(resp.Filename), destDir)
 	return resp.Filename, nil
 }

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -1,14 +1,20 @@
 package vochain
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
+	"time"
 
 	"go.vocdoni.io/dvote/censustree/gravitontree"
 	"go.vocdoni.io/dvote/config"
@@ -18,6 +24,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	blind "github.com/arnaucube/go-blindsecp256k1"
+	"github.com/cavaliergopher/grab/v3"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -267,4 +274,100 @@ func GetFriendlyResults(results []*models.QuestionResult) [][]string {
 		}
 	}
 	return r
+}
+
+// Untar decompress a tar archived file into a given destination
+func Untar(src string, destination string) error {
+	r, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("cannot open file %s: %w", src, err)
+	}
+	uncompressedStream, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("cannot read file %s: %w", src, err)
+	}
+	// untar
+	tr := tar.NewReader(uncompressedStream)
+	// uncompress each element
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		target := header.Name
+		// validate name against path traversal
+		if header.Name == "" || strings.Contains(header.Name, `\`) ||
+			strings.HasPrefix(header.Name, "/") || strings.Contains(header.Name, "../") {
+			return fmt.Errorf("tar contained invalid name error %q", target)
+		}
+		// add dst + re-format slashes according to system
+		target = filepath.Join(destination, header.Name)
+		// check the type
+		switch header.Typeflag {
+		// if its a dir and it doesn't exist create it (with 0755 permission)
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+		// if it's a file create it (with same permission)
+		case tar.TypeReg:
+			fileToWrite, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			// copy over contents
+			if _, err := io.Copy(fileToWrite, tr); err != nil {
+				return err
+			}
+			// manually close here after each file operation; defering would cause each file close
+			// to wait until all operations have completed.
+			fileToWrite.Close()
+		}
+	}
+	if err := r.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FetchFile downloads a file from a given URL
+func FetchFile(destDir, url string) (string, error) {
+	// check if dest dir exists
+	if _, err := os.Stat(destDir); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(destDir, 0o777); err != nil {
+			return "", fmt.Errorf("cannot create destination directory: %w", err)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("cannot check if destination directory exists")
+	}
+	client := grab.NewClient()
+	req, _ := grab.NewRequest(destDir, url)
+	log.Infof("downloading from %v...", req.URL())
+	resp := client.Do(req)
+	t := time.NewTicker(time.Second * 5)
+	defer t.Stop()
+loop:
+	for {
+		select {
+		case <-t.C:
+			log.Infof("transferred %d / %d bytes (%.2f%%)",
+				resp.BytesComplete(),
+				resp.Size,
+				100*resp.Progress(),
+			)
+
+		case <-resp.Done:
+			// download complete
+			break loop
+		}
+	}
+	if err := resp.Err(); err != nil {
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+	return resp.Filename, nil
 }

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -4,6 +4,7 @@ package vochain
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -25,8 +26,21 @@ import (
 
 // NewVochain starts a node with an ABCI application
 func NewVochain(vochaincfg *config.VochainCfg, genesis []byte) *BaseApplication {
+	if vochaincfg.SnapshotURL != "" {
+		log.Infof("importing snapshot...")
+		snapshotPath, err := FetchFile(filepath.Join(vochaincfg.DataDir, "snapshot"), vochaincfg.SnapshotURL)
+		if err != nil {
+			log.Fatalf("cannot import snapshot: %s", err)
+		}
+		log.Infof("snapshot successfully imported !")
+		if vochaincfg.ForceResync {
+			if err := restoreStateFromSnapshot(filepath.Join(vochaincfg.DataDir, "data"), snapshotPath); err != nil {
+				log.Fatalf("cannot restore state from snapshot: %s", err)
+			}
+		}
+	}
 	// creating new vochain app
-	app, err := NewBaseApplication(vochaincfg.DataDir + "/data")
+	app, err := NewBaseApplication(filepath.Join(vochaincfg.DataDir, "data"))
 	if err != nil {
 		log.Fatalf("cannot initialize vochain application: %s", err)
 	}
@@ -334,4 +348,24 @@ func AminoKeys(key crypto25519.PrivKey) (private, public []byte, err error) {
 	}
 
 	return aminoKey, aminoPubKey, nil
+}
+
+// restoreStateFromSnapshot overrides the node data with a given snapshot
+func restoreStateFromSnapshot(dataDir, src string) error {
+	log.Infof("deleting old datadir ... %s", dataDir)
+	if _, err := os.Stat(dataDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot check if destination directory exists")
+	} else if err != nil {
+		if err := os.RemoveAll(dataDir); err != nil {
+			return fmt.Errorf("cannot clean directory before applying the snapshot")
+		}
+	}
+	log.Infof("decompressing snapshot ...")
+	if err := Untar(
+		src,
+		strings.TrimSuffix(dataDir, "/data"),
+	); err != nil {
+		return fmt.Errorf("error decompressing snapshot %w", err)
+	}
+	return nil
 }

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -30,9 +30,9 @@ func NewVochain(vochaincfg *config.VochainCfg, genesis []byte) *BaseApplication 
 		log.Infof("importing snapshot...")
 		snapshotPath, err := FetchFile(filepath.Join(vochaincfg.DataDir, "snapshot"), vochaincfg.SnapshotURL)
 		if err != nil {
-			log.Fatalf("cannot import snapshot: %s", err)
+			log.Fatalf("cannot download snapshot: %s", err)
 		}
-		log.Infof("snapshot successfully imported !")
+		log.Infof("snapshot successfully downloaded!")
 		if vochaincfg.ForceResync {
 			if err := restoreStateFromSnapshot(filepath.Join(vochaincfg.DataDir, "data"), snapshotPath); err != nil {
 				log.Fatalf("cannot restore state from snapshot: %s", err)
@@ -352,13 +352,9 @@ func AminoKeys(key crypto25519.PrivKey) (private, public []byte, err error) {
 
 // restoreStateFromSnapshot overrides the node data with a given snapshot
 func restoreStateFromSnapshot(dataDir, src string) error {
-	log.Infof("deleting old datadir ... %s", dataDir)
-	if _, err := os.Stat(dataDir); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("cannot check if destination directory exists")
-	} else if err != nil {
-		if err := os.RemoveAll(dataDir); err != nil {
-			return fmt.Errorf("cannot clean directory before applying the snapshot")
-		}
+	log.Infof("cleaning up old datadir %s before applying the snapshot", dataDir)
+	if err := os.RemoveAll(dataDir); err != nil {
+		return fmt.Errorf("cannot clean old datadir: %w", err)
 	}
 	log.Infof("decompressing snapshot ...")
 	if err := Untar(


### PR DESCRIPTION
add --snapshotURL and --vochainForceResync flags
and the underlying functionality

The former is used for passing an URL from which to
download a state snapshot compressed file.
If forceResync is set to true all existing
vochain data will be wiped and replaced by
the decompressed one extracted from the
downloaded snapshot, otherwise the downloaded
state snapshot compressed file will just be saved.