### PR TITLE
fix/benchmark (depends on PR 563)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -92,6 +92,10 @@ func (a *APIrequest) Address() *common.Address {
 	return a.address
 }
 
+func (a *APIrequest) Reset() {
+	a = &APIrequest{}
+}
+
 func (a *APIrequest) SetAddress(addr *common.Address) {
 	a.address = addr
 }

--- a/benchmark/vochain_benchmark_csp_test.go
+++ b/benchmark/vochain_benchmark_csp_test.go
@@ -1,0 +1,143 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/client"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/test/testcommon"
+	"go.vocdoni.io/dvote/util"
+	"go.vocdoni.io/dvote/vochain"
+	models "go.vocdoni.io/proto/build/go/models"
+	"google.golang.org/protobuf/proto"
+)
+
+func BenchmarkVochainCSP(b *testing.B) {
+	log.Init("info", "stdout")
+	b.ReportAllocs()
+	var dvoteServer testcommon.DvoteAPIServer
+	host := *hostFlag
+	if host == "" {
+		dvoteServer.Start(b, "file", "census", "vote")
+		host = dvoteServer.ListenAddr
+	}
+
+	cl, err := client.New(host)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// create random key batch
+	keySet := testcommon.CreateEthRandomKeysBatch(b, b.N)
+	log.Infof("generated %d keys", len(keySet))
+
+	// setup the basic parties
+	cspKey := ethereum.NewSignKeys()
+	if err := cspKey.Generate(); err != nil {
+		b.Fatal(err)
+	}
+	entityID := dvoteServer.Signer.Address().Bytes()
+
+	log.Info("creating a new process")
+	start, processID, err := cl.CreateProcess(
+		dvoteServer.Signer,
+		entityID,
+		cspKey.PublicKey(),
+		"https://dummycsp.foo",
+		&models.EnvelopeType{EncryptedVotes: false},
+		nil,
+		models.CensusOrigin_OFF_CHAIN_CA,
+		0,
+		numberOfBlocks,
+		uint64(b.N),
+	)
+	if err != nil {
+		b.Fatalf("couldn't create process: %v", err)
+	}
+	log.Infof("created a new process, will start at block %d", start)
+
+	if err := waitProcessReady(b, cl, processID); err != nil {
+		b.Fatal(err)
+	}
+
+	// batch generate CSP proofs
+	proofs, err := cl.GetCSPproofBatch(keySet, cspKey, processID)
+	if err != nil {
+		b.Fatalf("could not generate batch CSP proofs: %v", err)
+	}
+
+	// send votes in parallel
+	log.Infof("sending %d votes in parallel", b.N)
+	count := int32(0)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		cl, err := client.New(host)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for pb.Next() {
+			sendVoteCSP(b,
+				cl,
+				dvoteServer.VochainAPP.ChainID(),
+				keySet[count],
+				proofs[count],
+				processID)
+			atomic.AddInt32(&count, 1)
+		}
+	})
+}
+
+func sendVoteCSP(b *testing.B, cl *client.Client, chainID string, s *ethereum.SignKeys,
+	proof *client.Proof, processID []byte) {
+	req := &api.APIrequest{}
+	doRequest := cl.ForTest(b, req)
+
+	// Generate VotePackage and put it in VoteEnvelope
+	votePkg := &vochain.VotePackage{
+		Nonce: fmt.Sprintf("%x", util.RandomHex(32)),
+		Votes: []int{1},
+	}
+	voteBytes, err := json.Marshal(votePkg)
+	if err != nil {
+		b.Fatalf("cannot marshal vote: %s", err)
+	}
+	p := &models.ProofCA{}
+	if err := proto.Unmarshal(proof.Siblings, p); err != nil {
+		b.Fatal(err)
+	}
+	tx := &models.VoteEnvelope{
+		Nonce:     util.RandomBytes(32),
+		ProcessId: processID,
+		Proof: &models.Proof{
+			Payload: &models.Proof_Ca{Ca: p},
+		},
+		VotePackage: voteBytes,
+	}
+	// Create transaction package and sign it
+	stx := &models.SignedTx{}
+	stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: tx}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	stx.Signature, err = s.SignVocdoniTx(stx.Tx, chainID)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	req.Reset()
+	req.Payload, err = proto.Marshal(stx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	// sending submitEnvelope request
+	resp := doRequest("submitRawTx", nil)
+	if !resp.Ok {
+		b.Errorf("error submitting vote for %s: %s", s.AddressString(), resp.String())
+	}
+}

--- a/benchmark/vochain_benchmark_test.go
+++ b/benchmark/vochain_benchmark_test.go
@@ -3,12 +3,10 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/vocdoni/arbo"
 	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/client"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -29,234 +27,129 @@ const (
 	hexProcessID   = "0xe9d5e8d791f51179e218c606f83f5967ab272292a6dbda887853d81f7a1d5105"
 )
 
-func BenchmarkVochain(b *testing.B) {
+func BenchmarkVochainBatchProof(b *testing.B) {
+	log.Init("info", "stdout")
 	b.ReportAllocs()
 	var dvoteServer testcommon.DvoteAPIServer
-	rint := util.RandomInt(0, 8192)
 	host := *hostFlag
 	if host == "" {
 		dvoteServer.Start(b, "file", "census", "vote")
 		host = dvoteServer.ListenAddr
 	}
-
-	// create random key batch
-	keySet := testcommon.CreateEthRandomKeysBatch(b, *censusSize)
-	log.Infof("generated %d keys", len(keySet))
-
-	// get signer pubkey
-	signerPubHex, _ := dvoteServer.Signer.HexString()
-	signerPub := testutil.Hex2byte(b, signerPubHex)
-
-	// check required components
 	cl, err := client.New(host)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	req := &api.APIrequest{}
-	zeroReq := &api.APIrequest{}
-	reset := func(r *api.APIrequest) {
-		*r = *zeroReq
-	}
-	doRequest := cl.ForTest(b, req)
+	// create random key batch
+	keySet := testcommon.CreateEthRandomKeysBatch(b, b.N)
+	log.Infof("generated %d keys", len(keySet))
 
-	log.Info("get info")
-	resp := doRequest("getInfo", nil)
-	log.Infof("apis available: %v", resp.APIList)
-
-	// create census
-	log.Infof("creating census")
-	reset(req)
-	req.CensusID = fmt.Sprintf("test%d", rint)
-	resp = doRequest("addCensus", dvoteServer.Signer)
-	if !resp.Ok {
-		b.Fatalf("error on addCensus response: %v", resp.Ok)
-	}
-	if len(resp.CensusID) < 32 {
-		b.Fatalf("addCensus returned an invalid censusId: %x", resp.CensusID)
-	}
-	censusID := resp.CensusID
-
-	// Census add claims
-	log.Debug("add bulk claims")
-	reset(req)
-	req.CensusID = censusID
-	req.Digested = false
-	claims := [][]byte{}
-	// Send claims by batches of 100
-	for i := 0; i < *censusSize; i++ {
-		claims = append(claims, keySet[i].PublicKey())
-		if i%100 == 0 {
-			req.CensusKeys = claims
-			resp := doRequest("addClaimBulk", dvoteServer.Signer)
-			if !resp.Ok {
-				b.Fatalf("error adding claims: %s", resp.Message)
-			}
-			claims = [][]byte{}
-		}
-	}
-	// Send remaining claims
-	if len(claims) > 0 {
-		req.CensusKeys = claims
-		resp = doRequest("addClaimBulk", dvoteServer.Signer)
-		if !resp.Ok {
-			b.Fatalf("error adding claims: %s", resp.Message)
-		}
-	}
-	// get census root
-	log.Infof("get root")
-	reset(req)
-	req.CensusID = censusID
-	resp = doRequest("getRoot", nil)
-	if !resp.Ok {
-		b.Fatalf("request returned an error: %s", resp.Message)
-	}
-
-	censusRoot := resp.Root
-	if len(censusRoot) < 1 {
-		b.Fatalf("got invalid root")
-	}
-
-	log.Infof("publish census")
-	reset(req)
-	req.CensusID = censusID
-	resp = doRequest("publish", dvoteServer.Signer)
-	if !resp.Ok {
-		b.Fatalf("request returned an error: %s", resp.Message)
-	}
-
-	log.Infof("ensure block height is not less than process start block")
-	reset(req)
-	resp = doRequest("getBlockHeight", nil)
-	if !resp.Ok {
-		b.Fatalf("request returned an error: %s", resp.Message)
-	}
-
-	// create process
-	entityID := signerPub[:types.EntityIDsize]
+	// setup the basic parties
+	entityID := dvoteServer.Signer.Address().Bytes()
 	processID := testutil.Hex2byte(b, hexProcessID)
-	processData := &models.Process{
-		EntityId:     entityID,
-		CensusRoot:   censusRoot,
-		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
-		BlockCount:   numberOfBlocks,
-		ProcessId:    processID,
-		StartBlock:   *resp.Height + 1,
-		Status:       models.ProcessStatus_READY,
-		EnvelopeType: &models.EnvelopeType{},
-		Mode:         &models.ProcessMode{AutoStart: true},
-		VoteOptions:  &models.ProcessVoteOptions{MaxCount: 1, MaxValue: 1},
-	}
-	process := &models.NewProcessTx{
-		Txtype:  models.TxType_NEW_PROCESS,
-		Nonce:   0,
-		Process: processData,
+
+	// create census and process
+	censusRoot, _, processID := createCensusAndProcess(b, cl, dvoteServer, keySet, entityID)
+	if err := waitProcessReady(b, cl, processID); err != nil {
+		b.Fatal(err)
 	}
 
-	stx := &models.SignedTx{}
-	stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_NewProcess{NewProcess: process}})
+	// batch generate proofs
+	proofs, err := cl.GetMerkleProofBatch(keySet, censusRoot, false)
 	if err != nil {
-		b.Fatal("cannot marshal process")
-	}
-	stx.Signature, err = dvoteServer.Signer.SignVocdoniTx(stx.Tx, dvoteServer.VochainAPP.ChainID())
-	if err != nil {
-		b.Fatalf("cannot sign oracle tx: %s", err)
-	}
-
-	reset(req)
-	req.Payload, err = proto.Marshal(stx)
-	if err != nil {
-		b.Fatalf("error marshaling process tx: %v", err)
-	}
-	resp = doRequest("submitRawTx", nil)
-	if !resp.Ok {
-		b.Fatalf("error broadcasting process tx: %s", resp.Message)
-	} else {
-		log.Info("process transaction sent")
-	}
-
-	// check if process is created
-	log.Infof("check if process %s was created", hexProcessID)
-	reset(req)
-	req.ProcessID = processID
-	failures := 20
-	for {
-		resp = doRequest("getProcessInfo", nil)
-		if resp.Ok {
-			log.Infof("process %s successfully created", hexProcessID)
-			break
-		}
-		failures--
-		if failures == 0 {
-			b.Fatalf("processID %s does not exist in the blockchain", hexProcessID)
-		}
-		time.Sleep(time.Second)
-	}
-	log.Info("waiting for the process to start")
-	for {
-		procInfo := doRequest("getProcessInfo", nil)
-		if procInfo.Ok {
-			if procInfo.Process.Status == int32(models.ProcessStatus_READY) {
-				height := doRequest("getBlockHeight", nil)
-				if *height.Height >= procInfo.Process.StartBlock {
-					break
-				}
-			}
-		}
-		failures--
-		if failures == 0 {
-			b.Fatalf("processID %s should be started by now", hexProcessID)
-		}
-		time.Sleep(time.Second)
+		b.Fatalf("could not generate batch CSP proofs: %v", err)
 	}
 
 	// send votes in parallel
+	log.Infof("sending %d votes in parallel", b.N)
 	count := int32(0)
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		// Create websocket client
 		cl, err := client.New(host)
 		if err != nil {
 			b.Fatal(err)
 		}
 		for pb.Next() {
-			voteBench(b,
+			sendVote(b,
 				cl,
 				dvoteServer.VochainAPP.ChainID(),
-				keySet[atomic.AddInt32(&count, 1)],
-				censusRoot,
+				keySet[count],
+				proofs[count],
 				processID)
+			atomic.AddInt32(&count, 1)
 		}
 	})
 }
 
-func voteBench(b *testing.B, cl *client.Client, chainID string, s *ethereum.SignKeys,
-	censusRoot, processID []byte) {
-	// API requests
-	req := &api.APIrequest{}
-	zeroReq := &api.APIrequest{}
-	reset := func(r *api.APIrequest) {
-		*r = *zeroReq
+func BenchmarkVochainSingleProof(b *testing.B) {
+	log.Init("info", "stdout")
+	b.ReportAllocs()
+	var dvoteServer testcommon.DvoteAPIServer
+	host := *hostFlag
+	if host == "" {
+		dvoteServer.Start(b, "file", "census", "vote")
+		host = dvoteServer.ListenAddr
 	}
+	cl, err := client.New(host)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// create random key batch
+	keySet := testcommon.CreateEthRandomKeysBatch(b, b.N)
+	log.Infof("generated %d keys", len(keySet))
+
+	// setup the basic parties
+	entityID := dvoteServer.Signer.Address().Bytes()
+	processID := testutil.Hex2byte(b, hexProcessID)
+
+	// create census and process
+	censusRoot, _, processID := createCensusAndProcess(b, cl, dvoteServer, keySet, entityID)
+	if err := waitProcessReady(b, cl, processID); err != nil {
+		b.Fatal(err)
+	}
+
+	// send votes in parallel
+	log.Infof("sending %d votes in parallel", b.N)
+	count := int32(0)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		cl, err := client.New(host)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for pb.Next() {
+			signer := keySet[count]
+			siblings, value, err := cl.GetProof(signer.PublicKey(), censusRoot, false)
+			if err != nil {
+				b.Fatalf("could not get proof for %s: %s", signer.AddressString(), err)
+			}
+			proof := &client.Proof{
+				Siblings: siblings,
+				Value:    value,
+			}
+
+			sendVote(b,
+				cl,
+				dvoteServer.VochainAPP.ChainID(),
+				signer,
+				proof,
+				processID,
+			)
+			atomic.AddInt32(&count, 1)
+		}
+	})
+}
+
+func sendVote(b *testing.B, cl *client.Client, chainID string, s *ethereum.SignKeys,
+	proof *client.Proof, processID []byte) {
+	req := &api.APIrequest{}
 	doRequest := cl.ForTest(b, req)
 
-	// create envelope
-	log.Infof("adding vote using key [%s]", s.AddressString())
-
-	pub, _ := s.HexString()
-	// generate envelope proof
-	log.Infof("generating proof that address %s with public key %s is in the census", s.AddressString(), pub)
-	req.CensusID = fmt.Sprintf("%x", censusRoot)
-	req.CensusKey = s.PublicKey()
-	req.Digested = false
-	req.CensusType = models.Census_ARBO_BLAKE2B
-	resp := doRequest("genProof", nil)
-	if len(resp.Siblings) == 0 {
-		b.Fatalf("proof not generated while it should be generated correctly: %v", resp.Message)
-	}
-
-	// generate envelope votePackage
+	// Generate VotePackage and put it in VoteEnvelope
 	votePkg := &vochain.VotePackage{
 		Nonce: fmt.Sprintf("%x", util.RandomHex(32)),
 		Votes: []int{1},
@@ -265,7 +158,7 @@ func voteBench(b *testing.B, cl *client.Client, chainID string, s *ethereum.Sign
 	if err != nil {
 		b.Fatalf("cannot marshal vote: %s", err)
 	}
-	// Generate VoteEnvelope package
+
 	tx := &models.VoteEnvelope{
 		Nonce:     util.RandomBytes(32),
 		ProcessId: processID,
@@ -273,8 +166,8 @@ func voteBench(b *testing.B, cl *client.Client, chainID string, s *ethereum.Sign
 			Payload: &models.Proof_Arbo{
 				Arbo: &models.ProofArbo{
 					Type:     models.ProofArbo_BLAKE2B,
-					Value:    arbo.BigIntToBytes(32, big.NewInt(1)),
-					Siblings: resp.Siblings,
+					Value:    proof.Value,
+					Siblings: proof.Siblings,
 				},
 			},
 		},
@@ -291,25 +184,73 @@ func voteBench(b *testing.B, cl *client.Client, chainID string, s *ethereum.Sign
 		b.Fatal(err)
 	}
 
-	reset(req)
+	req.Reset()
 	req.Payload, err = proto.Marshal(stx)
 	if err != nil {
 		b.Fatal(err)
 	}
 	// sending submitEnvelope request
-	resp = doRequest("submitRawTx", nil)
-	log.Infof("response: %s", resp.String())
+	resp := doRequest("submitRawTx", nil)
+	if !resp.Ok {
+		b.Errorf("error submitting vote for %s: %s", s.AddressString(), resp.String())
+	}
+}
 
-	// check vote added
-	/*	reset(req)
-		req.ProcessID = processID
-		req.Nullifier = vochain.GenerateNullifier(s.Address(), processID)
-		for {
-			resp = doRequest("getEnvelopeStatus", nil)
-			if *resp.Registered {
-				break
+func waitProcessReady(b *testing.B, cl *client.Client, processID []byte) error {
+	log.Info("waiting for the process to start")
+	req := &api.APIrequest{}
+	// reset(req)
+	doRequest := cl.ForTest(b, req)
+	req.ProcessID = processID
+	failures := 20
+	for {
+		procInfo := doRequest("getProcessInfo", nil)
+		if procInfo.Ok {
+			if procInfo.Process.Status == int32(models.ProcessStatus_READY) {
+				height := doRequest("getBlockHeight", nil)
+				if *height.Height >= procInfo.Process.StartBlock {
+					break
+				}
 			}
-			time.Sleep(time.Second * 2)
 		}
-	*/
+		failures--
+		if failures == 0 {
+			return fmt.Errorf("processID %s should be started by now", hexProcessID)
+		}
+		time.Sleep(time.Second)
+	}
+	return nil
+}
+
+func createCensusAndProcess(b *testing.B, cl *client.Client, dvoteServer testcommon.DvoteAPIServer, keySet []*ethereum.SignKeys, entityID []byte) (censusRoot []byte, censusURI string, processID []byte) {
+	// create census
+	censusRoot, censusURI, err := cl.CreateCensus(
+		dvoteServer.Signer,
+		keySet,
+		[]string{},
+		[]*types.BigInt{},
+	)
+	if err != nil {
+		b.Fatalf("failed to create the census: %v", err)
+	}
+	log.Infof("created census - published at %s", censusURI)
+
+	log.Info("creating a new process")
+	start, processID, err := cl.CreateProcess(
+		dvoteServer.Signer,
+		entityID,
+		censusRoot,
+		censusURI,
+		&models.EnvelopeType{EncryptedVotes: false},
+		nil,
+		models.CensusOrigin_OFF_CHAIN_TREE,
+		0,
+		numberOfBlocks,
+		uint64(b.N),
+	)
+	if err != nil {
+		b.Fatalf("couldn't create process: %v", err)
+	}
+	log.Infof("created a new process, will start at block %d", start)
+	return censusRoot, censusURI, processID
 }

--- a/test/testcommon/apis.go
+++ b/test/testcommon/apis.go
@@ -69,7 +69,7 @@ func (d *DvoteAPIServer) Start(tb testing.TB, apis ...string) {
 		}
 	})
 
-	httpRouter := httprouter.HTTProuter{}
+	httpRouter := httprouter.HTTProuter{PrometheusID: d.Signer.AddressString()}
 	if err := httpRouter.Init("127.0.0.1", 0); err != nil {
 		log.Fatal(err)
 	}

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -218,14 +218,14 @@ func NewMockVochainNode(tb testing.TB, d *DvoteAPIServer) *vochain.BaseApplicati
 	d.VochainCfg.NoWaitSync = true
 	d.VochainCfg.MempoolSize = 20000
 	d.VochainCfg.MinerTargetBlockTimeSeconds = 3
+	d.VochainCfg.DBType = "pebble"
 
 	// run node
 	d.VochainCfg.MinerKey = fmt.Sprintf("%x", validator.Key.PrivKey)
 	vnode := vochain.NewVochain(d.VochainCfg, genBytes)
 	tb.Cleanup(func() {
-		vnode.Node.Stop()
 		if err := vnode.Node.Stop(); err != nil {
-			tb.Error(err)
+			tb.Fatal(err)
 		}
 		vnode.Node.Wait()
 	})

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -343,12 +343,14 @@ func (app *BaseApplication) VoteEnvelopeCheck(ve *models.VoteEnvelope, txBytes, 
 	height := app.State.CurrentHeight()
 	endBlock := process.StartBlock + process.BlockCount
 
-	if height < process.StartBlock || height > endBlock {
-		return nil, fmt.Errorf("process %x not started or finished", ve.ProcessId)
+	if height < process.StartBlock {
+		return nil, fmt.Errorf("process %x starts at height %d, current height is %d", ve.ProcessId, process.StartBlock, height)
+	} else if height > endBlock {
+		return nil, fmt.Errorf("process %x finished at height %d, current height is %d", ve.ProcessId, endBlock, height)
 	}
 
 	if process.Status != models.ProcessStatus_READY {
-		return nil, fmt.Errorf("process %x not in READY state", ve.ProcessId)
+		return nil, fmt.Errorf("process %x not in READY state - current state: %s", ve.ProcessId, process.Status.String())
 	}
 
 	// Check in case of keys required, they have been sent by some keykeeper
@@ -827,7 +829,7 @@ func SetTransactionCostsTxCheck(vtx *models.Tx, txBytes, signature []byte, state
 	}
 	// check signature recovered address
 	if common.BytesToAddress(treasurer.Address) != sigAddress {
-		return 0, fmt.Errorf("address recovered not treasurer: expected %s got %s", treasurer.String(), sigAddress.String())
+		return 0, fmt.Errorf("address recovered not treasurer: expected %s got %s", common.BytesToAddress(treasurer.Address), sigAddress.String())
 	}
 	return tx.Value, nil
 }


### PR DESCRIPTION
`BenchmarkVochainBatchProof`, `BenchmarkVochainSingleProof` benchmarks vote processing on a single node with a distributed census. In one, the proofs for the votes are fetched in a batch; the other, the proofs are requested when forming the vote envelope, one at a time.

`BenchmarkVochainCSP` benchmarks vote processing on a single node with a centralized census. The proofs that the voters are in the census are fetched as a batch in the beginning.

Core i7 8550U plugged into AC, ~2.8-2.9GHz
```
BenchmarkVochainSingleProof-8   	    3428	    307200 ns/op	  101673 B/op	     956 allocs/op
BenchmarkVochainBatchProof-8   	    4600	    287593 ns/op	   62049 B/op	     578 allocs/op`
BenchmarkVochainCSP-8   	    3936	    306749 ns/op	   48031 B/op	     515 allocs/op
```