### PR TITLE
better implementation of APIrequest.Reset() that doesn't fail staticc…

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -93,7 +93,7 @@ func (a *APIrequest) Address() *common.Address {
 }
 
 func (a *APIrequest) Reset() {
-	a = &APIrequest{}
+	*a = APIrequest{}
 }
 
 func (a *APIrequest) SetAddress(addr *common.Address) {


### PR DESCRIPTION
…heck

According to Golang sources, the idiomatic way of implementing `Reset()` is to dereference the `a` that contains the method like [here](https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/hash/adler32/adler32.go).
