### PR TITLE
[Breaking] f/delegates tx support

### DIFF
--- a/vochain/process.go
+++ b/vochain/process.go
@@ -461,14 +461,14 @@ func (app *BaseApplication) NewProcessTxCheck(vtx *models.Tx, txBytes,
 	// check if recovered address is an Oracle and if not
 	// check if recovered address is a delegate of the entityID provided
 	if !bytes.Equal(tx.Process.EntityId, addr.Bytes()) && !isOracle {
-		entityIDAddress := common.BytesToAddress(tx.Process.EntityId)
-		entityIDAccount, err := state.GetAccount(entityIDAddress, true)
+		entityAddress := common.BytesToAddress(tx.Process.EntityId)
+		entityAccount, err := state.GetAccount(entityAddress, true)
 		if err != nil {
 			return nil, common.Address{}, fmt.Errorf(
-				"cannot get entityID account for checking if the sender is a delegate: %w", err,
+				"cannot get entity account for checking if the sender is a delegate: %w", err,
 			)
 		}
-		if !entityIDAccount.IsDelegate(*addr) {
+		if !entityAccount.IsDelegate(*addr) {
 			return nil, common.Address{}, fmt.Errorf(
 				"unauthorized to create a new process, recovered addr is %s", addr.Hex())
 		}

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -130,8 +130,8 @@ func (app *BaseApplication) AddTx(vtx *VochainTx, commit bool) (*AddTxResponse, 
 			if err := app.State.AddProcess(p); err != nil {
 				return nil, fmt.Errorf("newProcess: addProcess: %w", err)
 			}
-			entityIDAddr := common.BytesToAddress(p.EntityId)
-			if err := app.State.IncrementAccountProcessIndex(entityIDAddr); err != nil {
+			entityAddr := common.BytesToAddress(p.EntityId)
+			if err := app.State.IncrementAccountProcessIndex(entityAddr); err != nil {
 				return nil, fmt.Errorf("newProcess: cannot increment process index: %w", err)
 			}
 			return response, app.State.SubtractCostIncrementNonce(txSender, models.TxType_NEW_PROCESS)

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -130,7 +130,8 @@ func (app *BaseApplication) AddTx(vtx *VochainTx, commit bool) (*AddTxResponse, 
 			if err := app.State.AddProcess(p); err != nil {
 				return nil, fmt.Errorf("newProcess: addProcess: %w", err)
 			}
-			if err := app.State.IncrementAccountProcessIndex(txSender); err != nil {
+			entityIDAddr := common.BytesToAddress(p.EntityId)
+			if err := app.State.IncrementAccountProcessIndex(entityIDAddr); err != nil {
 				return nil, fmt.Errorf("newProcess: cannot increment process index: %w", err)
 			}
 			return response, app.State.SubtractCostIncrementNonce(txSender, models.TxType_NEW_PROCESS)


### PR DESCRIPTION
Adding support for txs with delegates was something pending for the ethless approach.
This PR adds support for NewProcess, SetProcess and SetAccountInfoUri to work with delegates.

Given that the code was modified for adding tests for delegates:
- Add unit tests for NewProcess
- Add more tests for SetProcess operations with delegates 
It also introduces some changes to process_test.go:
- Use quicktest lib
- Wrap some repetitive code

With the deleted code with just 21 more lines of code we have support for delegates and its unit testing :)