### PR TITLE
vochain/cache: fix condition to purge txs from cache

### DIFF
--- a/vochain/cache.go
+++ b/vochain/cache.go
@@ -107,7 +107,7 @@ func (v *State) CachePurge(height uint32) {
 			log.Warn("vote cache index is not [32]byte")
 			continue
 		}
-		if vote.Height+voteCachePurgeThreshold >= height {
+		if height >= vote.Height+voteCachePurgeThreshold {
 			v.voteCache.Remove(cacheGetNullifierKey(vote.Nullifier))
 			v.voteCache.Remove(id)
 			removeFromMempool = append(removeFromMempool, vid)


### PR DESCRIPTION
the idea is that a tx will be purged from cache when the blockchain height is greater than the vote.Height plus a voteCachePurgeThreshold. the comparison operator was reversed and the transactions were removed from cache on every CachePurge()