### PR TITLE
dvotenode: avoid spam debug msgs from cache purge

### DIFF
--- a/vochain/cache.go
+++ b/vochain/cache.go
@@ -107,7 +107,9 @@ func (v *State) CachePurge(height uint32) {
 			removed++
 		}
 	}
-	log.Debugf("removed %d votes from cache", removed)
+	if removed != 0 {
+		log.Debugf("removed %d votes from cache", removed)
+	}
 }
 
 // SetCacheSize sets the size for the vote LRU cache.


### PR DESCRIPTION
fix #643 

my understanding is that the voteCache is empty during replay anyway, so CachePurge() really costs nothing, only the log.Debugf is noisy.

i believe this `if removed != 0 {` makes sense in any case, not only during replay.