### PR TITLE
vochain: use TenderLogger to avoid tendermint log spam

### DIFF
--- a/vochain/start.go
+++ b/vochain/start.go
@@ -231,13 +231,12 @@ func newTendermint(app *BaseApplication,
 	}
 
 	// create tendermint logger
+	logDisable := false
 	if tconfig.LogLevel == "none" {
+		logDisable = true
 		tconfig.LogLevel = "error"
 	}
-	logger, err := tmlog.NewDefaultLogger("plain", tconfig.LogLevel, false)
-	if err != nil {
-		log.Errorf("failed to parse log level: %v", err)
-	}
+	logger := NewTenderLogger("tendermint", logDisable)
 
 	// read or create local private validator
 	pv, err := NewPrivateValidator(localConfig.MinerKey, tconfig)


### PR DESCRIPTION
this fixes a regression introduced in 2022/01/16 in
commit "version bump: tendermint v0.35.1 and prometheus v1.12.0"

fix #641 