### PR TITLE
dvotenode: fix vochainLogLevel

### DIFF
--- a/cmd/dvotenode/dvotenode.go
+++ b/cmd/dvotenode/dvotenode.go
@@ -127,8 +127,8 @@ func newConfig() (*config.DvoteCfg, config.Error) {
 		"create local/testing genesis file for the vochain")
 	globalCfg.VochainConfig.Genesis = *flag.String("vochainGenesis", "",
 		"use alternative genesis file for the vochain")
-	globalCfg.VochainConfig.LogLevel = *flag.String("vochainLogLevel", "none",
-		"tendermint node log level (error, info, debug, none)")
+	globalCfg.VochainConfig.LogLevel = *flag.String("vochainLogLevel", "disabled",
+		"tendermint node log level (debug, info, error, disabled)")
 	globalCfg.VochainConfig.Peers = *flag.StringSlice("vochainPeers", []string{},
 		"comma-separated list of p2p peers")
 	globalCfg.VochainConfig.Seeds = *flag.StringSlice("vochainSeeds", []string{},

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -76,7 +76,7 @@ var _ tmlog.Logger = (*TenderLogger)(nil)
 
 func (l *TenderLogger) Debug(msg string, keyvals ...interface{}) {
 	if !l.Disabled {
-		log.Infow(fmt.Sprintf("[%s] %s", l.Artifact, msg), keyvals...)
+		log.Debugw(fmt.Sprintf("[%s] %s", l.Artifact, msg), keyvals...)
 	}
 }
 
@@ -101,7 +101,7 @@ func (l *TenderLogger) With(keyvals ...interface{}) tmlog.Logger {
 	return l2
 }
 
-// NewTenderLogger creates a Tenderming compatible logger for specified artifact
+// NewTenderLogger creates a Tendermint compatible logger for specified artifact
 func NewTenderLogger(artifact string, disabled bool) *TenderLogger {
 	return &TenderLogger{Artifact: artifact, Disabled: disabled}
 }
@@ -230,13 +230,9 @@ func newTendermint(app *BaseApplication,
 		return nil, fmt.Errorf("config is invalid: %w", err)
 	}
 
-	// create tendermint logger
-	logDisable := false
-	if tconfig.LogLevel == "none" {
-		logDisable = true
-		tconfig.LogLevel = "error"
-	}
-	logger := NewTenderLogger("tendermint", logDisable)
+	// create tendermint logger. if tconfig.LogLevel == "disabled", bool evals to true and log is disabled
+	// (anyway tendermint shouldn't log anything, since zerolog level == "disabled", but just in case)
+	logger := NewTenderLogger("tendermint", tconfig.LogLevel == "disabled")
 
 	// read or create local private validator
 	pv, err := NewPrivateValidator(localConfig.MinerKey, tconfig)


### PR DESCRIPTION
* route tm Debug messages to log.Debug (instead of log.Info)
* tendermint v0.35 uses zerolog which supports "disabled" level, use that

better fix #641 