### PR TITLE
data/ipfs: upgrade IPFS CID to v1

### DIFF
--- a/api/census_test.go
+++ b/api/census_test.go
@@ -36,7 +36,7 @@ func TestCensus(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	censusDB := censusdb.NewCensusDB(db)
 
-	storage := data.IPFSHandle{}
+	storage := data.MockStorage(t)
 	api.Attach(nil, nil, nil, data.Storage(&storage), censusDB)
 	qt.Assert(t, api.EnableHandlers(CensusHandler), qt.IsNil)
 

--- a/apiclient/election.go
+++ b/apiclient/election.go
@@ -186,7 +186,7 @@ func (c *HTTPclient) NewElection(description *api.ElectionDescription) (types.He
 		return nil, fmt.Errorf("cannot format metadata: %w", err)
 	}
 	log.Debugf("election metadata: %s", string(metadataBytes))
-	metadataURI := "ipfs://" + data.IPFScontentIdentifier(metadataBytes)
+	metadataURI := "ipfs://" + data.CalculateIPFSCIDv1json(metadataBytes)
 
 	// get the own account details
 	acc, err := c.Account("")

--- a/data/ipfs.go
+++ b/data/ipfs.go
@@ -31,16 +31,16 @@ import (
 )
 
 const (
-	MaxFileSizeBytes      = 1024 * 1024 * 50 // 50 MB
-	RetrivedFileCacheSize = 128
+	MaxFileSizeBytes       = 1024 * 1024 * 50 // 50 MB
+	RetrievedFileCacheSize = 128
 )
 
 type IPFSHandle struct {
-	Node         *ipfscore.IpfsNode
-	CoreAPI      coreiface.CoreAPI
-	DataDir      string
-	LogLevel     string
-	retriveCache *lru.Cache
+	Node          *ipfscore.IpfsNode
+	CoreAPI       coreiface.CoreAPI
+	DataDir       string
+	LogLevel      string
+	retrieveCache *lru.Cache
 
 	// cancel helps us stop extra goroutines and listeners which complement
 	// the IpfsNode above.
@@ -110,7 +110,7 @@ func (i *IPFSHandle) Init(d *types.DataStore) error {
 	i.Node = node
 	i.CoreAPI = coreAPI
 	i.DataDir = d.Datadir
-	i.retriveCache = lru.New(RetrivedFileCacheSize)
+	i.retrieveCache = lru.New(RetrievedFileCacheSize)
 	return nil
 }
 
@@ -239,9 +239,9 @@ func (i *IPFSHandle) ListPins(ctx context.Context) (map[string]string, error) {
 // Retrieve gets an IPFS file (either from the p2p network or from the local cache)
 func (i *IPFSHandle) Retrieve(ctx context.Context, path string, maxSize int64) ([]byte, error) {
 	path = strings.TrimPrefix(path, "ipfs://")
-	ccontent := i.retriveCache.Get(path)
+	ccontent := i.retrieveCache.Get(path)
 	if ccontent != nil {
-		log.Debugf("retreived file %s from cache", path)
+		log.Debugf("retrieved file %s from cache", path)
 		return ccontent.([]byte), nil
 	}
 	rpath, err := i.CoreAPI.ResolvePath(ctx, corepath.New(path))
@@ -273,10 +273,10 @@ func (i *IPFSHandle) Retrieve(ctx context.Context, path string, maxSize int64) (
 		return nil, err
 	}
 	if len(content) == 0 {
-		return nil, fmt.Errorf("retreived file is empty")
+		return nil, fmt.Errorf("retrieved file is empty")
 	}
 	// Save file to cache for future attempts
-	i.retriveCache.Add(path, content)
+	i.retrieveCache.Add(path, content)
 
 	return content, nil
 }

--- a/data/ipfs_mockstorage.go
+++ b/data/ipfs_mockstorage.go
@@ -1,0 +1,26 @@
+package data
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	ipfscore "github.com/ipfs/kubo/core"
+	ipfsapi "github.com/ipfs/kubo/core/coreapi"
+)
+
+// MockStorage returns a IPFSHandle with a (offline, nilrepo) IPFS node
+// with a functional CoreAPI
+func MockStorage(t *testing.T) IPFSHandle {
+	storage := IPFSHandle{}
+	n, err := ipfscore.NewNode(context.Background(), &ipfscore.BuildCfg{
+		Online:    false,
+		Permanent: false,
+		NilRepo:   false,
+	})
+	qt.Assert(t, err, qt.IsNil)
+	api, err := ipfsapi.NewCoreAPI(n)
+	qt.Assert(t, err, qt.IsNil)
+	storage.CoreAPI = api
+	return storage
+}

--- a/data/ipfs_test.go
+++ b/data/ipfs_test.go
@@ -1,0 +1,33 @@
+package data
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	ipfscid "github.com/ipfs/go-cid"
+)
+
+func TestIPFSCIDv1(t *testing.T) {
+	msg := []byte("{\"test\": { \"hello\": \"world\" }}")
+	expectedCid := "bagaaiera63prsqlm2mptglagfk6ywr4cv3ibcxbpapi2rjzzufnilp52crvq"
+
+	i := MockStorage(t)
+	cidFromPublish, err := i.Publish(context.Background(), msg)
+	qt.Assert(t, err, qt.IsNil)
+	cid, err := ipfscid.Decode(cidFromPublish)
+	qt.Assert(t, err, qt.IsNil)
+	t.Log("Publish returned:")
+	t.Logf("CID: %s, Hash: %s, Version: %d, MhType: %x, Codec: %x",
+		cid.String(), cid.Hash(), cid.Version(), cid.Prefix().MhType, cid.Type())
+
+	cidFromCalculateIPFSCIDv1json := CalculateIPFSCIDv1json(msg)
+	cid, err = ipfscid.Decode(cidFromCalculateIPFSCIDv1json)
+	qt.Assert(t, err, qt.IsNil)
+	t.Log("CalculateIPFSCIDv1json returned:")
+	t.Logf("CID: %s, Hash: %s, Version: %d, MhType: %x, Codec: %x",
+		cid.String(), cid.Hash(), cid.Version(), cid.Prefix().MhType, cid.Type())
+
+	qt.Assert(t, cidFromCalculateIPFSCIDv1json, qt.Equals, expectedCid)
+	qt.Assert(t, cidFromPublish, qt.Equals, cidFromCalculateIPFSCIDv1json)
+}

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/ipfs/go-cid v0.2.0
+	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-ipfs-files v0.1.1
 	github.com/ipfs/go-ipfs-keystore v0.0.2
 	github.com/ipfs/go-log v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1137,6 +1137,8 @@ github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqg
 github.com/ipfs/go-cid v0.1.0/go.mod h1:rH5/Xv83Rfy8Rw6xG+id3DYAMUVmem1MowoKwdXmN2o=
 github.com/ipfs/go-cid v0.2.0 h1:01JTiihFq9en9Vz0lc0VDWvZe/uBonGpzo4THP0vcQ0=
 github.com/ipfs/go-cid v0.2.0/go.mod h1:P+HXFDF4CVhaVayiEb4wkAy7zBHxBwsJyt0Y5U6MLro=
+github.com/ipfs/go-cid v0.3.2 h1:OGgOd+JCFM+y1DjWPmVH+2/4POtpDzwcr7VgnB7mZXc=
+github.com/ipfs/go-cid v0.3.2/go.mod h1:gQ8pKqT/sUxGY+tIwy1RPpAojYu7jAyCp5Tz1svoupw=
 github.com/ipfs/go-cidutil v0.0.2/go.mod h1:ewllrvrxG6AMYStla3GD7Cqn+XYSLqjK0vc+086tB6s=
 github.com/ipfs/go-cidutil v0.1.0 h1:RW5hO7Vcf16dplUU60Hs0AKDkQAVPVplr7lk97CFL+Q=
 github.com/ipfs/go-cidutil v0.1.0/go.mod h1:e7OEVBMIv9JaOxt9zaGEmAoSlXW9jdFZ5lP/0PwcfpA=


### PR DESCRIPTION
data/ipfs: upgrade IPFS CID to v1 

 * reimplement Publish using i.CoreApi
 * move unixfsFilesNode out of AddAndPin
 * reimplement AddAndPin using i.CoreAPI
 * lint Pin and Unpin
 * simpler PublishIPNSpath, refactoring addAndPin to return corepath.Resolved
 * use IPFSCIDv1, drop IPFScontentIdentifier that returned v0
 * new func MockStorage needed by api/census_test
