### PR TITLE
nit: fix misspellings of retrieve in comments

### DIFF
--- a/data/downloader/downloader.go
+++ b/data/downloader/downloader.go
@@ -17,7 +17,7 @@ const (
 	// remote file download queue.
 	ImportQueueRoutines = 10
 	// ImportRetrieveTimeout the maximum duration the import queue will wait
-	// for retreiving a remote file.
+	// for retrieving a remote file.
 	ImportRetrieveTimeout = 3 * time.Minute
 	// ImportQueueTimeout is the maximum duration the import queue will wait
 	// for pining a remote file.

--- a/data/downloader/downloader_test.go
+++ b/data/downloader/downloader_test.go
@@ -23,7 +23,7 @@ func TestDownloader(t *testing.T) {
 	}
 
 	d.AddToQueue(stg.URIprefix()+"testfile1", callback, false)
-	<-callbackChan // wait for retriving the file
+	<-callbackChan // wait for retrieving the file
 	qt.Assert(t, d.QueueSize(), qt.Equals, int32(0))
 
 	d.AddToQueue(stg.URIprefix()+"testfile2", callback, true)

--- a/db/interface.go
+++ b/db/interface.go
@@ -49,7 +49,7 @@ type Database interface {
 }
 
 type ReadTx interface {
-	// Get retreives the value for the given key. If the key does not
+	// Get retrieves the value for the given key. If the key does not
 	// exist, returns the error ErrKeyNotFound
 	Get(key []byte) ([]byte, error)
 	// Discard discards the transaction. This method can be called always,

--- a/db/lru/lru.go
+++ b/db/lru/lru.go
@@ -23,7 +23,7 @@ func (l *Cache) Add(key, value interface{}) {
 	l.lru.Add(key, value)
 }
 
-// Get retrives an element from the cache
+// Get retrieves an element from the cache
 func (l *Cache) Get(key interface{}) interface{} {
 	value, ok := l.lru.Get(key)
 	if !ok {

--- a/vochain/account.go
+++ b/vochain/account.go
@@ -150,7 +150,7 @@ func (v *State) BurnTxCost(from common.Address, cost uint64) error {
 	return nil
 }
 
-// GetAccount retrives the Account for an address.
+// GetAccount retrieves the Account for an address.
 // Returns a nil account and no error if the account does not exist.
 // Committed is relative to the state on which the function is executed.
 func (v *State) GetAccount(address common.Address, committed bool) (*Account, error) {

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -231,7 +231,7 @@ func (app *BaseApplication) isSynchronizingTendermint() bool {
 	defer app.isSyncLock.Unlock()
 	status, err := app.Node.Status(context.Background())
 	if err != nil {
-		log.Warnf("error retriving node status information: %v", err)
+		log.Warnf("error retrieving node status information: %v", err)
 		return true
 	}
 	return status.SyncInfo.CatchingUp

--- a/vochain/processarchive/processarchive.go
+++ b/vochain/processarchive/processarchive.go
@@ -92,7 +92,7 @@ func (js *jsonStorage) AddProcess(p *Process) error {
 	return os.WriteFile(procPath, procData, 0o644)
 }
 
-// GetProcess retreives a process from the js storage
+// GetProcess retrieves a process from the js storage
 func (js *jsonStorage) GetProcess(pid []byte) (*Process, error) {
 	if len(pid) != types.ProcessIDsize {
 		return nil, fmt.Errorf("process not valid")

--- a/vochain/scrutinizer/scrutinizer.go
+++ b/vochain/scrutinizer/scrutinizer.go
@@ -638,7 +638,7 @@ func (s *Scrutinizer) OnProcessResults(pid []byte, results *models.ProcessResult
 	// would compute different state hash.
 	// As a temporary solution, lets compare results but just print the error.
 
-	// This code must be run async in order to not delay the consensus. The results retreival
+	// This code must be run async in order to not delay the consensus. The results retrieval
 	// could require some time.
 	go func() {
 		if results == nil || results.Votes == nil {

--- a/vochain/scrutinizer/vote.go
+++ b/vochain/scrutinizer/vote.go
@@ -64,7 +64,7 @@ func (s *Scrutinizer) GetEnvelopeReference(nullifier []byte) (*indexertypes.Vote
 	return txRef, nil
 }
 
-// GetEnvelope retreives an Envelope from the Blockchain block store identified by its nullifier.
+// GetEnvelope retrieves an Envelope from the Blockchain block store identified by its nullifier.
 // Returns the envelope and the signature (if any).
 func (s *Scrutinizer) GetEnvelope(nullifier []byte) (*indexertypes.EnvelopePackage, error) {
 	startTime := time.Now()
@@ -164,7 +164,7 @@ func (s *Scrutinizer) WalkEnvelopes(processId []byte, async bool,
 	return err
 }
 
-// GetEnvelopes retreives all Envelopes of a ProcessId from the Blockchain block store
+// GetEnvelopes retrieves all Envelopes of a ProcessId from the Blockchain block store
 func (s *Scrutinizer) GetEnvelopes(processId []byte, max, from int,
 	searchTerm string) ([]*indexertypes.EnvelopeMetadata, error) {
 	if from < 0 {


### PR DESCRIPTION
trivial nit (only `// comments`)