### PR TITLE
RFC: allow Nonce=0

### DIFF
--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -283,12 +283,12 @@ func (c *testClient) ensureTxCostEquals(signer *ethereum.SignKeys, txType models
 			return fmt.Errorf("cannot get treasurer: %w", err)
 		}
 
-		log.Infof("will set %s txcost=%d (treasurer nonce: %d)", txType, cost, treasurerAccount.Nonce)
+		log.Infof("will set %s txcost=%d (treasurer nonce: %d) with nonce 0", txType, cost, treasurerAccount.Nonce)
 		txhash, err := c.SetTransactionCost(
 			signer,
 			txType,
 			cost,
-			treasurerAccount.Nonce)
+			0)
 		if err != nil {
 			log.Warn(err)
 			time.Sleep(time.Second)

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -514,10 +514,11 @@ func (app *BaseApplication) CheckTx(req abcitypes.RequestCheckTx) abcitypes.Resp
 		return abcitypes.ResponseCheckTx{Code: 1, Data: []byte("unmarshalTx " + err.Error())}
 	}
 	return abcitypes.ResponseCheckTx{
-		Code: 0,
-		Data: response.Data,
-		Info: fmt.Sprintf("%x", response.TxHash),
-		Log:  response.Log,
+		Code:     0,
+		Data:     response.Data,
+		Info:     fmt.Sprintf("%x", response.TxHash),
+		Log:      response.Log,
+		Priority: 500,
 	}
 }
 

--- a/vochain/state/account.go
+++ b/vochain/state/account.go
@@ -218,6 +218,11 @@ func SetAccountInfoTxCheck(vtx *models.Tx, txBytes, signature []byte, state *Sta
 	if txSenderAccount == nil {
 		return ErrAccountNotExist
 	}
+	log.Warn("XXXX tx.GetNonce=", tx.GetNonce())
+	if tx.GetNonce() == 0 {
+		*tx.Nonce = txSenderAccount.GetNonce()
+	}
+	log.Warn("XXXY tx.GetNonce=", tx.GetNonce(), "txSenderAccount.GetNonce()=", txSenderAccount.GetNonce())
 	// check txSender nonce
 	if tx.GetNonce() != txSenderAccount.Nonce {
 		return fmt.Errorf(

--- a/vochain/state_account_test.go
+++ b/vochain/state_account_test.go
@@ -687,29 +687,35 @@ func TestSendTokensTx(t *testing.T) {
 	// should send
 	err = testSendTokensTx(t, &signer, app, toAccAddr.String(), 100, 0)
 	qt.Assert(t, err, qt.IsNil)
+	// should send
+	err = testSendTokensTx(t, &signer, app, randomEthAccount, 100, 1)
+	qt.Assert(t, err, qt.IsNil)
 
+	// should fail sending if nonce is reused
+	err = testSendTokensTx(t, &signer, app, randomEthAccount, 100, 1)
+	qt.Assert(t, err, qt.IsNotNil)
 	// should fail sending if incorrect nonce
-	err = testSendTokensTx(t, &signer, app, randomEthAccount, 100, 0)
+	err = testSendTokensTx(t, &signer, app, randomEthAccount, 100, 1234)
 	qt.Assert(t, err, qt.IsNotNil)
 	// should fail sending if to acc does not exist
 	noAccount := ethereum.SignKeys{}
 	err = noAccount.Generate()
 	qt.Assert(t, err, qt.IsNil)
-	err = testSendTokensTx(t, &signer, app, noAccount.Address().String(), 100, 1)
+	err = testSendTokensTx(t, &signer, app, noAccount.Address().String(), 100, 2)
 	qt.Assert(t, err, qt.IsNotNil)
 	// should fail sending if not enought balance
-	err = testSendTokensTx(t, &signer, app, randomEthAccount, 1000, 1)
+	err = testSendTokensTx(t, &signer, app, randomEthAccount, 1000, 2)
 	qt.Assert(t, err, qt.IsNotNil)
 	// get to account
 	toAcc, err := app.State.GetAccount(toAccAddr, false)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, toAcc, qt.IsNotNil)
-	qt.Assert(t, toAcc.Balance, qt.Equals, uint64(100))
+	qt.Assert(t, toAcc.Balance, qt.Equals, uint64(200))
 	// get from acc
 	fromAcc, err := app.State.GetAccount(signer.Address(), false)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, fromAcc, qt.IsNotNil)
-	qt.Assert(t, fromAcc.Balance, qt.Equals, uint64(890))
+	qt.Assert(t, fromAcc.Balance, qt.Equals, uint64(780))
 }
 
 func testSendTokensTx(t *testing.T,

--- a/vochain/state_account_test.go
+++ b/vochain/state_account_test.go
@@ -532,8 +532,12 @@ func TestSetTransactionsCosts(t *testing.T) {
 		t.Fatal(err)
 	}
 	// should not change tx costs if not treasurer
-	if err := testSetTransactionCostsTx(t, app, &signer, 0, 20); err == nil {
+	randomAcc := ethereum.SignKeys{}
+	if err := randomAcc.Generate(); err != nil {
 		t.Fatal(err)
+	}
+	if err := testSetTransactionCostsTx(t, app, &randomAcc, 0, 30); err == nil {
+		t.Fatal("should not change tx costs if not treasurer")
 	}
 	if cost, err := app.State.TxCost(models.TxType_COLLECT_FAUCET, false); err != nil {
 		t.Fatal(err)

--- a/vochain/state_account_test.go
+++ b/vochain/state_account_test.go
@@ -685,26 +685,26 @@ func TestSendTokensTx(t *testing.T) {
 	app.Commit()
 
 	// should send
-	err = testSendTokensTx(t, &signer, app, toAccAddr.String(), 100, 0)
+	err = testSendTokensTx(t, &signer, app, toAccAddr, 100, 0)
 	qt.Assert(t, err, qt.IsNil)
 	// should send
-	err = testSendTokensTx(t, &signer, app, randomEthAccount, 100, 1)
+	err = testSendTokensTx(t, &signer, app, toAccAddr, 100, 1)
 	qt.Assert(t, err, qt.IsNil)
 
 	// should fail sending if nonce is reused
-	err = testSendTokensTx(t, &signer, app, randomEthAccount, 100, 1)
+	err = testSendTokensTx(t, &signer, app, toAccAddr, 100, 1)
 	qt.Assert(t, err, qt.IsNotNil)
 	// should fail sending if incorrect nonce
-	err = testSendTokensTx(t, &signer, app, randomEthAccount, 100, 1234)
+	err = testSendTokensTx(t, &signer, app, toAccAddr, 100, 1234)
 	qt.Assert(t, err, qt.IsNotNil)
 	// should fail sending if to acc does not exist
 	noAccount := ethereum.SignKeys{}
 	err = noAccount.Generate()
 	qt.Assert(t, err, qt.IsNil)
-	err = testSendTokensTx(t, &signer, app, noAccount.Address().String(), 100, 2)
+	err = testSendTokensTx(t, &signer, app, noAccount.Address(), 100, 2)
 	qt.Assert(t, err, qt.IsNotNil)
 	// should fail sending if not enought balance
-	err = testSendTokensTx(t, &signer, app, randomEthAccount, 1000, 2)
+	err = testSendTokensTx(t, &signer, app, toAccAddr, 1000, 2)
 	qt.Assert(t, err, qt.IsNotNil)
 	// get to account
 	toAcc, err := app.State.GetAccount(toAccAddr, false)
@@ -721,12 +721,11 @@ func TestSendTokensTx(t *testing.T) {
 func testSendTokensTx(t *testing.T,
 	signer *ethereum.SignKeys,
 	app *BaseApplication,
-	to string,
+	toAddr common.Address,
 	value uint64,
 	nonce uint32) error {
 	var err error
 
-	toAddr := common.HexToAddress(to)
 	// tx
 	tx := &models.SendTokensTx{
 		Txtype: models.TxType_SEND_TOKENS,

--- a/vochain/transaction.go
+++ b/vochain/transaction.go
@@ -866,6 +866,9 @@ func SetTransactionCostsTxCheck(vtx *models.Tx, txBytes, signature []byte, state
 		return 0, err
 	}
 	// check nonce
+	if tx.GetNonce() == 0 {
+		tx.Nonce = treasurer.Nonce
+	}
 	if tx.Nonce != treasurer.Nonce {
 		return 0, fmt.Errorf("invalid nonce %d, expected: %d", tx.Nonce, treasurer.Nonce)
 	}
@@ -1150,6 +1153,9 @@ func MintTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *vstate.
 			txSenderAddress.String(),
 		)
 	}
+	if tx.GetNonce() == 0 {
+		tx.Nonce = treasurer.Nonce
+	}
 	if tx.Nonce != treasurer.Nonce {
 		return fmt.Errorf("invalid nonce %d, expected: %d", tx.Nonce, treasurer.Nonce)
 	}
@@ -1211,6 +1217,9 @@ func SendTokensTxCheck(vtx *models.Tx, txBytes, signature []byte, state *vstate.
 	}
 	if acc == nil {
 		return vstate.ErrAccountNotExist
+	}
+	if tx.GetNonce() == 0 {
+		tx.Nonce = acc.Nonce
 	}
 	if tx.Nonce != acc.Nonce {
 		return fmt.Errorf("invalid nonce, expected %d got %d", acc.Nonce, tx.Nonce)


### PR DESCRIPTION
after thinking about the "mempool ordering" thing for the Nth time, i still don't see how setting a Priority field would help.

in fact, i wonder what's the current issue or problem. is it only race conditions during tests?

because in that case, AFAIU the main problem is getting the nonce right. for that matter, i thought why not let the node choose the nonce? so here's a dirty POC for RFC and with that feedback prepare a "real" PR or discard the idea altogether and go back to brainstorming