### PR TITLE
indexer: add afterSyncBootStrap test

### DIFF
--- a/vochain/state/eventlistener.go
+++ b/vochain/state/eventlistener.go
@@ -38,3 +38,8 @@ type EventListener interface {
 func (v *State) AddEventListener(l EventListener) {
 	v.eventListeners = append(v.eventListeners, l)
 }
+
+// CleanEventListeners removes all event listeners.
+func (v *State) CleanEventListeners() {
+	v.eventListeners = nil
+}


### PR DESCRIPTION
Before migrating this function from badgerhold to sqlite we need to have a test.

The implemented test is basic, but sets the logic for extending it when the migration is performed.

As bonus, get the envelopes from the State instead of the blockstore.

Signed-off-by: p4u <pau@dabax.net>