### PR TITLE
indexer: compute results and get envelope from statedb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.uber.org/zap v1.21.0 // indirect
-	go.vocdoni.io/proto v1.13.4-0.20230117100158-5cb6dd43f510
+	go.vocdoni.io/proto v1.14.1-0.20230124095055-c3e02490cdfe
 	golang.org/x/crypto v0.1.0
 	golang.org/x/net v0.1.0
 	google.golang.org/protobuf v1.28.1
@@ -74,13 +74,7 @@ require (
 
 require github.com/iancoleman/strcase v0.2.0
 
-require (
-	github.com/iden3/go-rapidsnark/prover v0.0.9
-	github.com/iden3/go-rapidsnark/types v0.0.2
-	github.com/iden3/go-rapidsnark/verifier v0.0.3
-	github.com/iden3/go-rapidsnark/witness v0.0.3
-	github.com/rs/zerolog v1.28.0
-)
+require github.com/rs/zerolog v1.28.0
 
 require (
 	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3161,8 +3161,8 @@ go.vocdoni.io/proto v0.1.8/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M
 go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
 go.vocdoni.io/proto v1.13.3-0.20211019215004-0ca7d4436553/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
-go.vocdoni.io/proto v1.13.4-0.20230117100158-5cb6dd43f510 h1:IS8BvfhIwvzCIleKVhCpfLMVws/44L2WW4et6110rKM=
-go.vocdoni.io/proto v1.13.4-0.20230117100158-5cb6dd43f510/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
+go.vocdoni.io/proto v1.14.1-0.20230124095055-c3e02490cdfe h1:qgZvXPrqGRfD4G2Au1KAF3XYY7NND/kPu7BNZTOn6wc=
+go.vocdoni.io/proto v1.14.1-0.20230124095055-c3e02490cdfe/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20200411211856-f5505b9728dd/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=
 go4.org v0.0.0-20201209231011-d4a079459e60 h1:iqAGo78tVOJXELHQFRjR6TMwItrvXH4hrGJ32I/NFF8=

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -411,6 +411,7 @@ func (idx *Indexer) AfterSyncBootstrap() {
 			"electionID": fmt.Sprintf("%x", p),
 			"weight":     results.Weight,
 			"votes":      len(results.Votes),
+			"results":    results.String(),
 		})
 		// Add process to live results so new votes will be added
 		idx.addProcessToLiveResults(p)

--- a/vochain/indexer/indexertypes/results.go
+++ b/vochain/indexer/indexertypes/results.go
@@ -34,7 +34,7 @@ type Results struct {
 func (r *Results) String() string {
 	results := bytes.Buffer{}
 	for _, q := range r.Votes {
-		results.WriteString(" [")
+		results.WriteString("[")
 		for j, o := range q {
 			results.WriteString(o.String())
 			if j < len(q)-1 {

--- a/vochain/state/votes.go
+++ b/vochain/state/votes.go
@@ -113,14 +113,16 @@ func (s *State) AddVote(vote *Vote) error {
 	// save block number
 	vote.Height = s.CurrentHeight()
 
+	// get the vote from state database
 	sdbVote, err := s.Vote(vote.ProcessID, vote.Nullifier, false)
 	if err != nil {
 		if errors.Is(err, ErrVoteNotFound) {
 			sdbVote = &models.StateDBVote{
-				VoteHash:    vote.Hash(),
-				Nullifier:   vote.Nullifier,
-				Weight:      vote.WeightBytes(),
-				VotePackage: vote.VotePackage,
+				VoteHash:             vote.Hash(),
+				Nullifier:            vote.Nullifier,
+				Weight:               vote.WeightBytes(),
+				VotePackage:          vote.VotePackage,
+				EncryptionKeyIndexes: vote.EncryptionKeyIndexes,
 			}
 		} else {
 			return err
@@ -130,6 +132,7 @@ func (s *State) AddVote(vote *Vote) error {
 		sdbVote.VoteHash = vote.Hash()
 		sdbVote.VotePackage = vote.VotePackage
 		sdbVote.Weight = vote.WeightBytes()
+		sdbVote.EncryptionKeyIndexes = vote.EncryptionKeyIndexes
 		if sdbVote.OverwriteCount != nil {
 			*sdbVote.OverwriteCount++
 		} else {


### PR DESCRIPTION
Since we are now storing the votes into the state database, we do not need to access the tendermint blockstore anymore.

Pending TODO: store the txHash into the indexer voteRef so we don't need to access the blockstore anymore.

Signed-off-by: p4u <pau@dabax.net>