### PR TITLE
ci: analyze code coverage in 'go test', and send to coverall.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         run: go mod tidy
       - name: Run Go test
         if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/stage' && !startsWith(github.ref, 'refs/heads/release') && github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/apiv2'
-        run: go test ./...
+        run: go test -coverprofile=covprofile ./...
       - name: Run Go test race
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stage' || startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/apiv2'
         run: |
@@ -76,6 +76,12 @@ jobs:
           export LOG_PANIC_ON_INVALIDCHARS=true
           # -race can easily make the crypto stuff 10x slower
           go test -vet=off -timeout=15m -race ./...
+      - name: Send coverage to coverall.io
+        env:
+          COVERALLS_TOKEN: ${{ secrets.github_token }}
+        run: |
+          go install github.com/mattn/goveralls@latest
+          goveralls -coverprofile=covprofile -service=github
 
   job_compose_test:
     runs-on: [self-hosted, ci2-1]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GoDoc](https://godoc.org/go.vocdoni.io/dvote?status.svg)](https://godoc.org/go.vocdoni.io/dvote)
 [![Go Report Card](https://goreportcard.com/badge/go.vocdoni.io/dvote)](https://goreportcard.com/report/go.vocdoni.io/dvote)
+[![Coverage Status](https://coveralls.io/repos/github/vocdoni/vocdoni-node/badge.svg)](https://coveralls.io/github/vocdoni/vocdoni-node)
 
 [![Join Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/xFTh8Np2ga)
 [![Twitter Follow](https://img.shields.io/twitter/follow/vocdoni.svg?style=social&label=Follow)](https://twitter.com/vocdoni)


### PR DESCRIPTION
adapted from @p4u 4799f58a add coverage analysis using coverall.io API and gh actions