### PR TITLE
Helper functions to encode and decode census type between protobuf definition and API constants

### DIFF
--- a/api/census_helpers.go
+++ b/api/census_helpers.go
@@ -8,7 +8,11 @@ import (
 	"go.vocdoni.io/proto/build/go/models"
 )
 
-func censusType(t string) (models.Census_Type, bool) {
+// decodeCensusType decodes the given census type string to a valid
+// models.Census_Type value, by default models.Census_UNKNOWN. This function
+// also returns a boolean indicating whether the current census is indexed or
+// not.
+func decodeCensusType(t string) (models.Census_Type, bool) {
 	switch t {
 	case CensusTypeZK:
 		return models.Census_ARBO_POSEIDON, true
@@ -18,6 +22,21 @@ func censusType(t string) (models.Census_Type, bool) {
 		return models.Census_ARBO_BLAKE2B, false
 	}
 	return models.Census_UNKNOWN, false
+}
+
+// encodeCensusType returns the string version of the given models.Census_Type, by
+// default CensusTypeUnknown.
+func encodeCensusType(t models.Census_Type) string {
+	switch t {
+	case models.Census_ARBO_POSEIDON:
+		return CensusTypeZKWeighted
+	case models.Census_ARBO_BLAKE2B:
+		return CensusTypeWeighted
+	case models.Census_CA:
+		return CensusTypeCSP
+	}
+
+	return CensusTypeUnknown
 }
 
 func censusIDparse(censusID string) ([]byte, error) {

--- a/api/censuses.go
+++ b/api/censuses.go
@@ -150,7 +150,7 @@ func (a *API) censusCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCont
 	if err != nil {
 		return err
 	}
-	censusType, indexed := censusType(ctx.URLParam("type"))
+	censusType, indexed := decodeCensusType(ctx.URLParam("type"))
 	if censusType == models.Census_UNKNOWN {
 		return ErrCensusTypeUnknown
 	}
@@ -267,16 +267,8 @@ func (a *API) censusTypeHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContex
 		return err
 	}
 
-	// Set unknown as default type and check other available types
-	censusType := CensusTypeUnknown
-	switch ref.CensusType {
-	case int32(models.Census_ARBO_POSEIDON):
-		censusType = CensusTypeZKWeighted
-	case int32(models.Census_ARBO_BLAKE2B):
-		censusType = CensusTypeWeighted
-	case int32(models.Census_CA):
-		censusType = CensusTypeCSP
-	}
+	// Encode the current censusType to string
+	censusType := encodeCensusType(models.Census_Type(ref.CensusType))
 
 	// Envolves the type into the Census struct and return it as JSON
 	data, err := json.Marshal(Census{Type: censusType})
@@ -581,15 +573,7 @@ func (a *API) censusProofHandler(msg *apirest.APIdata, ctx *httprouter.HTTPConte
 
 	// Get the census type to return it into the response to prevent to perform
 	// two api calls.
-	censusType := CensusTypeUnknown
-	switch ref.CensusType {
-	case int32(models.Census_ARBO_POSEIDON):
-		censusType = CensusTypeZKWeighted
-	case int32(models.Census_ARBO_BLAKE2B):
-		censusType = CensusTypeWeighted
-	case int32(models.Census_CA):
-		censusType = CensusTypeCSP
-	}
+	censusType := encodeCensusType(models.Census_Type(ref.CensusType))
 
 	// If the census type is zkweighted (that means that it uses Poseidon hash
 	// with Arbo merkle tree), skip to perform a hash function over the census


### PR DESCRIPTION
Currently the API uses the existing private helper `api.censusType()` to encode a given census type string into a valid `models.Census_Type` value. After the #807 merge, the inverse logic is needed in more than one place so we decide to create a function with the inverse operation, that converts a given `models.Census_Type` into a valid string value, solving #813.

To implement this change, the old function `api.censusType()` function has been renamed to `api.decodeCensusType()` and the new function with the inverse logic has been named as `api.encodeCensusType`. 