### PR TITLE
Bug: wrap api lists into objects

### DIFF
--- a/api/chain.go
+++ b/api/chain.go
@@ -14,6 +14,7 @@ import (
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/dvote/vochain/indexer"
+	"go.vocdoni.io/dvote/vochain/indexer/indexertypes"
 )
 
 const (
@@ -317,14 +318,11 @@ func (a *API) chainTxListPaginated(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 	if err != nil {
 		return err
 	}
-	// wrap list in a map to consistently return list in a object, return empty
+	// wrap list in a struct to consistently return list in a object, return empty
 	// object if the list does not contains any result
-	res := map[string]interface{}{}
-	if len(refs) > 0 {
-		res["transactions"] = refs
-	}
-
-	data, err := json.Marshal(res)
+	data, err := json.Marshal(struct {
+		Txs []*indexertypes.TxReference `json:"transactions,omitempty"`
+	}{refs})
 	if err != nil {
 		return err
 	}

--- a/api/chain.go
+++ b/api/chain.go
@@ -317,8 +317,14 @@ func (a *API) chainTxListPaginated(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 	if err != nil {
 		return err
 	}
-	// wrap list in a map to consistently return list in a object
-	data, err := json.Marshal(map[string]interface{}{"transactions": refs})
+	// wrap list in a map to consistently return list in a object, return empty
+	// object if the list does not contains any result
+	res := map[string]interface{}{}
+	if len(refs) > 0 {
+		res["transactions"] = refs
+	}
+
+	data, err := json.Marshal(res)
 	if err != nil {
 		return err
 	}

--- a/api/chain.go
+++ b/api/chain.go
@@ -317,7 +317,8 @@ func (a *API) chainTxListPaginated(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 	if err != nil {
 		return err
 	}
-	data, err := json.Marshal(refs)
+	// wrap list in a map to consistently return list in a object
+	data, err := json.Marshal(map[string]interface{}{"transactions": refs})
 	if err != nil {
 		return err
 	}

--- a/api/chain.go
+++ b/api/chain.go
@@ -158,18 +158,20 @@ func (a *API) organizationListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 		}
 	}
 	page = page * MaxPageSize
-	organization := &Organization{}
+	organizations := []*OrganizationList{}
 
 	list := a.indexer.EntityList(MaxPageSize, page, "")
 	for _, orgID := range list {
-		organization.Organizations = append(organization.Organizations, &OrganizationList{
+		organizations = append(organizations, &OrganizationList{
 			OrganizationID: orgID,
 			ElectionCount:  a.indexer.ProcessCount(orgID),
 		})
 	}
 
-	var data []byte
-	if data, err = json.Marshal(organization); err != nil {
+	data, err := json.Marshal(struct {
+		Organizations []*OrganizationList `json:"organizations"`
+	}{organizations})
+	if err != nil {
 		return err
 	}
 
@@ -321,7 +323,7 @@ func (a *API) chainTxListPaginated(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 	// wrap list in a struct to consistently return list in a object, return empty
 	// object if the list does not contains any result
 	data, err := json.Marshal(struct {
-		Txs []*indexertypes.TxReference `json:"transactions,omitempty"`
+		Txs []*indexertypes.TxReference `json:"transactions"`
 	}{refs})
 	if err != nil {
 		return err

--- a/api/elections.go
+++ b/api/elections.go
@@ -129,9 +129,6 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrCantFetchElectionList, err)
 	}
-	// if len(elections) == 0 {
-	// 	return ctx.Send(nil, apirest.HTTPstatusCodeNotFound)
-	// }
 
 	list := []ElectionSummary{}
 	for _, eid := range elections {

--- a/api/elections.go
+++ b/api/elections.go
@@ -153,8 +153,8 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 			VoteCount:      count,
 		})
 	}
-
-	data, err := json.Marshal(list)
+	// wrap list in a map to consistently return list in a object
+	data, err := json.Marshal(map[string]interface{}{"elections:": list})
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
 	}

--- a/api/elections.go
+++ b/api/elections.go
@@ -129,11 +129,11 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrCantFetchElectionList, err)
 	}
-	if len(elections) == 0 {
-		return ctx.Send(nil, apirest.HTTPstatusCodeNotFound)
-	}
+	// if len(elections) == 0 {
+	// 	return ctx.Send(nil, apirest.HTTPstatusCodeNotFound)
+	// }
 
-	var list []ElectionSummary
+	list := []ElectionSummary{}
 	for _, eid := range elections {
 		e, err := a.indexer.ProcessInfo(eid)
 		if err != nil {

--- a/api/elections.go
+++ b/api/elections.go
@@ -153,13 +153,11 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 			VoteCount:      count,
 		})
 	}
-	// wrap list in a map to consistently return list in a object, return empty
+	// wrap list in a struct to consistently return list in a object, return empty
 	// object if the list does not contains any result
-	res := map[string]interface{}{}
-	if len(list) > 0 {
-		res["elections"] = list
-	}
-	data, err := json.Marshal(res)
+	data, err := json.Marshal(struct {
+		Elections []ElectionSummary `json:"elections,omitempty"`
+	}{list})
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
 	}
@@ -333,7 +331,9 @@ func (a *API) electionVotesHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 			TransactionIndex: &v.TxIndex,
 		})
 	}
-	data, err := json.Marshal(votes)
+	data, err := json.Marshal(struct {
+		Votes []Vote `json:"votes,omitempty"`
+	}{votes})
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
 	}

--- a/api/elections.go
+++ b/api/elections.go
@@ -156,7 +156,7 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 	// wrap list in a struct to consistently return list in a object, return empty
 	// object if the list does not contains any result
 	data, err := json.Marshal(struct {
-		Elections []ElectionSummary `json:"elections,omitempty"`
+		Elections []ElectionSummary `json:"elections"`
 	}{list})
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
@@ -297,8 +297,8 @@ func (a *API) electionKeysHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCont
 	return ctx.Send(data, apirest.HTTPstatusCodeOK)
 }
 
-// GET elections/<electionID>/votes
-// GET elections/<electionID>/votes/page/<page>
+// GET /elections/<electionID>/votes
+// GET /elections/<electionID>/votes/page/<page>
 // returns the list of voteIDs for an election (paginated)
 func (a *API) electionVotesHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	electionID, err := hex.DecodeString(util.TrimHex(ctx.URLParam("electionID")))
@@ -332,7 +332,7 @@ func (a *API) electionVotesHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 		})
 	}
 	data, err := json.Marshal(struct {
-		Votes []Vote `json:"votes,omitempty"`
+		Votes []Vote `json:"votes"`
 	}{votes})
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
@@ -469,7 +469,7 @@ func (a *API) electionScrutinyHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 	return ctx.Send(data, apirest.HTTPstatusCodeOK)
 }
 
-// POST elections
+// POST /elections
 // creates a new election
 func (a *API) electionCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	req := &ElectionCreate{}

--- a/api/elections.go
+++ b/api/elections.go
@@ -153,8 +153,13 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 			VoteCount:      count,
 		})
 	}
-	// wrap list in a map to consistently return list in a object
-	data, err := json.Marshal(map[string]interface{}{"elections:": list})
+	// wrap list in a map to consistently return list in a object, return empty
+	// object if the list does not contains any result
+	res := map[string]interface{}{}
+	if len(list) > 0 {
+		res["elections"] = list
+	}
+	data, err := json.Marshal(res)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
 	}

--- a/api/vote.go
+++ b/api/vote.go
@@ -45,7 +45,7 @@ func (a *API) enableVoteHandlers() error {
 	return nil
 }
 
-// /votes
+// POST /votes
 // submit a vote
 func (a *API) submitVoteHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	req := &Vote{}
@@ -78,7 +78,7 @@ func (a *API) submitVoteHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContex
 	return ctx.Send(data, apirest.HTTPstatusCodeOK)
 }
 
-// /votes/<voteID>
+// GET /votes/<voteID>
 // get a vote by its voteID (nullifier)
 func (a *API) getVoteHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	voteID, err := hex.DecodeString(util.TrimHex(ctx.URLParam("voteID")))
@@ -122,7 +122,7 @@ func (a *API) getVoteHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) 
 	return ctx.Send(data, apirest.HTTPstatusCodeOK)
 }
 
-// /votes/verify/<electionID>/<voteID>
+// GET /votes/verify/<electionID>/<voteID>
 // verify a vote (get basic information)
 func (a *API) verifyVoteHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	voteID, err := hex.DecodeString(util.TrimHex(ctx.URLParam("voteID")))

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -136,7 +136,7 @@ func (a *API) walletSignAndSendTx(stx *models.SignedTx, wallet *ethereum.SignKey
 	}, nil
 }
 
-// /wallet/add/{privateKey}
+// POST /wallet/add/{privateKey}
 // add a new account to the local store
 func (a *API) walletAddHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	// check private key format is correct and transorm it to wallet and bytes
@@ -193,7 +193,7 @@ func (a *API) walletAddHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext
 	return ctx.Send(data, apirest.HTTPstatusCodeOK)
 }
 
-// /wallet/bootstrap
+// GET /wallet/bootstrap
 // set a new account
 func (a *API) walletCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	wallet, err := a.walletFromToken(msg.AuthToken)
@@ -232,7 +232,7 @@ func (a *API) walletCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCont
 	return ctx.Send(data, apirest.HTTPstatusCodeOK)
 }
 
-// /wallet/transfer/{dstAddress}/{amount}
+// GET /wallet/transfer/{dstAddress}/{amount}
 // transfer balance to another account
 func (a *API) walletTransferHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	wallet, err := a.walletFromToken(msg.AuthToken)
@@ -282,7 +282,7 @@ func (a *API) walletTransferHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCo
 	return ctx.Send(data, apirest.HTTPstatusCodeOK)
 }
 
-// /wallet/election POST
+// POST /wallet/election
 // creates an election
 func (a *API) walletElectionHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	wallet, err := a.walletFromToken(msg.AuthToken)


### PR DESCRIPTION
Attempt to fix the [`vocdoni/interoperability` issue #9](https://github.com/vocdoni/interoperability/issues/9), which explains how the API returns list results in different formats: a raw list of items or an object containing a single key with the list as a value.

The aim of this fix is to ensure that the API returns lists in a consistent way, wrapped in an object if the resulting list is not empty, or an empty object if it is.

Only two API handlers are involved in the fix:
* `api.chainTxListPaginated()` (api/chain.go#L331), that handles `/chain/transactions/page/<pageNumber>` endpoint.
* `api.electionFullListHandler()` (api/election.go#L119), that handles `/elections` endpoint.
* `api.electionVotesHandler()` (api/election.go#L301), that handles `elections/<electionID>/votes` and `elections/<electionID>/votes/page/<page>` endpoints.

Neither case has a struct for a list of results returned by the API handlers, so the implemented solution wraps the results in a inline defined struct with the key expected before marshalling. This solution was implemented in other API endpoints such as `/elections/<electionID>/votes/count`

Another possible solution would be to create two structs to wrap this particular type of item for both cases, such as a list of ElectionSummary's and a list of TxReference's.