### PR TITLE
ApiClient WaitUntilElectionStatus helper updated to handle 404 errors

### DIFF
--- a/apiclient/helpers.go
+++ b/apiclient/helpers.go
@@ -144,7 +144,9 @@ func (c *HTTPclient) WaitUntilElectionStatus(ctx context.Context,
 	for {
 		election, err := c.Election(electionID)
 		if err != nil {
-			if !strings.Contains(err.Error(), "no rows in result set") {
+			// Return an error if the received error is not a '404 - Not found'
+			// error which means that the election has not yet been created.
+			if !strings.Contains(err.Error(), "API error: 404") {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
The `HTTPclient.WaitUntilElectionStatus()` helper function locks the current function and waits until the provided election has reached the provided status. This is achieved, by making GET requests to `/elections/<electionID>` API endpoint in an infinite loop, comparing the status of this election with the data received.

If this helper function is used to wait for an election to reach "CREATED" status, the API will return a 404 error without any message until the election reaches it. This case was not supported by the current implementation of this helper, and may be updated.

To handle this error, the error string comparison may be updated.