### PR TITLE
make all binaries now report their version (internal.Version)

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -16,6 +16,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
+	"go.vocdoni.io/dvote/internal"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -31,6 +32,10 @@ var (
 )
 
 func main() {
+	// Report the version before loading the config or logger init, just in case something goes wrong.
+	// For the sake of including the version in the log, it's also included in a log line later on.
+	fmt.Fprintf(os.Stderr, "vocdoni version %q\n", internal.Version)
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
@@ -40,6 +45,7 @@ func main() {
 	cfgFile := flag.String("config", filepath.Join(home, ".vocdoni-cli.json"), "config file")
 	flag.Parse()
 	log.Init(*logLevel, "stdout")
+	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
 
 	cli, err := NewVocdoniCLI(*cfgFile, *host)
 	if err != nil {

--- a/cmd/end2endtest/main.go
+++ b/cmd/end2endtest/main.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,7 @@ import (
 	flag "github.com/spf13/pflag"
 	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/internal"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/proto/build/go/models"
 
@@ -82,6 +84,10 @@ type config struct {
 }
 
 func main() {
+	// Report the version before loading the config or logger init, just in case something goes wrong.
+	// For the sake of including the version in the log, it's also included in a log line later on.
+	fmt.Fprintf(os.Stderr, "vocdoni version %q\n", internal.Version)
+
 	c := config{}
 	flag.StringVar(&c.host, "host", "https://api-dev.vocdoni.net/v2", "API host to connect to")
 	flag.StringVar(&c.logLevel, "logLevel", "info", "log level (debug, info, warn, error, fatal)")
@@ -114,6 +120,7 @@ func main() {
 	flag.Parse()
 
 	log.Init(c.logLevel, "stdout")
+	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
 
 	rand.Seed(time.Now().UnixNano())
 

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -298,11 +298,8 @@ func newConfig() (*config.Config, config.Error) {
 }
 
 func main() {
-	// Don't use the log package here, because we want to report the version
-	// before loading the config. This is because something could go wrong
-	// while loading the config, and because the logger isn't set up yet.
-	// For the sake of including the version in the log, it's also included
-	// in a log line later on.
+	// Report the version before loading the config or logger init, just in case something goes wrong.
+	// For the sake of including the version in the log, it's also included in a log line later on.
 	fmt.Fprintf(os.Stderr, "vocdoni version %q\n", internal.Version)
 
 	// creating config and init logger
@@ -384,8 +381,7 @@ func main() {
 		}()
 	}
 
-	log.Infof("starting vocdoni node version %q in %s mode",
-		internal.Version, globalCfg.Mode)
+	log.Infow("starting vocdoni node", "version", internal.Version, "mode", globalCfg.Mode)
 	if globalCfg.Dev {
 		log.Warn("developer mode is enabled!")
 	}

--- a/cmd/vochaininspector/inspector.go
+++ b/cmd/vochaininspector/inspector.go
@@ -15,6 +15,7 @@ import (
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/metadb"
+	"go.vocdoni.io/dvote/internal"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/service"
 	"go.vocdoni.io/dvote/statedb"
@@ -28,6 +29,10 @@ import (
 )
 
 func main() {
+	// Report the version before loading the config or logger init, just in case something goes wrong.
+	// For the sake of including the version in the log, it's also included in a log line later on.
+	fmt.Fprintf(os.Stderr, "vocdoni version %q\n", internal.Version)
+
 	var dataDir, chain, action, logLevel, pid string
 	var blockHeight int
 	home, err := os.UserHomeDir()
@@ -51,6 +56,7 @@ func main() {
 
 	flag.Parse()
 	log.Init(logLevel, "stdout")
+	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
 
 	switch action {
 	case "listProcess":

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/internal"
 	"go.vocdoni.io/dvote/log"
 	client "go.vocdoni.io/dvote/rpcclient"
 	"go.vocdoni.io/dvote/types"
@@ -53,6 +55,10 @@ func opsAvailable() (opsav []string) {
 }
 
 func main() {
+	// Report the version before loading the config or logger init, just in case something goes wrong.
+	// For the sake of including the version in the log, it's also included in a log line later on.
+	fmt.Fprintf(os.Stderr, "vocdoni version %q\n", internal.Version)
+
 	// starting test
 
 	loglevel := flag.String("logLevel", "info", "log level")
@@ -104,6 +110,8 @@ func main() {
 	}
 	flag.Parse()
 	log.Init(*loglevel, "stdout")
+	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
+
 	rand.Seed(time.Now().UnixNano())
 
 	accountKeys := make([]*ethereum.SignKeys, len(*accountPrivKeys))

--- a/cmd/voconed/voconed.go
+++ b/cmd/voconed/voconed.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 	"go.vocdoni.io/dvote/api/faucet"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/internal"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/vochain/state"
 	"go.vocdoni.io/dvote/vocone"
@@ -29,6 +31,10 @@ type VoconeConfig struct {
 }
 
 func main() {
+	// Report the version before loading the config or logger init, just in case something goes wrong.
+	// For the sake of including the version in the log, it's also included in a log line later on.
+	fmt.Fprintf(os.Stderr, "vocdoni version %q\n", internal.Version)
+
 	config := VoconeConfig{}
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -135,6 +141,8 @@ func main() {
 	}
 
 	log.Init(config.logLevel, "stdout")
+	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
+
 	log.Infof("using data directory at %s", config.dir)
 
 	mngKey := ethereum.SignKeys{}


### PR DESCRIPTION
trying to debug an issue with voconed:latest docker image, i found out the only binary reporting its version is `node`.

here i replicate that very useful behaviour in all binaries