### PR TITLE
apirest: fix APIerror returns, since fmt.Errorf was not really working

### DIFF
--- a/api/chain.go
+++ b/api/chain.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -274,17 +273,17 @@ func (a *API) chainEstimateHeightHandler(msg *apirest.APIdata, ctx *httprouter.H
 func (a *API) chainSendTxHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	req := &Transaction{}
 	if err := json.Unmarshal(msg.Data, req); err != nil {
-		return fmt.Errorf("%w: %v", ErrCantParseDataAsJSON, err)
+		return ErrCantParseDataAsJSON.WithErr(err)
 	}
 	res, err := a.vocapp.SendTx(req.Payload)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrVochainSendTxFailed, err)
+		return ErrVochainSendTxFailed.WithErr(err)
 	}
 	if res == nil {
 		return ErrVochainEmptyReply
 	}
 	if res.Code != 0 {
-		return fmt.Errorf("%w: (%d) %s", ErrVochainReturnedErrorCode, res.Code, string(res.Data))
+		return ErrVochainReturnedErrorCode.Withf("(%d) %s", res.Code, string(res.Data))
 	}
 	var data []byte
 	if data, err = json.Marshal(Transaction{
@@ -358,7 +357,7 @@ func (a *API) chainTxbyHashHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 		if errors.Is(err, indexer.ErrTransactionNotFound) {
 			return ErrTransactionNotFound
 		}
-		return fmt.Errorf("cannot get transaction reference: %w", err)
+		return ErrTransactionNotFound.WithErr(err)
 	}
 	data, err := json.Marshal(ref)
 	if err != nil {
@@ -383,7 +382,7 @@ func (a *API) chainTxHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) 
 		if errors.Is(err, vochain.ErrTransactionNotFound) {
 			return ErrTransactionNotFound
 		}
-		return fmt.Errorf("%w: %v", ErrVochainGetTxFailed, err)
+		return ErrVochainGetTxFailed.WithErr(err)
 	}
 	return ctx.Send([]byte(protoFormat(stx.Tx)), apirest.HTTPstatusOK)
 }
@@ -399,7 +398,7 @@ func (a *API) chainTxByIndexHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCo
 		if errors.Is(err, indexer.ErrTransactionNotFound) {
 			return ErrTransactionNotFound
 		}
-		return fmt.Errorf("%w: %v", ErrVochainGetTxFailed, err)
+		return ErrVochainGetTxFailed.WithErr(err)
 	}
 	data, err := json.Marshal(ref)
 	if err != nil {

--- a/api/elections.go
+++ b/api/elections.go
@@ -122,23 +122,23 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 		var err error
 		page, err = strconv.Atoi(ctx.URLParam("page"))
 		if err != nil {
-			return fmt.Errorf("%w (%s)", ErrCantParsePageNumber, ctx.URLParam("page"))
+			return ErrCantParsePageNumber.With(ctx.URLParam("page"))
 		}
 	}
 	elections, err := a.indexer.ProcessList(nil, page*MaxPageSize, MaxPageSize, "", 0, 0, "", false)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrCantFetchElectionList, err)
+		return ErrCantFetchElectionList.WithErr(err)
 	}
 
 	list := []ElectionSummary{}
 	for _, eid := range elections {
 		e, err := a.indexer.ProcessInfo(eid)
 		if err != nil {
-			return fmt.Errorf("%w (%x): %v", ErrCantFetchElection, eid, err)
+			return ErrCantFetchElection.Withf("(%x): %v", eid, err)
 		}
 		count, err := a.indexer.GetEnvelopeHeight(eid)
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrCantFetchEnvelopeHeight, err)
+			return ErrCantFetchEnvelopeHeight.WithErr(err)
 		}
 		list = append(list, ElectionSummary{
 			ElectionID:     eid,
@@ -156,7 +156,7 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 		Elections []ElectionSummary `json:"elections"`
 	}{list})
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
+		return ErrMarshalingServerJSONFailed.WithErr(err)
 	}
 	return ctx.Send(data, apirest.HTTPstatusOK)
 }
@@ -166,18 +166,18 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 func (a *API) electionHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	electionID, err := hex.DecodeString(util.TrimHex(ctx.URLParam("electionID")))
 	if err != nil {
-		return fmt.Errorf("%w (%s): %v", ErrCantParseElectionID, ctx.URLParam("electionID"), err)
+		return ErrCantParseElectionID.Withf("(%s): %v", ctx.URLParam("electionID"), err)
 	}
 	proc, err := a.indexer.ProcessInfo(electionID)
 	if err != nil {
 		if errors.Is(err, indexer.ErrProcessNotFound) {
 			return ErrElectionNotFound
 		}
-		return fmt.Errorf("%w (%x): %v", ErrCantFetchElection, electionID, err)
+		return ErrCantFetchElection.Withf("(%x): %v", electionID, err)
 	}
 	count, err := a.indexer.GetEnvelopeHeight(electionID)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrCantFetchEnvelopeHeight, err)
+		return ErrCantFetchEnvelopeHeight.WithErr(err)
 	}
 
 	election := Election{
@@ -206,7 +206,7 @@ func (a *API) electionHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext)
 	if proc.HaveResults {
 		results, err := a.indexer.GetResults(electionID)
 		if err != nil {
-			return fmt.Errorf("%w (%x): %v", ErrCantFetchElectionResults, electionID, err)
+			return ErrCantFetchElectionResults.Withf("(%x): %v", electionID, err)
 		}
 		election.Results = results.Votes
 	}
@@ -228,7 +228,7 @@ func (a *API) electionHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext)
 	}
 	data, err := json.Marshal(election)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
+		return ErrMarshalingServerJSONFailed.WithErr(err)
 	}
 	return ctx.Send(data, apirest.HTTPstatusOK)
 }
@@ -238,7 +238,7 @@ func (a *API) electionHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext)
 func (a *API) electionVotesCountHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	electionID, err := hex.DecodeString(util.TrimHex(ctx.URLParam("electionID")))
 	if err != nil || electionID == nil {
-		return fmt.Errorf("%w (%s): %v", ErrCantParseElectionID, ctx.URLParam("electionID"), err)
+		return ErrCantParseElectionID.Withf("(%s): %v", ctx.URLParam("electionID"), err)
 	}
 	// check process exists and return 404 if not
 	if _, err := getElection(electionID, a.vocapp.State); err != nil {
@@ -252,7 +252,7 @@ func (a *API) electionVotesCountHandler(msg *apirest.APIdata, ctx *httprouter.HT
 		}{Count: count},
 	)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
+		return ErrMarshalingServerJSONFailed.WithErr(err)
 	}
 	return ctx.Send(data, apirest.HTTPstatusOK)
 }
@@ -262,7 +262,7 @@ func (a *API) electionVotesCountHandler(msg *apirest.APIdata, ctx *httprouter.HT
 func (a *API) electionKeysHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	electionID, err := hex.DecodeString(util.TrimHex(ctx.URLParam("electionID")))
 	if err != nil || electionID == nil {
-		return fmt.Errorf("%w (%s): %v", ErrCantParseElectionID, ctx.URLParam("electionID"), err)
+		return ErrCantParseElectionID.Withf("(%s): %v", ctx.URLParam("electionID"), err)
 	}
 	process, err := getElection(electionID, a.vocapp.State)
 	if err != nil {
@@ -290,7 +290,7 @@ func (a *API) electionKeysHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCont
 
 	data, err := json.Marshal(election)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
+		return ErrMarshalingServerJSONFailed.WithErr(err)
 	}
 	return ctx.Send(data, apirest.HTTPstatusOK)
 }
@@ -301,7 +301,7 @@ func (a *API) electionKeysHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCont
 func (a *API) electionVotesHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	electionID, err := hex.DecodeString(util.TrimHex(ctx.URLParam("electionID")))
 	if err != nil || electionID == nil {
-		return fmt.Errorf("%w (%s): %v", ErrCantParseElectionID, ctx.URLParam("electionID"), err)
+		return ErrCantParseElectionID.Withf("(%s): %v", ctx.URLParam("electionID"), err)
 	}
 	if _, err := getElection(electionID, a.vocapp.State); err != nil {
 		return err
@@ -336,7 +336,7 @@ func (a *API) electionVotesHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 		Votes []Vote `json:"votes"`
 	}{votes})
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
+		return ErrMarshalingServerJSONFailed.WithErr(err)
 	}
 	return ctx.Send(data, apirest.HTTPstatusOK)
 }
@@ -346,7 +346,7 @@ func (a *API) electionVotesHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 func (a *API) electionScrutinyHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	electionID, err := hex.DecodeString(util.TrimHex(ctx.URLParam("electionID")))
 	if err != nil || electionID == nil {
-		return fmt.Errorf("%w (%s): %v", ErrCantParseElectionID, ctx.URLParam("electionID"), err)
+		return ErrCantParseElectionID.Withf("(%s): %v", ctx.URLParam("electionID"), err)
 	}
 	process, err := getElection(electionID, a.vocapp.State)
 	if err != nil {
@@ -454,12 +454,12 @@ func (a *API) electionScrutinyHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 		electionResults.Results,
 	)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrCantABIEncodeResults, err)
+		return ErrCantABIEncodeResults.WithErr(err)
 	}
 
 	data, err := json.Marshal(electionResults)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrMarshalingServerJSONFailed, err)
+		return ErrMarshalingServerJSONFailed.WithErr(err)
 	}
 	return ctx.Send(data, apirest.HTTPstatusOK)
 }
@@ -505,7 +505,7 @@ func (a *API) electionCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCo
 		// if election metadata defined, check the format
 		metadata := ElectionMetadata{}
 		if err := json.Unmarshal(req.Metadata, &metadata); err != nil {
-			return fmt.Errorf("%w: %v", ErrCantParseMetadataAsJSON, err)
+			return ErrCantParseMetadataAsJSON.WithErr(err)
 		}
 
 		// set metadataCID from metadata bytes
@@ -519,13 +519,13 @@ func (a *API) electionCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCo
 	// send the transaction
 	res, err := a.vocapp.SendTx(req.TxPayload)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrVochainSendTxFailed, err)
+		return ErrVochainSendTxFailed.WithErr(err)
 	}
 	if res == nil {
 		return ErrVochainEmptyReply
 	}
 	if res.Code != 0 {
-		return fmt.Errorf("%w: (%d) %s", ErrVochainReturnedErrorCode, res.Code, string(res.Data))
+		return ErrVochainReturnedErrorCode.Withf("(%d) %s", res.Code, string(res.Data))
 	}
 
 	resp := &ElectionCreate{
@@ -565,7 +565,7 @@ func (a *API) electionCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCo
 // helper endpoint to get the IPFS CID hash of a file
 func (a *API) computeCidHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	if len(msg.Data) > MaxOffchainFileSize {
-		return fmt.Errorf("%w (%d bytes)", ErrFileSizeTooBig, MaxOffchainFileSize)
+		return ErrFileSizeTooBig.Withf("%d vs %d bytes", len(msg.Data), MaxOffchainFileSize)
 	}
 	req := &File{}
 	if err := json.Unmarshal(msg.Data, req); err != nil {

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,7 +1,11 @@
 //nolint:lll
 package api
 
-import "go.vocdoni.io/dvote/httprouter/apirest"
+import (
+	"fmt"
+
+	"go.vocdoni.io/dvote/httprouter/apirest"
+)
 
 // APIerror satisfies the error interface.
 // Error() returns a human-readable description of the error.
@@ -12,79 +16,79 @@ import "go.vocdoni.io/dvote/httprouter/apirest"
 // Do note that HTTPstatus 204 No Content implies the response body will be empty,
 // so the Code and Message will actually be discarded, never sent to the client
 var (
-	ErrAddressMalformed           = apirest.APIerror{Code: 4000, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "address malformed"}
-	ErrDstAddressMalformed        = apirest.APIerror{Code: 4001, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "destination address malformed"}
-	ErrDstAccountUnknown          = apirest.APIerror{Code: 4002, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "destination account is unknown"}
-	ErrAccountNotFound            = apirest.APIerror{Code: 4003, HTTPstatus: apirest.HTTPstatusNotFound, Message: "account not found"}
-	ErrAccountAlreadyExists       = apirest.APIerror{Code: 4004, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "account already exists"}
-	ErrTreasurerNotFound          = apirest.APIerror{Code: 4005, HTTPstatus: apirest.HTTPstatusNotFound, Message: "treasurer account not found"}
-	ErrOrgNotFound                = apirest.APIerror{Code: 4006, HTTPstatus: apirest.HTTPstatusNotFound, Message: "organization not found"}
-	ErrTransactionNotFound        = apirest.APIerror{Code: 4007, HTTPstatus: apirest.HTTPstatusNoContent, Message: "transaction hash not found"}
-	ErrBlockNotFound              = apirest.APIerror{Code: 4008, HTTPstatus: apirest.HTTPstatusNotFound, Message: "block not found"}
-	ErrMetadataProvidedButNoURI   = apirest.APIerror{Code: 4009, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "metadata provided but no metadata URI found in transaction"}
-	ErrMetadataURINotMatchContent = apirest.APIerror{Code: 4010, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "metadata URI does not match metadata content"}
-	ErrMarshalingJSONFailed       = apirest.APIerror{Code: 4011, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "marshaling JSON failed"}
-	ErrFileSizeTooBig             = apirest.APIerror{Code: 4012, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "file size exceeds the maximum allowed"}
-	ErrCantParseOrgID             = apirest.APIerror{Code: 4013, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse organizationID"}
-	ErrCantParseAccountID         = apirest.APIerror{Code: 4014, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse accountID"}
-	ErrCantParseBearerToken       = apirest.APIerror{Code: 4015, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse bearer token"}
-	ErrCantParseDataAsJSON        = apirest.APIerror{Code: 4016, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse data as JSON"}
-	ErrCantParseElectionID        = apirest.APIerror{Code: 4017, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse electionID"}
-	ErrCantParseMetadataAsJSON    = apirest.APIerror{Code: 4018, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse metadata (invalid format)"}
-	ErrCantParsePageNumber        = apirest.APIerror{Code: 4019, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse page number"}
-	ErrCantParsePayloadAsJSON     = apirest.APIerror{Code: 4020, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse payload as JSON"}
-	ErrCantParseVoteID            = apirest.APIerror{Code: 4021, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot parse voteID"}
-	ErrCantExtractMetadataURI     = apirest.APIerror{Code: 4022, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "cannot extract metadata URI"}
-	ErrVoteIDMalformed            = apirest.APIerror{Code: 4023, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "voteID is malformed"}
-	ErrVoteNotFound               = apirest.APIerror{Code: 4024, HTTPstatus: apirest.HTTPstatusNotFound, Message: "vote not found"}
-	ErrCensusIDLengthInvalid      = apirest.APIerror{Code: 4025, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "censusID length is wrong"}
-	ErrCensusRootIsNil            = apirest.APIerror{Code: 4026, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "census root is nil"}
-	ErrCensusTypeUnknown          = apirest.APIerror{Code: 4027, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "census type is unknown"}
-	ErrCensusTypeMismatch         = apirest.APIerror{Code: 4028, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "census type mismatch"}
-	ErrCensusIndexedFlagMismatch  = apirest.APIerror{Code: 4029, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "census indexed flag mismatch"}
-	ErrCensusRootHashMismatch     = apirest.APIerror{Code: 4030, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "census root hash mismatch after importing dump"}
-	ErrParamStatusMissing         = apirest.APIerror{Code: 4031, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "parameter (status) missing or invalid"}
-	ErrParamParticipantsMissing   = apirest.APIerror{Code: 4032, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "parameter (participants) missing"}
-	ErrParamParticipantsTooBig    = apirest.APIerror{Code: 4033, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "parameter (participants) exceeds max length per call"}
-	ErrParamDumpOrRootMissing     = apirest.APIerror{Code: 4034, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "parameter (dump or root) missing"}
-	ErrParamKeyOrProofMissing     = apirest.APIerror{Code: 4035, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "parameter (key or proof) missing"}
-	ErrParamRootInvalid           = apirest.APIerror{Code: 4036, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "parameter (root) invalid"}
-	ErrParamNetworkInvalid        = apirest.APIerror{Code: 4037, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "invalid network"}
-	ErrParamToInvalid             = apirest.APIerror{Code: 4038, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "invalid address"}
-	ErrParticipantKeyMissing      = apirest.APIerror{Code: 4039, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "missing participant key"}
-	ErrIndexedCensusCantUseWeight = apirest.APIerror{Code: 4040, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "indexed census cannot use weight"}
-	ErrWalletNotFound             = apirest.APIerror{Code: 4041, HTTPstatus: apirest.HTTPstatusNotFound, Message: "wallet not found"}
-	ErrWalletPrivKeyAlreadyExists = apirest.APIerror{Code: 4042, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "wallet private key already exists"}
-	ErrElectionEndDateInThePast   = apirest.APIerror{Code: 4043, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "election end date cannot be in the past"}
-	ErrElectionEndDateBeforeStart = apirest.APIerror{Code: 4044, HTTPstatus: apirest.HTTPstatusBadRequest, Message: "election end date must be after start date"}
-	ErrElectionNotFound           = apirest.APIerror{Code: 4045, HTTPstatus: apirest.HTTPstatusNotFound, Message: "election not found"}
-	ErrCensusNotFound             = apirest.APIerror{Code: 4046, HTTPstatus: apirest.HTTPstatusNotFound, Message: "census not found"}
+	ErrAddressMalformed           = apirest.APIerror{Code: 4000, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("address malformed")}
+	ErrDstAddressMalformed        = apirest.APIerror{Code: 4001, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("destination address malformed")}
+	ErrDstAccountUnknown          = apirest.APIerror{Code: 4002, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("destination account is unknown")}
+	ErrAccountNotFound            = apirest.APIerror{Code: 4003, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("account not found")}
+	ErrAccountAlreadyExists       = apirest.APIerror{Code: 4004, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("account already exists")}
+	ErrTreasurerNotFound          = apirest.APIerror{Code: 4005, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("treasurer account not found")}
+	ErrOrgNotFound                = apirest.APIerror{Code: 4006, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("organization not found")}
+	ErrTransactionNotFound        = apirest.APIerror{Code: 4007, HTTPstatus: apirest.HTTPstatusNoContent, Err: fmt.Errorf("transaction hash not found")}
+	ErrBlockNotFound              = apirest.APIerror{Code: 4008, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("block not found")}
+	ErrMetadataProvidedButNoURI   = apirest.APIerror{Code: 4009, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("metadata provided but no metadata URI found in transaction")}
+	ErrMetadataURINotMatchContent = apirest.APIerror{Code: 4010, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("metadata URI does not match metadata content")}
+	ErrMarshalingJSONFailed       = apirest.APIerror{Code: 4011, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("marshaling JSON failed")}
+	ErrFileSizeTooBig             = apirest.APIerror{Code: 4012, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("file size exceeds the maximum allowed")}
+	ErrCantParseOrgID             = apirest.APIerror{Code: 4013, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse organizationID")}
+	ErrCantParseAccountID         = apirest.APIerror{Code: 4014, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse accountID")}
+	ErrCantParseBearerToken       = apirest.APIerror{Code: 4015, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse bearer token")}
+	ErrCantParseDataAsJSON        = apirest.APIerror{Code: 4016, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse data as JSON")}
+	ErrCantParseElectionID        = apirest.APIerror{Code: 4017, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse electionID")}
+	ErrCantParseMetadataAsJSON    = apirest.APIerror{Code: 4018, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse metadata (invalid format)")}
+	ErrCantParsePageNumber        = apirest.APIerror{Code: 4019, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse page number")}
+	ErrCantParsePayloadAsJSON     = apirest.APIerror{Code: 4020, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse payload as JSON")}
+	ErrCantParseVoteID            = apirest.APIerror{Code: 4021, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse voteID")}
+	ErrCantExtractMetadataURI     = apirest.APIerror{Code: 4022, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot extract metadata URI")}
+	ErrVoteIDMalformed            = apirest.APIerror{Code: 4023, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("voteID is malformed")}
+	ErrVoteNotFound               = apirest.APIerror{Code: 4024, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("vote not found")}
+	ErrCensusIDLengthInvalid      = apirest.APIerror{Code: 4025, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("censusID length is wrong")}
+	ErrCensusRootIsNil            = apirest.APIerror{Code: 4026, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("census root is nil")}
+	ErrCensusTypeUnknown          = apirest.APIerror{Code: 4027, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("census type is unknown")}
+	ErrCensusTypeMismatch         = apirest.APIerror{Code: 4028, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("census type mismatch")}
+	ErrCensusIndexedFlagMismatch  = apirest.APIerror{Code: 4029, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("census indexed flag mismatch")}
+	ErrCensusRootHashMismatch     = apirest.APIerror{Code: 4030, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("census root hash mismatch after importing dump")}
+	ErrParamStatusMissing         = apirest.APIerror{Code: 4031, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (status) missing or invalid")}
+	ErrParamParticipantsMissing   = apirest.APIerror{Code: 4032, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (participants) missing")}
+	ErrParamParticipantsTooBig    = apirest.APIerror{Code: 4033, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (participants) exceeds max length per call")}
+	ErrParamDumpOrRootMissing     = apirest.APIerror{Code: 4034, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (dump or root) missing")}
+	ErrParamKeyOrProofMissing     = apirest.APIerror{Code: 4035, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (key or proof) missing")}
+	ErrParamRootInvalid           = apirest.APIerror{Code: 4036, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (root) invalid")}
+	ErrParamNetworkInvalid        = apirest.APIerror{Code: 4037, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("invalid network")}
+	ErrParamToInvalid             = apirest.APIerror{Code: 4038, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("invalid address")}
+	ErrParticipantKeyMissing      = apirest.APIerror{Code: 4039, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("missing participant key")}
+	ErrIndexedCensusCantUseWeight = apirest.APIerror{Code: 4040, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("indexed census cannot use weight")}
+	ErrWalletNotFound             = apirest.APIerror{Code: 4041, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("wallet not found")}
+	ErrWalletPrivKeyAlreadyExists = apirest.APIerror{Code: 4042, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("wallet private key already exists")}
+	ErrElectionEndDateInThePast   = apirest.APIerror{Code: 4043, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("election end date cannot be in the past")}
+	ErrElectionEndDateBeforeStart = apirest.APIerror{Code: 4044, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("election end date must be after start date")}
+	ErrElectionNotFound           = apirest.APIerror{Code: 4045, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("election not found")}
+	ErrCensusNotFound             = apirest.APIerror{Code: 4046, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("census not found")}
 
-	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "vochain returned an empty reply"}
-	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "vochain SendTx failed"}
-	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "vochain GetTx failed"}
-	ErrVochainReturnedErrorCode         = apirest.APIerror{Code: 5003, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "vochain replied with error code"}
-	ErrVochainReturnedInvalidElectionID = apirest.APIerror{Code: 5004, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "vochain returned an invalid electionID after executing tx"}
-	ErrVochainReturnedWrongMetadataCID  = apirest.APIerror{Code: 5005, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "vochain returned an unexpected metadata CID after executing tx"}
-	ErrMarshalingServerJSONFailed       = apirest.APIerror{Code: 5006, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "marshaling (server-side) JSON failed"}
-	ErrCantFetchElectionList            = apirest.APIerror{Code: 5007, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot fetch election list"}
-	ErrCantFetchElection                = apirest.APIerror{Code: 5008, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot fetch election"}
-	ErrCantFetchElectionResults         = apirest.APIerror{Code: 5009, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot fetch election results"}
-	ErrCantFetchTokenTransfers          = apirest.APIerror{Code: 5010, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot fetch token transfers"}
-	ErrCantFetchEnvelopeHeight          = apirest.APIerror{Code: 5011, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot fetch envelope height"}
-	ErrCantFetchEnvelope                = apirest.APIerror{Code: 5012, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot fetch vote envelope"}
-	ErrCantCheckTxType                  = apirest.APIerror{Code: 5013, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot check transaction type"}
-	ErrCantABIEncodeResults             = apirest.APIerror{Code: 5014, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot abi.encode results"}
-	ErrCantComputeKeyHash               = apirest.APIerror{Code: 5015, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot compute key hash"}
-	ErrCantAddKeyAndValueToTree         = apirest.APIerror{Code: 5016, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot add key and value to tree"}
-	ErrCantAddKeyToTree                 = apirest.APIerror{Code: 5017, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot add key to tree"}
-	ErrCantGenerateFaucetPkg            = apirest.APIerror{Code: 5018, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot generate faucet package"}
-	ErrCantEstimateBlockHeight          = apirest.APIerror{Code: 5019, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot estimate startDate block height"}
-	ErrCantMarshalMetadata              = apirest.APIerror{Code: 5020, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot marshal metadata"}
-	ErrCantPublishMetadata              = apirest.APIerror{Code: 5021, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "cannot publish metadata file"}
-	ErrTxTypeMismatch                   = apirest.APIerror{Code: 5022, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "transaction type mismatch"}
-	ErrElectionIsNil                    = apirest.APIerror{Code: 5023, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "election is nil"}
-	ErrElectionResultsNotYetAvailable   = apirest.APIerror{Code: 5024, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "election results are not yet available"}
-	ErrElectionResultsIsNil             = apirest.APIerror{Code: 5025, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "election results is nil"}
-	ErrElectionResultsMismatch          = apirest.APIerror{Code: 5026, HTTPstatus: apirest.HTTPstatusInternalErr, Message: "election results don't match reported ones"}
+	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
+	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
+	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}
+	ErrVochainReturnedErrorCode         = apirest.APIerror{Code: 5003, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain replied with error code")}
+	ErrVochainReturnedInvalidElectionID = apirest.APIerror{Code: 5004, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an invalid electionID after executing tx")}
+	ErrVochainReturnedWrongMetadataCID  = apirest.APIerror{Code: 5005, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an unexpected metadata CID after executing tx")}
+	ErrMarshalingServerJSONFailed       = apirest.APIerror{Code: 5006, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("marshaling (server-side) JSON failed")}
+	ErrCantFetchElectionList            = apirest.APIerror{Code: 5007, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot fetch election list")}
+	ErrCantFetchElection                = apirest.APIerror{Code: 5008, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot fetch election")}
+	ErrCantFetchElectionResults         = apirest.APIerror{Code: 5009, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot fetch election results")}
+	ErrCantFetchTokenTransfers          = apirest.APIerror{Code: 5010, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot fetch token transfers")}
+	ErrCantFetchEnvelopeHeight          = apirest.APIerror{Code: 5011, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot fetch envelope height")}
+	ErrCantFetchEnvelope                = apirest.APIerror{Code: 5012, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot fetch vote envelope")}
+	ErrCantCheckTxType                  = apirest.APIerror{Code: 5013, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot check transaction type")}
+	ErrCantABIEncodeResults             = apirest.APIerror{Code: 5014, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot abi.encode results")}
+	ErrCantComputeKeyHash               = apirest.APIerror{Code: 5015, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot compute key hash")}
+	ErrCantAddKeyAndValueToTree         = apirest.APIerror{Code: 5016, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot add key and value to tree")}
+	ErrCantAddKeyToTree                 = apirest.APIerror{Code: 5017, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot add key to tree")}
+	ErrCantGenerateFaucetPkg            = apirest.APIerror{Code: 5018, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot generate faucet package")}
+	ErrCantEstimateBlockHeight          = apirest.APIerror{Code: 5019, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot estimate startDate block height")}
+	ErrCantMarshalMetadata              = apirest.APIerror{Code: 5020, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot marshal metadata")}
+	ErrCantPublishMetadata              = apirest.APIerror{Code: 5021, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot publish metadata file")}
+	ErrTxTypeMismatch                   = apirest.APIerror{Code: 5022, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("transaction type mismatch")}
+	ErrElectionIsNil                    = apirest.APIerror{Code: 5023, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("election is nil")}
+	ErrElectionResultsNotYetAvailable   = apirest.APIerror{Code: 5024, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("election results are not yet available")}
+	ErrElectionResultsIsNil             = apirest.APIerror{Code: 5025, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("election results is nil")}
+	ErrElectionResultsMismatch          = apirest.APIerror{Code: 5026, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("election results don't match reported ones")}
 )

--- a/api/faucet/faucet.go
+++ b/api/faucet/faucet.go
@@ -61,7 +61,7 @@ func (f *FaucetAPI) faucetHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCont
 	log.Debugf("faucet request from %s for network %s", to.String(), network)
 	fpackage, err := vochain.GenerateFaucetPackage(f.signingKey, to, amount)
 	if err != nil {
-		return fmt.Errorf("%w: %v", api.ErrCantGenerateFaucetPkg, err)
+		return api.ErrCantGenerateFaucetPkg.WithErr(err)
 	}
 	fpackageBytes, err := json.Marshal(FaucetPackage{
 		FaucetPayload: fpackage.Payload,

--- a/test/apierror_test.go
+++ b/test/apierror_test.go
@@ -1,0 +1,120 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
+	"go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/httprouter/apirest"
+	"go.vocdoni.io/dvote/test/testcommon"
+	"go.vocdoni.io/dvote/test/testcommon/testutil"
+)
+
+func TestAPIerror(t *testing.T) {
+	server := testcommon.APIserver{}
+	server.Start(t,
+		api.ChainHandler,
+		api.CensusHandler,
+		api.VoteHandler,
+		api.AccountHandler,
+		api.ElectionHandler,
+		api.WalletHandler,
+	)
+	// Block 1
+	server.VochainAPP.AdvanceTestBlock()
+
+	token1 := uuid.New()
+	c := testutil.NewTestHTTPclient(t, server.ListenAddr, &token1)
+
+	hugeFile := &apirest.APIdata{
+		Data: bytes.Repeat([]byte("0"), api.MaxOffchainFileSize+1),
+	}
+
+	type args struct {
+		method   string
+		jsonBody any
+		urlPath  []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want apirest.APIerror
+	}{
+		{
+			args: args{"GET", nil, []string{"accounts", "0123456789"}},
+			want: api.ErrAddressMalformed,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts", "0123456789012345678901234567890123456789"}},
+			want: api.ErrAccountNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts", "0123456789012345678901234567890123456789", "elections", "count"}},
+			want: api.ErrOrgNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"chain", "blocks", "1234"}},
+			want: api.ErrBlockNotFound,
+		},
+		{
+			args: args{"POST", hugeFile, []string{"files", "cid"}},
+			want: api.ErrFileSizeTooBig,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts", "totallyWrong!@#$", "elections", "status", "ready"}},
+			want: api.ErrCantParseOrgID,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts", "totallyWrong!@#$", "transfers"}},
+			want: api.ErrCantParseAccountID,
+		},
+		{
+			args: args{"GET", nil, []string{"votes", "verify",
+				"0123456789012345678901234567890123456789012345678901234567890123",
+				"000"}},
+			want: api.ErrCantParseVoteID,
+		},
+		{
+			args: args{"GET", nil, []string{"votes", "verify",
+				"0123456789012345678901234567890123456789012345678901234567890123",
+				"0000"}},
+			want: api.ErrVoteIDMalformed,
+		},
+		{
+			args: args{"GET", nil, []string{"votes", "verify",
+				"0123456789012345678901234567890123456789012345678901234567890123",
+				"0123456789012345678901234567890123456789012345678901234567890123"}},
+			want: api.ErrVoteNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"votes", "verify",
+				"bbbbb",
+				"0123456789012345678901234567890123456789012345678901234567890123"}},
+			want: api.ErrCantParseElectionID,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts", "0123456789012345678901234567890123456789",
+				"elections",
+				"status", "ready",
+				"page", "-1"}},
+			want: api.ErrCantFetchElectionList,
+		},
+		{
+			args: args{"GET", nil, []string{"elections", "page", "thisIsTotallyNotAnInt"}},
+			want: api.ErrCantParsePageNumber,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want.Error(), func(t *testing.T) {
+			resp, code := c.Request(tt.args.method, tt.args.jsonBody, tt.args.urlPath...)
+			t.Logf("httpstatus=%d body=%s", code, resp)
+			qt.Assert(t, code, qt.Equals, tt.want.HTTPstatus)
+			apierr := &apirest.APIerror{}
+			qt.Assert(t, json.Unmarshal(resp, apierr), qt.IsNil)
+			qt.Assert(t, apierr.Code, qt.Equals, tt.want.Code)
+		})
+	}
+}


### PR DESCRIPTION
now APIerror struct contains an error instead of a string,
this allows error wrapping.

New APIerror methods: With, Withf, WithErr

All `return fmt.Errorf` in api are replaced with `APIerror.With`

(Also includes correcting a small nit for MarshalJSON failures, since they are really server-side and they returned 400 instead of 500)