### PR TITLE
Feature/update zk circuit artifacts to master

### DIFF
--- a/crypto/zk/circuit/config.go
+++ b/crypto/zk/circuit/config.go
@@ -54,7 +54,7 @@ func (config ZkCircuitConfig) KeySize() int {
 var CircuitsConfigurations = map[string]ZkCircuitConfig{
 	"dev": {
 		URI: "https://raw.githubusercontent.com/vocdoni/" +
-			"zk-franchise-proof-circuit/feature/merging_repos_and_new_tests",
+			"zk-franchise-proof-circuit/master",
 		CircuitPath:             "artifacts/zkCensus/dev/160",
 		Levels:                  160, // ZkCircuit number of levels
 		LocalDir:                "zkCircuits",


### PR DESCRIPTION
To support anonymous voting using weighted census based on zk-snarks, the snark circuit had to be updated. After the circuit was updated, new artifacts were generated during the new circuit compilation, and these were stored on a development branch of the artifacts and circuit repository.

This branch has been merged into master and the URI endpoint of these artifacts needs to be updated in circuit configuration on `crypto/zk/circuit/config.go`