### PR TITLE
indexer and downloader fix and small improvements

### DIFF
--- a/api/censusdb/censusdb.go
+++ b/api/censusdb/censusdb.go
@@ -3,6 +3,7 @@ package censusdb
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -177,9 +178,9 @@ func (c *CensusDB) ImportAsPublic(data []byte) error {
 	if cdata.Data == nil || cdata.RootHash == nil {
 		return fmt.Errorf("missing dump or root parameters")
 	}
-	log.Debugf("importing census %x of type %s", cdata.RootHash, cdata.Type.String())
+	log.Debugw("importing census", "root", hex.EncodeToString(cdata.RootHash), "type", cdata.Type.String())
 	if c.Exists(cdata.RootHash) {
-		return fmt.Errorf("could not import census %x, already exists", cdata.RootHash)
+		return ErrCensusAlreadyExists
 	}
 	uri := "ipfs://" + storagelayer.CalculateIPFSCIDv1json(data)
 	ref, err := c.New(cdata.RootHash, cdata.Type, uri, nil, cdata.MaxLevels)

--- a/config/config.go
+++ b/config/config.go
@@ -132,9 +132,8 @@ type VochainCfg struct {
 	NoWaitSync bool
 	// MempoolSize is the size of the mempool
 	MempoolSize int
-	// ImportPreviousCensus if true the census downloader will try to download
-	// all census (not only the new ones)
-	ImportPreviousCensus bool
+	// SkipPreviousOffchainData if enabled, the node will skip downloading the previous off-chain data to the current block
+	SkipPreviousOffchainData bool
 	// Enable Prometheus metrics from tendermint
 	TendermintMetrics bool
 	// Target block time in seconds (only for miners)

--- a/service/offchaindata.go
+++ b/service/offchaindata.go
@@ -31,7 +31,7 @@ func (vs *VocdoniService) OffChainDataHandler() error {
 		vs.App,
 		vs.DataDownloader,
 		vs.CensusDB,
-		!vs.Config.ImportPreviousCensus,
+		vs.Config.SkipPreviousOffchainData,
 	)
 	return nil
 }

--- a/vochain/offchaindatahandler/census.go
+++ b/vochain/offchaindatahandler/census.go
@@ -17,7 +17,9 @@ func (d *OffChainDataHandler) importExternalCensus(uri string, data []byte) {
 		return
 	}
 	if err := d.census.ImportAsPublic(data); err != nil {
-		log.Warnf("cannot import census from %s: %v", uri, err)
+		if !errors.Is(err, censusdb.ErrCensusAlreadyExists) {
+			log.Warnf("cannot import census from %s: %v", uri, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Indexer and offchain data downloader were initialized after vochain synchronization. So during fast-sync none of them were actually processing the blockchain data. This behavior caused some elections and metadata not to exist if the node is bootstraped once the vochain started.

In addition to this fixes, some small improvements, mainly related with log messages.