### PR TITLE
Feature: pubkey as censustree key deprecation

### DIFF
--- a/crypto/zk/circuit/config.go
+++ b/crypto/zk/circuit/config.go
@@ -41,7 +41,7 @@ type ZkCircuitConfig struct {
 	WasmFilename string `json:"wasmFilename"` // circuit.wasm
 }
 
-// KeySize returns the maximun number of bytes of a leaf key according to the
+// KeySize returns the maximum number of bytes of a leaf key according to the
 // number of levels of the current circuit (nBytes = nLevels / 8).
 func (config ZkCircuitConfig) KeySize() int {
 	return config.Levels / 8

--- a/test/census_test.go
+++ b/test/census_test.go
@@ -38,6 +38,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/censustree"
 	"go.vocdoni.io/dvote/tree/arbo"
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -138,7 +139,7 @@ func TestCensusRPC(t *testing.T) {
 		claim, err := arbo.HashFunctionBlake2b.Hash(crypto.FromECDSAPub(&key.Public))
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, claim, qt.Not(qt.HasLen), 0)
-		claims = append(claims, claim)
+		claims = append(claims, claim[:censustree.DefaultMaxKeyLen])
 		req.Weights = append(req.Weights, (&types.BigInt{}).SetUint64(uint64(*censusWeight)))
 	}
 	req.CensusKeys = claims

--- a/test/testcommon/testvoteproof/voteproof.go
+++ b/test/testcommon/testvoteproof/voteproof.go
@@ -51,7 +51,7 @@ func GetCSPproofBatch(signers []*ethereum.SignKeys,
 func CreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys, []byte, [][]byte) {
 	db := metadb.NewTest(t)
 	tr, err := censustree.New(censustree.Options{Name: "testcensus", ParentDB: db,
-		MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})
+		MaxLevels: censustree.DefaultMaxLevels, CensusType: models.Census_ARBO_BLAKE2B})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,6 +61,7 @@ func CreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys, []b
 	for _, k := range keys {
 		c, err := tr.Hash(k.PublicKey())
 		qt.Check(t, err, qt.IsNil)
+		c = c[:censustree.DefaultMaxKeyLen]
 		err = tr.Add(c, nil)
 		qt.Check(t, err, qt.IsNil)
 		hashedKeys = append(hashedKeys, c)

--- a/vochain/state/votes.go
+++ b/vochain/state/votes.go
@@ -176,7 +176,8 @@ func (v *State) voteID(pid, nullifier []byte) ([]byte, error) {
 	// The vote nullifier generated during anonymous voting with zksnarks could
 	// have 31 or 32 bytes of lenght. Now, here only check that the nullifier is
 	// not empty and then, if it is wrong, the verification will be fail.
-	// TODO: (lucas) Set a minimun and maximun length for the nullifier and check it.
+	// TODO: (lucas) Set a minimun and maximum length for the nullifier and
+	// check it.
 	if len(nullifier) == 0 {
 		return nil, fmt.Errorf("empty or nil nullifier")
 	}

--- a/vochain/transaction/proof.go
+++ b/vochain/transaction/proof.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"go.vocdoni.io/dvote/censustree"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/saltedkey"
 	"go.vocdoni.io/dvote/log"
@@ -101,7 +102,14 @@ func VerifyProofOffChainTree(process *models.Process, proof *models.Proof,
 		if err != nil {
 			return false, nil, fmt.Errorf("cannot hash proof key: %w", err)
 		}
-		valid, err := tree.VerifyProof(hashFunc, hashedKey, p.Value, p.Siblings, censusRoot)
+		// If the provided key is longer than the defined maximum length
+		// truncate it.
+		// TODO: return an error if the other key lengths are deprecated
+		leafKey := hashedKey
+		if len(leafKey) > censustree.DefaultMaxKeyLen {
+			leafKey = leafKey[:censustree.DefaultMaxKeyLen]
+		}
+		valid, err := tree.VerifyProof(hashFunc, leafKey, p.Value, p.Siblings, censusRoot)
 		// Legacy: support p.Value == nil, assume then value=1
 		if p.Value == nil {
 			return valid, bigOne, err

--- a/vochain/vote_test.go
+++ b/vochain/vote_test.go
@@ -20,7 +20,7 @@ import (
 func testCreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys, []byte, [][]byte) {
 	db := metadb.NewTest(t)
 	tr, err := censustree.New(censustree.Options{Name: "testcensus", ParentDB: db,
-		MaxLevels: 256, CensusType: models.Census_ARBO_BLAKE2B})
+		MaxLevels: censustree.DefaultMaxLevels, CensusType: models.Census_ARBO_BLAKE2B})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,6 +30,7 @@ func testCreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys,
 	for _, k := range keys {
 		c, err := tr.Hash(k.PublicKey())
 		qt.Check(t, err, qt.IsNil)
+		c = c[:censustree.DefaultMaxKeyLen]
 		err = tr.Add(c, nil)
 		qt.Check(t, err, qt.IsNil)
 		hashedKeys = append(hashedKeys, c)


### PR DESCRIPTION
The goal of this PR is to reduce the number of levels in the census trees to 160 and to support census tree keys of up to 20 bytes, deprecating the use of publicKeys as census tree keys, thus attempting to fix issue #819.

To achieve this goal, I propose to create a new constant that defines the maximum length of any census key to 20 bytes, and to include some checks on the backend to ensure that longer keys are supported by truncating them.