### PR TITLE
Collect coverage of both unit and integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,16 +80,16 @@ jobs:
           go-version: '1.20'
       - name: Run Go test (and collect code coverage)
         if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/stage' && !startsWith(github.ref, 'refs/heads/release') && github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/apiv2'
-        run: go test -coverprofile=unit.covprofile ./...
+        run: go test -coverprofile=unit.covdata.txt ./...
       - name: Run Go test race
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stage' || startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/apiv2'
         env:
           LOG_PANIC_ON_INVALIDCHARS: true # check that log lines contains no invalid chars (evidence of format mismatch)
         run: go test -vet=off -timeout=15m -race ./... # note that -race can easily make the crypto stuff 10x slower
       - name: Send unit test coverage to coveralls.io
-        uses: coverallsapp/github-action@v2
+        uses: shogo82148/actions-goveralls@v1
         with:
-          file: unit.covprofile
+          path-to-profile: unit.covdata.txt
           flag-name: unit
           parallel: true
 
@@ -115,28 +115,20 @@ jobs:
         uses: actions/checkout@v3
       - name: Run compose script
         env:
-          TESTSUITE_BUILD_TAG: ${{ env.GITHUB_SHA | slice(0, 10) }}
-          COMPOSE_PROJECT_NAME: testsuite_${{ github.run_id }}
+          TESTSUITE_BUILD_TAG: ${{ github.sha }}
+          COMPOSE_PROJECT_NAME: testsuite_${{ github.run_id }} # unique name for docker-compose (needed for concurrent job runs)
+          COMPOSE_DVOTE_PORT_MAPPING: "9090" # this binds gateway0 to a random available port on docker host (needed for concurrent job runs)
           COMPOSE_HOST_PATH: ${{ github.workspace }}/dockerfiles/testsuite
-          COMPOSE_DOCKER_CLI_BUILD: 1
-          DOCKER_BUILDKIT: 1
-          DOCKER_CLI_EXPERIMENTAL: enabled
-          COMPOSE_DVOTE_PORT_MAPPING: "9090" # Will use a random available port mapping
           LOG_PANIC_ON_INVALIDCHARS: true # check that log lines contains no invalid chars (evidence of format mismatch)
-          BUILDARGS: "-cover" # collect code coverage when running binaries
+          GOCOVERDIR: "./gocoverage/" # collect code coverage when running binaries
         run: |
           cd dockerfiles/testsuite && ./start_test.sh
       - name: Send integration test coverage to coveralls.io
-        # coverallsapp/github-action@v2 fails on our self-hosted since runner has no permissions to write in /usr/local/bin
-        # workaround using /tmp
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.github_token }}
-        run: |
-          curl -sL https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-linux.tar.gz | tar xz -C /tmp
-          /tmp/coveralls \
-            --file dockerfiles/testsuite/integration.covprofile \
-            --job-flag=integration \
-            --parallel
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: dockerfiles/testsuite/gocoverage/covdata.txt
+          flag-name: integration
+          parallel: true
 
   job_docker_release:
     runs-on: ubuntu-latest
@@ -212,7 +204,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Send coverage to Coveralls.io (finish)
-      uses: coverallsapp/github-action@v2
+      uses: shogo82148/actions-goveralls@v1
       with:
         parallel-finished: true
-        carryforward: "unit,integration"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,10 @@ jobs:
           GOCOVERDIR: "./gocoverage/" # collect code coverage when running binaries
         run: |
           cd dockerfiles/testsuite && ./start_test.sh
+      - name: Set up Go environment
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
       - name: Send integration test coverage to coveralls.io
         uses: shogo82148/actions-goveralls@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,13 @@
 ---
 name: Main
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - dev
+      - stage
+      - master
+  pull_request:
 
 jobs:
   job_go_checks:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,11 +126,6 @@ jobs:
           BUILDARGS: "-cover" # collect code coverage when running binaries
         run: |
           cd dockerfiles/testsuite && ./start_test.sh
-      - name: Convert code coverage profile format
-        run: docker run --rm -v $(pwd):/wd/ golang:1.20
-              go tool covdata textfmt
-              -i=$(find /wd/dockerfiles/testsuite/gocoverage/ -type d -printf '%p,'| sed 's/,$//')
-              -o=/wd/integration.covprofile
       - name: Send integration test coverage to coveralls.io
         # coverallsapp/github-action@v2 fails on our self-hosted since runner has no permissions to write in /usr/local/bin
         # workaround using /tmp
@@ -139,7 +134,7 @@ jobs:
         run: |
           curl -sL https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-linux.tar.gz | tar xz -C /tmp
           /tmp/coveralls \
-            --file integration.covprofile \
+            --file dockerfiles/testsuite/integration.covprofile \
             --job-flag=integration \
             --parallel
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,21 +114,23 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
       - name: Run compose script
+        env:
+          TESTSUITE_BUILD_TAG: ${{ env.GITHUB_SHA | slice(0, 10) }}
+          COMPOSE_PROJECT_NAME: testsuite_${{ github.run_id }}
+          COMPOSE_HOST_PATH: ${{ github.workspace }}/dockerfiles/testsuite
+          COMPOSE_DOCKER_CLI_BUILD: 1
+          DOCKER_BUILDKIT: 1
+          DOCKER_CLI_EXPERIMENTAL: enabled
+          COMPOSE_DVOTE_PORT_MAPPING: "9090" # Will use a random available port mapping
+          LOG_PANIC_ON_INVALIDCHARS: true # check that log lines contains no invalid chars (evidence of format mismatch)
+          BUILDARGS: "-cover" # collect code coverage when running binaries
         run: |
-          export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1
-          export DOCKER_CLI_EXPERIMENTAL=enabled
-          export COMPOSE_PROJECT_NAME=${RANDOM}${RANDOM}_testsuite
-          export TESTSUITE_BUILD_TAG=${CI_COMMIT_SHA::10}
-          export COMPOSE_HOST_PATH=${PWD}/dockerfiles/testsuite
-          export COMPOSE_DVOTE_PORT_MAPPING="9090" # Will use a random available port mapping
-          export LOG_PANIC_ON_INVALIDCHARS=true
-          export BUILDARGS="-cover" # collect code coverage when running binaries
-          cd dockerfiles/testsuite
-          docker-compose build
-          ./start_test.sh
+          cd dockerfiles/testsuite && ./start_test.sh
       - name: Convert code coverage profile format
         run: docker run --rm -v $(pwd):/wd/ golang:1.20
-              go tool covdata textfmt -i=/wd/dockerfiles/testsuite/integration.covdir/ -o /wd/integration.covprofile
+              go tool covdata textfmt
+              -i=$(find /wd/dockerfiles/testsuite/gocoverage/ -type d -printf '%p,'| sed 's/,$//')
+              -o=/wd/integration.covprofile
       - name: Send integration test coverage to coveralls.io
         # coverallsapp/github-action@v2 fails on our self-hosted since runner has no permissions to write in /usr/local/bin
         # workaround using /tmp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,16 +78,20 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.20'
-      - name: Run Go test
+      - name: Run Go test (and collect code coverage)
         if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/stage' && !startsWith(github.ref, 'refs/heads/release') && github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/apiv2'
-        run: go test ./...
+        run: go test -coverprofile=unit.covprofile ./...
       - name: Run Go test race
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stage' || startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/apiv2'
-        run: |
-          # check that log lines contains no invalid chars (evidence of format mismatch)
-          export LOG_PANIC_ON_INVALIDCHARS=true
-          # -race can easily make the crypto stuff 10x slower
-          go test -vet=off -timeout=15m -race ./...
+        env:
+          LOG_PANIC_ON_INVALIDCHARS: true # check that log lines contains no invalid chars (evidence of format mismatch)
+        run: go test -vet=off -timeout=15m -race ./... # note that -race can easily make the crypto stuff 10x slower
+      - name: Send unit test coverage to coveralls.io
+        uses: coverallsapp/github-action@v2
+        with:
+          file: unit.covprofile
+          flag-name: unit
+          parallel: true
 
   job_compose_test:
     runs-on: [self-hosted, ci2-1]
@@ -118,9 +122,24 @@ jobs:
           export COMPOSE_HOST_PATH=${PWD}/dockerfiles/testsuite
           export COMPOSE_DVOTE_PORT_MAPPING="9090" # Will use a random available port mapping
           export LOG_PANIC_ON_INVALIDCHARS=true
+          export BUILDARGS="-cover" # collect code coverage when running binaries
           cd dockerfiles/testsuite
           docker-compose build
           ./start_test.sh
+      - name: Convert code coverage profile format
+        run: docker run --rm -v $(pwd):/wd/ golang:1.20
+              go tool covdata textfmt -i=/wd/dockerfiles/testsuite/integration.covdir/ -o /wd/integration.covprofile
+      - name: Send integration test coverage to coveralls.io
+        # coverallsapp/github-action@v2 fails on our self-hosted since runner has no permissions to write in /usr/local/bin
+        # workaround using /tmp
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.github_token }}
+        run: |
+          curl -sL https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-linux.tar.gz | tar xz -C /tmp
+          /tmp/coveralls \
+            --file integration.covprofile \
+            --job-flag=integration \
+            --parallel
 
   job_docker_release:
     runs-on: ubuntu-latest
@@ -189,3 +208,14 @@ jobs:
           # Some of our devs are on Mac. Ensure it builds.
           # It's surprisingly hard with some deps like bazil.org/fuse.
           GOOS=darwin go build ./...
+
+  job_coveralls:
+    needs: [job_go_test, job_compose_test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send coverage to Coveralls.io (finish)
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true
+        carryforward: "unit,integration"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GoDoc](https://godoc.org/go.vocdoni.io/dvote?status.svg)](https://godoc.org/go.vocdoni.io/dvote)
 [![Go Report Card](https://goreportcard.com/badge/go.vocdoni.io/dvote)](https://goreportcard.com/report/go.vocdoni.io/dvote)
+[![Coverage Status](https://coveralls.io/repos/github/vocdoni/vocdoni-node/badge.svg)](https://coveralls.io/github/vocdoni/vocdoni-node)
 
 [![Join Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/xFTh8Np2ga)
 [![Twitter Follow](https://img.shields.io/twitter/follow/vocdoni.svg?style=social&label=Follow)](https://twitter.com/vocdoni)

--- a/dockerfiles/testsuite/docker-compose.yml
+++ b/dockerfiles/testsuite/docker-compose.yml
@@ -108,6 +108,13 @@ services:
     links:
       - gateway0
     volumes:
+      - gocoverage-test:/app/run/gocoverage
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage
+    command: "true"
+  gocoverage:
+    image: golang:1.20
+    volumes:
       - gocoverage-seed:/app/run/gocoverage/seed
       - gocoverage-miner0:/app/run/gocoverage/miner0
       - gocoverage-miner1:/app/run/gocoverage/miner1
@@ -116,9 +123,6 @@ services:
       - gocoverage-oracle:/app/run/gocoverage/oracle
       - gocoverage-gateway0:/app/run/gocoverage/gateway0
       - gocoverage-test:/app/run/gocoverage/test
-    environment:
-      - GOCOVERDIR=/app/run/gocoverage/test
-    command: "true"
 
 volumes:
   data-seed: {}

--- a/dockerfiles/testsuite/docker-compose.yml
+++ b/dockerfiles/testsuite/docker-compose.yml
@@ -5,11 +5,16 @@ services:
     image: "dvotenode:${TESTSUITE_BUILD_TAG:-latest}"
     build: # reused by the other services
       context: ../../
+      args:
+        - BUILDARGS
     env_file: "${COMPOSE_HOST_PATH:-.}/env.seed"
     volumes:
       - data-seed:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
       - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - gocoverage-seed:/app/run/gocoverage
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage
 
   miner0:
     image: "dvotenode:${TESTSUITE_BUILD_TAG:-latest}"
@@ -18,6 +23,9 @@ services:
       - data-miner0:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
       - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - gocoverage-miner0:/app/run/gocoverage
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage
     links:
       - seed
 
@@ -28,6 +36,9 @@ services:
       - data-miner1:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
       - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - gocoverage-miner1:/app/run/gocoverage
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage
     links:
       - seed
 
@@ -38,6 +49,9 @@ services:
       - data-miner2:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
       - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - gocoverage-miner2:/app/run/gocoverage
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage
     links:
       - seed
 
@@ -48,6 +62,9 @@ services:
       - data-miner3:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
       - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - gocoverage-miner3:/app/run/gocoverage
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage
     links:
       - seed
 
@@ -60,6 +77,9 @@ services:
       - data-oracle:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
       - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - gocoverage-oracle:/app/run/gocoverage
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage
     links:
       - seed
 
@@ -72,6 +92,9 @@ services:
       - data-gateway0:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
       - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - gocoverage-gateway0:/app/run/gocoverage
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage
     links:
       - seed
 
@@ -80,8 +103,21 @@ services:
     build:
       context: ../../
       target: test
+      args:
+        - BUILDARGS
     links:
       - gateway0
+    volumes:
+      - gocoverage-seed:/app/run/gocoverage/seed
+      - gocoverage-miner0:/app/run/gocoverage/miner0
+      - gocoverage-miner1:/app/run/gocoverage/miner1
+      - gocoverage-miner2:/app/run/gocoverage/miner2
+      - gocoverage-miner3:/app/run/gocoverage/miner3
+      - gocoverage-oracle:/app/run/gocoverage/oracle
+      - gocoverage-gateway0:/app/run/gocoverage/gateway0
+      - gocoverage-test:/app/run/gocoverage/test
+    environment:
+      - GOCOVERDIR=/app/run/gocoverage/test
     command: "true"
 
 volumes:
@@ -92,3 +128,11 @@ volumes:
   data-miner3: {}
   data-oracle: {}
   data-gateway0: {}
+  gocoverage-seed: {}
+  gocoverage-miner0: {}
+  gocoverage-miner1: {}
+  gocoverage-miner2: {}
+  gocoverage-miner3: {}
+  gocoverage-oracle: {}
+  gocoverage-gateway0: {}
+  gocoverage-test: {}

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -191,8 +191,12 @@ if echo "$BUILDARGS" | grep -q -- "-cover"; then
 	echo "### Collect all coverage files in $hostdir ###"
 	mkdir -p $hostdir
 	$COMPOSE_CMD down
-    $COMPOSE_CMD_RUN --user=`id -u`:`id -g` -v $(pwd):/host/ \
-	--entrypoint="cp -rf /app/run/gocoverage/. /host/$hostdir" test
+    docker run --rm --user=`id -u`:`id -g` -v $(pwd):/wd/ golang:1.20 \
+			  cp -rf /app/run/gocoverage/. /wd/$hostdir
+	docker run --rm --user=`id -u`:`id -g` -v $(pwd):/wd/ golang:1.20 \
+              go tool covdata textfmt \
+              -i=$(find /wd/$hostdir/ -type d -printf '%p,'| sed 's/,$//') \
+              -o=/wd/integration.covprofile
 fi
 
 [ $CLEAN -eq 1 ] && {

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -186,6 +186,15 @@ for test in ${tests_to_run[@]} ; do
 	fi
 done
 
+if echo "$BUILDARGS" | grep -q -- "-cover"; then
+	hostdir="./gocoverage/"
+	echo "### Collect all coverage files in $hostdir ###"
+	mkdir -p $hostdir
+	$COMPOSE_CMD down
+    $COMPOSE_CMD_RUN --user=`id -u`:`id -g` -v $(pwd):/host/ \
+	--entrypoint="cp -rf /app/run/gocoverage/. /host/$hostdir" test
+fi
+
 [ $CLEAN -eq 1 ] && {
 	echo "### Cleaning docker environment ###"
 	$COMPOSE_CMD down -v --remove-orphans

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -8,6 +8,7 @@
 #  e2etest_tokentxs: run token transactions test (end-user voting is not included)
 
 export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 COMPOSE_INTERACTIVE_NO_CLI=1
+[ -n "$GOCOVERDIR" ] && export BUILDARGS="-cover" # docker-compose build passes this to go 1.20 so that binaries collect code coverage
 
 COMPOSE_CMD=${COMPOSE_CMD:-"docker-compose"}
 COMPOSE_CMD_RUN="$COMPOSE_CMD run"
@@ -18,7 +19,6 @@ ELECTION_SIZE_ANON=${TESTSUITE_ELECTION_SIZE_ANON:-8}
 CLEAN=${CLEAN:-1}
 LOGLEVEL=${LOGLEVEL:-debug}
 CONCURRENT=${CONCURRENT:-0}
-[ -n "$GOCOVERDIR" ] && BUILDARGS="-cover" # docker-compose build passes this to go 1.20 so that binaries collect code coverage
 ### must be splited by lines
 DEFAULT_ACCOUNT_KEYS="73ac72a16ea84dd1f76b62663d2aa380253aec4386935e460dad55d4293a0b11
 be9248891bd6c220d013afb4b002f72c8c22cbad9c02003c19729bcbd6962e52
@@ -35,6 +35,8 @@ TREASURER_KEY="$VOCDONI_SIGNINGKEY"
 [ -n "$TESTSUITE_TREASURER_KEY" ] && TREASURER_KEY="$TESTSUITE_TREASURER_KEY"
 TEST_PREFIX="testsuite_test"
 RANDOMID="${RANDOM}${RANDOM}"
+
+log() { echo $(date --rfc-3339=s) "$@" ; }
 
 ### if you want to add a new test:
 ### add "newtest" to tests_to_run array (as well as a comment at the head of the file)
@@ -138,49 +140,50 @@ e2etest_tokentxs() {
 # useful for debugging bash flow
 # docker-compose() { echo "# would do: docker-compose $@" ; sleep 0.2 ;}
 
-echo "### Starting test suite ###"
+log "### Starting test suite ###"
 $COMPOSE_CMD build
 $COMPOSE_CMD up -d
 
 check_gw_is_up() {
+	date
 	$COMPOSE_CMD_RUN test \
 		curl -s --fail $GWHOST \
 		  -X POST \
 		  -d '{"id": "req00'$RANDOM'", "request": {"method": "genProof", "timestamp":'$(date +%s)'}}' 2>/dev/null
 }
 
-echo "### Waiting for test suite to be ready ###"
+log "### Waiting for test suite to be ready ###"
 for i in {1..20}; do
 	check_gw_is_up && break || sleep 2
 done
+log "### Test suite ready ###"
 
 # create temp dir
 results="/tmp/.vochaintest$RANDOM"
 mkdir -p $results
 
-echo "### Test suite ready ###"
 for test in ${tests_to_run[@]}; do
 	if [ $test == "tokentransactions" ] || [ $CONCURRENT -eq 0 ] ; then
-		echo "### Running test $test ###"
+		log "### Running test $test ###"
 		( set -o pipefail ; $test | tee $results/$test.stdout ; echo $? > $results/$test.retval )
 	else
-		echo "### Running test $test concurrently with others ###"
+		log "### Running test $test concurrently with others ###"
 		( set -o pipefail ; $test | tee $results/$test.stdout ; echo $? > $results/$test.retval ) &
 	fi
 	sleep 6
 done
 
-echo "### Waiting for tests to finish ###"
+log "### Waiting for tests to finish ###"
 wait
 
 failed=""
 for test in ${tests_to_run[@]} ; do
 	RET=$(cat $results/$test.retval)
 	if [ "$RET" == "0" ] ; then
-		echo "Vochain test $test finished correctly!"
+		log "### Vochain test $test finished correctly! ###"
 	else
-		echo "Vochain test $test failed!"
-		echo "### Post run logs ###"
+		log "### Vochain test $test failed! ###"
+		log "### Post run logs ###"
 		$COMPOSE_CMD logs --tail 1000
 		failed="$test"
 		break
@@ -188,29 +191,39 @@ for test in ${tests_to_run[@]} ; do
 done
 
 if [ -n "$GOCOVERDIR" ] ; then
-	echo "### Collect all coverage files in $GOCOVERDIR ###"
+	log "### Collect all coverage files in $GOCOVERDIR ###"
 	mkdir -p $GOCOVERDIR
+	$COMPOSE_CMD_RUN --user=`id -u`:`id -g` -v $(pwd):/wd/ gocoverage sh -c "\
+		find /app/run/gocoverage/
+		find /wd/$GOCOVERDIR/
+		"
 	$COMPOSE_CMD down
 	$COMPOSE_CMD_RUN --user=`id -u`:`id -g` -v $(pwd):/wd/ gocoverage sh -c "\
+		find /app/run/gocoverage/
+		find /wd/$GOCOVERDIR/
 	    ls -l /app/run/gocoverage/. /wd/$GOCOVERDIR
 		cp -rf /app/run/gocoverage/. /wd/$GOCOVERDIR
 		ls -la /app/run/gocoverage/. /wd/$GOCOVERDIR
 		whoami
 		touch /wd/whoami
+		echo -- cmd args are \
+			-i=\$(find /wd/$GOCOVERDIR/ -type d -printf '%p,'| sed 's/,$//') \
+			-o=/wd/$GOCOVERDIR/covdata.txt
+		find /wd/$GOCOVERDIR/
 		go tool covdata textfmt \
 			-i=\$(find /wd/$GOCOVERDIR/ -type d -printf '%p,'| sed 's/,$//') \
 			-o=/wd/$GOCOVERDIR/covdata.txt
 		"
-	echo "### Coverage data in textfmt left in $GOCOVERDIR/covdata.txt ###"
+	log "### Coverage data in textfmt left in $GOCOVERDIR/covdata.txt ###"
 fi
 
 [ $CLEAN -eq 1 ] && {
-	echo "### Cleaning docker environment ###"
+	log "### Cleaning docker environment ###"
 	$COMPOSE_CMD down -v --remove-orphans
 }
 
 if [ -n "$failed" ]; then
-  echo "### Logs from failed test ($test) ###"
+  log "### Logs from failed test ($test) ###"
   cat $results/$failed.stdout
 fi
 


### PR DESCRIPTION
now that we have go 1.20 i want to finally see the coverage of our integration test (https://go.dev/testing/coverage/)
ideally, integrate both unit and integration coverage (as in https://dustinspecker.com/posts/go-combined-unit-integration-code-coverage/)