### PR TITLE
vochain: LoadZkCircuit now downloads zkCircuits into ~/.cache/vocdoni/

### DIFF
--- a/api/chain.go
+++ b/api/chain.go
@@ -247,8 +247,6 @@ func (a *API) chainInfoHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext
 func (a *API) chainCircuitInfoHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	// Get current circuit tag
 	circuitConfig := circuit.GetCircuitConfiguration(a.vocapp.CircuitConfigurationTag())
-	// Set LocalDir parameter to empty to be omitted
-	circuitConfig.LocalDir = ""
 	// Encode the circuit configuration to JSON
 	data, err := json.Marshal(circuitConfig)
 	if err != nil {

--- a/crypto/zk/circuit/circuit_test.go
+++ b/crypto/zk/circuit/circuit_test.go
@@ -49,7 +49,6 @@ func TestLoadZkCircuit(t *testing.T) {
 	config := ZkCircuitConfig{
 		URI:                     server.URL,
 		CircuitPath:             "/test/",
-		LocalDir:                "./test-files",
 		ProvingKeyFilename:      testProvingKey,
 		VerificationKeyFilename: testVerificationKey,
 		WasmFilename:            testWasm,
@@ -67,7 +66,7 @@ func TestLoadZkCircuit(t *testing.T) {
 	hashFn.Write(testFiles[testWasm])
 	config.WasmHash = hashFn.Sum(nil)
 
-	testCircuits := filepath.Join(config.LocalDir, config.CircuitPath)
+	testCircuits := filepath.Join(BaseDir, config.CircuitPath)
 	defer os.RemoveAll(testCircuits)
 
 	circuit, err := LoadZkCircuit(context.Background(), config)
@@ -93,7 +92,6 @@ func TestLoadLocal(t *testing.T) {
 	circuit := &ZkCircuit{
 		Config: ZkCircuitConfig{
 			CircuitPath:             "/test/",
-			LocalDir:                "./test-files",
 			ProvingKeyFilename:      testProvingKey,
 			VerificationKeyFilename: testVerificationKey,
 			WasmFilename:            testWasm,
@@ -101,7 +99,7 @@ func TestLoadLocal(t *testing.T) {
 	}
 
 	// Create local parent folder
-	testCircuits := filepath.Join(circuit.Config.LocalDir, circuit.Config.CircuitPath)
+	testCircuits := filepath.Join(BaseDir, circuit.Config.CircuitPath)
 	err := os.MkdirAll(testCircuits, os.ModePerm)
 	c.Assert(err, qt.IsNil)
 	defer os.RemoveAll(testCircuits)
@@ -140,7 +138,6 @@ func TestLoadRemote(t *testing.T) {
 		Config: ZkCircuitConfig{
 			URI:                     server.URL,
 			CircuitPath:             "/test/",
-			LocalDir:                "./test-files",
 			ProvingKeyFilename:      testProvingKey,
 			VerificationKeyFilename: testVerificationKey,
 			WasmFilename:            testWasm,
@@ -156,7 +153,7 @@ func TestLoadRemote(t *testing.T) {
 	c.Assert(circuit.Wasm, qt.DeepEquals, testFiles[testWasm])
 
 	// Compare with the local copies
-	testCircuits := filepath.Join(circuit.Config.LocalDir, circuit.Config.CircuitPath)
+	testCircuits := filepath.Join(BaseDir, circuit.Config.CircuitPath)
 	localProvingKey, err := os.ReadFile(filepath.Join(testCircuits, testProvingKey))
 	c.Assert(err, qt.IsNil)
 	c.Assert(localProvingKey, qt.DeepEquals, testFiles[testProvingKey])

--- a/crypto/zk/circuit/config.go
+++ b/crypto/zk/circuit/config.go
@@ -67,14 +67,13 @@ var CircuitsConfigurations = map[string]ZkCircuitConfig{
 	},
 }
 
-// GetCircuitConfiguration returns the circuit configuration associated to the
+// GetCircuitConfiguration returns the circuit configuration associated with the
 // provided tag or gets the default one.
 func GetCircuitConfiguration(configTag string) ZkCircuitConfig {
-	circuitConf := CircuitsConfigurations[DefaultCircuitConfigurationTag]
 	if conf, ok := CircuitsConfigurations[configTag]; ok {
-		circuitConf = conf
+		return conf
 	}
-	return circuitConf
+	return CircuitsConfigurations[DefaultCircuitConfigurationTag]
 }
 
 // hexToBytes parses a hex string and returns the byte array from it. Warning,

--- a/crypto/zk/circuit/config.go
+++ b/crypto/zk/circuit/config.go
@@ -3,12 +3,13 @@ package circuit
 import (
 	"encoding/hex"
 	"log"
-	"strings"
+
+	"go.vocdoni.io/dvote/util"
 )
 
 // DefaultCircuitConfigurationTag constant contains the tag value that points
 // to the default ZkSnark circuit configuration. It ensures that at least one
-// circuit configuration is available so the configuration refered by this tag
+// circuit configuration is available so the configuration referred by this tag
 // must be defined.
 const DefaultCircuitConfigurationTag = "dev"
 
@@ -76,8 +77,7 @@ func GetCircuitConfiguration(configTag string) ZkCircuitConfig {
 // hexToBytes parses a hex string and returns the byte array from it. Warning,
 // in case of error it will panic.
 func hexToBytes(s string) []byte {
-	s = strings.TrimPrefix(s, "0x")
-	b, err := hex.DecodeString(s)
+	b, err := hex.DecodeString(util.TrimHex(s))
 	if err != nil {
 		log.Fatalf("Error decoding hex string %s: %s", s, err)
 	}

--- a/crypto/zk/circuit/config.go
+++ b/crypto/zk/circuit/config.go
@@ -16,15 +16,13 @@ const DefaultCircuitConfigurationTag = "dev"
 type ZkCircuitConfig struct {
 	// URI defines the URI from where to download the files
 	URI string `json:"uri"`
-	// CircuitPath defines the path from where the files are downloaded
+	// CircuitPath defines the path from where the files are downloaded.
+	// Locally, they will be cached inside circuit.BaseDir path,
+	// under that directory it will follow the CircuitPath dir structure
 	CircuitPath string `json:"circuitPath"`
 	// Levels refers the number of levels that the merkle tree associated to the
 	// current circuit configuration artifacts has
 	Levels int `json:"levels"`
-	// LocalDir defines in which directory will be the files
-	// downloaded, under that directory it will follow the CircuitPath
-	// directories structure
-	LocalDir string `json:"localDir,omitempty"`
 	// ProvingKeyHash contains the expected hash for the file filenameZKey
 	ProvingKeyHash []byte `json:"zKeyHash"`
 	// FilenameProvingKey defines the name of the file of the circom ProvingKey
@@ -57,7 +55,6 @@ var CircuitsConfigurations = map[string]ZkCircuitConfig{
 			"zk-franchise-proof-circuit/master",
 		CircuitPath:             "artifacts/zkCensus/dev/160",
 		Levels:                  160, // ZkCircuit number of levels
-		LocalDir:                "zkCircuits",
 		ProvingKeyHash:          hexToBytes("0x48596c390d24a173c796b0dae68f3c08db034171917ca1b2f253ce9476a35945"),
 		ProvingKeyFilename:      "proving_key.zkey",
 		VerificationKeyHash:     hexToBytes("0x411c78a012d6d163e02704d9ce33b6d84e84ee67f62179f53158ffabd88da44a"),

--- a/rpcclient/api.go
+++ b/rpcclient/api.go
@@ -892,7 +892,6 @@ func (c *Client) TestSendAnonVotes(
 	}
 
 	log.Infof("Downloading Circuit Artifacts")
-	circuitConfig.LocalDir = "/tmp"
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 


### PR DESCRIPTION
until now, it would use ./zkCircuits, being relative this would create many copies, pollute the git repo while doing `go test`, and redownload the same files many times
    
`node` binary still puts them into -dataDir

also, i included a trivial refactor for idiomatic code, unrelated to the main objective of this PR, but not big enough to warrant a PR