### PR TITLE
remove unnecessary type conversions

### DIFF
--- a/crypto/ethereum/ethereum.go
+++ b/crypto/ethereum/ethereum.go
@@ -88,7 +88,7 @@ func (k *SignKeys) PublicKey() types.HexBytes {
 
 // PrivateKey returns the private key
 func (k *SignKeys) PrivateKey() types.HexBytes {
-	return types.HexBytes(ethcrypto.FromECDSA(&k.Private))
+	return ethcrypto.FromECDSA(&k.Private)
 }
 
 // DecompressPubKey takes a compressed public key and returns it descompressed. If already decompressed, returns the same key.

--- a/vochain/indexer/process.go
+++ b/vochain/indexer/process.go
@@ -170,7 +170,7 @@ func (s *Indexer) EntityList(max, from int, searchTerm string) []types.HexBytes 
 	}
 	hexIDs := make([]types.HexBytes, len(entityIDs))
 	for i, id := range entityIDs {
-		hexIDs[i] = types.HexBytes(id)
+		hexIDs[i] = id
 	}
 	return hexIDs
 }

--- a/vochain/indexer/transaction.go
+++ b/vochain/indexer/transaction.go
@@ -80,7 +80,7 @@ func (s *Indexer) OnNewTx(tx *vochaintx.VochainTx, blockHeight uint32, txIndex i
 	s.lockPool.Lock()
 	defer s.lockPool.Unlock()
 	s.newTxPool = append(s.newTxPool, &indexertypes.TxReference{
-		Hash:         types.HexBytes(tx.TxID[:]),
+		Hash:         tx.TxID[:],
 		BlockHeight:  blockHeight,
 		TxBlockIndex: txIndex,
 		TxType:       tx.TxModelType,


### PR DESCRIPTION
Seems `types.HexBytes(..)` is not necessary since the data is already `[]byte`