### PR TITLE
rename util.CreateEthRandomKeysBatch -> ethereum.NewSignKeysBatch

### DIFF
--- a/cmd/end2endtest/main.go
+++ b/cmd/end2endtest/main.go
@@ -215,7 +215,7 @@ func mkTreeVoteTest(c config) {
 	log.Infof("new census created with id %s", censusID.String())
 
 	// Generate 10 participant accounts
-	voterAccounts := util.CreateEthRandomKeysBatch(c.nvotes)
+	voterAccounts := ethereum.NewSignKeysBatch(c.nvotes)
 
 	// Add the accounts to the census by batches
 	participants := &vapi.CensusParticipants{}

--- a/cmd/end2endtest/zkweighted.go
+++ b/cmd/end2endtest/zkweighted.go
@@ -93,7 +93,7 @@ func mkTreeAnonVoteTest(c config) {
 	log.Infof("new census created with id %s", censusID.String())
 
 	// Generate n participant accounts
-	voterAccounts := util.CreateEthRandomKeysBatch(c.nvotes)
+	voterAccounts := ethereum.NewSignKeysBatch(c.nvotes)
 
 	// Add the accounts to the census by batches
 	participants := &vapi.CensusParticipants{}

--- a/crypto/ethereum/ethereum.go
+++ b/crypto/ethereum/ethereum.go
@@ -13,6 +13,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/dvote/util"
 )
 
 // SignatureLength is the size of an ECDSA signature in hexString format
@@ -45,6 +46,18 @@ func NewSignKeys() *SignKeys {
 	}
 }
 
+// NewSignKeysBatch creates a set of eth random signing keys
+func NewSignKeysBatch(n int) []*SignKeys {
+	s := make([]*SignKeys, n)
+	for i := 0; i < n; i++ {
+		s[i] = NewSignKeys()
+		if err := s[i].Generate(); err != nil {
+			panic(err)
+		}
+	}
+	return s
+}
+
 // Generate generates new keys
 func (k *SignKeys) Generate() error {
 	key, err := ethcrypto.GenerateKey()
@@ -58,7 +71,7 @@ func (k *SignKeys) Generate() error {
 
 // AddHexKey imports a private hex key
 func (k *SignKeys) AddHexKey(privHex string) error {
-	key, err := ethcrypto.HexToECDSA(trimHex(privHex))
+	key, err := ethcrypto.HexToECDSA(util.TrimHex(privHex))
 	if err != nil {
 		return err
 	}
@@ -105,7 +118,7 @@ func DecompressPubKey(pubComp types.HexBytes) (types.HexBytes, error) {
 
 // CompressPubKey returns the compressed public key in hexString format
 func CompressPubKey(pubHexDec string) (string, error) {
-	pubHexDec = trimHex(pubHexDec)
+	pubHexDec = util.TrimHex(pubHexDec)
 	if len(pubHexDec) < PubKeyLengthBytesUncompressed*2 {
 		return pubHexDec, nil
 	}
@@ -262,11 +275,4 @@ func BuildVocdoniMessage(message []byte) []byte {
 // HashRaw hashes data with no prefix
 func HashRaw(data []byte) []byte {
 	return ethcrypto.Keccak256(data)
-}
-
-func trimHex(s string) string {
-	if len(s) >= 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X') {
-		return s[2:]
-	}
-	return s
 }

--- a/test/testcommon/testvoteproof/voteproof.go
+++ b/test/testcommon/testvoteproof/voteproof.go
@@ -56,7 +56,7 @@ func CreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys, []b
 		t.Fatal(err)
 	}
 
-	keys := util.CreateEthRandomKeysBatch(size)
+	keys := ethereum.NewSignKeysBatch(size)
 	hashedKeys := [][]byte{}
 	for _, k := range keys {
 		c, err := tr.Hash(k.PublicKey())

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -4,8 +4,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
-
-	"go.vocdoni.io/dvote/crypto/ethereum"
 )
 
 func TrimHex(s string) string {
@@ -53,16 +51,4 @@ func SplitBytes(buf []byte, lim int) [][]byte {
 		chunks = append(chunks, buf[:])
 	}
 	return chunks
-}
-
-// CreateEthRandomKeysBatch creates a set of eth random signing keys
-func CreateEthRandomKeysBatch(n int) []*ethereum.SignKeys {
-	s := make([]*ethereum.SignKeys, n)
-	for i := 0; i < n; i++ {
-		s[i] = ethereum.NewSignKeys()
-		if err := s[i].Generate(); err != nil {
-			panic(err)
-		}
-	}
-	return s
 }

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -9,6 +9,7 @@ import (
 
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"go.vocdoni.io/dvote/censustree"
+	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/db/metadb"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -44,7 +45,7 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 		b.Fatal(err)
 	}
 
-	keys := util.CreateEthRandomKeysBatch(nvoters)
+	keys := ethereum.NewSignKeysBatch(nvoters)
 	if keys == nil {
 		b.Fatal("cannot create keys batch")
 	}

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -145,7 +145,7 @@ func TestCSPproof(t *testing.T) {
 
 	// Test 20 valid votes
 	vp := []byte("[1,2,3,4]")
-	keys := util.CreateEthRandomKeysBatch(20)
+	keys := ethereum.NewSignKeysBatch(20)
 	for _, k := range keys {
 		bundle := &models.CAbundle{
 			ProcessId: pid,

--- a/vochain/vote_test.go
+++ b/vochain/vote_test.go
@@ -25,7 +25,7 @@ func testCreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys,
 		t.Fatal(err)
 	}
 
-	keys := util.CreateEthRandomKeysBatch(size)
+	keys := ethereum.NewSignKeysBatch(size)
 	hashedKeys := [][]byte{}
 	for _, k := range keys {
 		c, err := tr.Hash(k.PublicKey())

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -108,7 +108,7 @@ func testCSPvote(cli *apiclient.HTTPclient) error {
 	if err != nil {
 		return err
 	}
-	voterKeys := util.CreateEthRandomKeysBatch(censusSize)
+	voterKeys := ethereum.NewSignKeysBatch(censusSize)
 	proofs, err := testvoteproof.GetCSPproofBatch(voterKeys, &cspKey, processID)
 	if err != nil {
 		return err


### PR DESCRIPTION
ethereum package has NewSignKeys, and util.CreateEthRandomKeysBatch was just a batch of NewSignKeys, so it makes more sense to have it in the same package

deduplicate trimHex as well, use util.TrimHex