### PR TITLE
api: return ErrXXX.With instead of fmt.Errorf

### DIFF
--- a/api/api_types.go
+++ b/api/api_types.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -272,7 +271,7 @@ func CensusTypeToOrigin(ctype CensusTypeDescription) (models.CensusOrigin, []byt
 		origin = models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED
 		root = ctype.RootHash
 	default:
-		return 0, nil, fmt.Errorf("%w: %q", ErrCensusTypeUnknown, ctype)
+		return 0, nil, ErrCensusTypeUnknown.Withf("%q", ctype)
 	}
 	if root == nil {
 		return 0, nil, ErrCensusRootIsNil

--- a/api/census_helpers.go
+++ b/api/census_helpers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/hex"
-	"fmt"
 
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/proto/build/go/models"
@@ -40,7 +39,7 @@ func encodeCensusType(t models.Census_Type) string {
 func censusIDparse(censusID string) ([]byte, error) {
 	censusID = util.TrimHex(censusID)
 	if len(censusID) != censusIDsize*2 {
-		return nil, fmt.Errorf("%w (%d != %d)", ErrCensusIDLengthInvalid, len(censusID), censusIDsize*2)
+		return nil, ErrCensusIDLengthInvalid.Withf("(%d != %d)", len(censusID), censusIDsize*2)
 
 	}
 	return hex.DecodeString(censusID)

--- a/api/censuses.go
+++ b/api/censuses.go
@@ -661,7 +661,7 @@ func (a *API) censusProofHandler(msg *apirest.APIdata, ctx *httprouter.HTTPConte
 	}
 	leafV, siblings, err := ref.Tree().GenProof(leafKey)
 	if err != nil {
-		return fmt.Errorf("something was wrong during census proof generation: %w", err)
+		return ErrKeyNotFoundInCensus.With(hex.EncodeToString(leafKey))
 	}
 	response := Census{
 		Proof: siblings,
@@ -674,7 +674,7 @@ func (a *API) censusProofHandler(msg *apirest.APIdata, ctx *httprouter.HTTPConte
 	if ref.CensusType == int32(models.Census_ARBO_POSEIDON) {
 		response.Siblings, err = ref.Tree().GetCircomSiblings(leafKey)
 		if err != nil {
-			return fmt.Errorf("error geting the census siblings to circom: %w", err)
+			return ErrCantGetCircomSiblings.WithErr(err)
 		}
 	}
 	if len(leafV) > 0 {
@@ -736,7 +736,7 @@ func (a *API) censusVerifyHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCont
 
 	valid, err := ref.Tree().VerifyProof(leafKey, cdata.Value, cdata.Proof, cdata.Root)
 	if err != nil {
-		return fmt.Errorf("something was wrong during census proof verification: %w", err)
+		return ErrCensusProofVerificationFailed.WithErr(err)
 	}
 	if !valid {
 		return ctx.Send(nil, apirest.HTTPstatusBadRequest)

--- a/api/elections.go
+++ b/api/elections.go
@@ -340,7 +340,7 @@ func (a *API) electionVotesHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 		if errors.Is(err, indexer.ErrVoteNotFound) {
 			return ErrVoteNotFound
 		}
-		return fmt.Errorf("%w (%x): %v", ErrCantFetchElection, electionID, err)
+		return ErrCantFetchEnvelope.WithErr(err)
 	}
 	votes := []Vote{}
 	for _, v := range votesRaw {
@@ -625,10 +625,10 @@ func getElection(electionID []byte, vs *state.State) (*models.Process, error) {
 		if errors.Is(err, state.ErrProcessNotFound) {
 			return nil, ErrElectionNotFound
 		}
-		return nil, fmt.Errorf("%w (%x): %v", ErrCantFetchElection, electionID, err)
+		return nil, ErrCantFetchElection.Withf("(%x): %v", electionID, err)
 	}
 	if process == nil {
-		return nil, fmt.Errorf("%w (%x)", ErrElectionIsNil, electionID)
+		return nil, ErrElectionIsNil.Withf("%x", electionID)
 	}
 	return process, nil
 }

--- a/api/errors.go
+++ b/api/errors.go
@@ -65,6 +65,7 @@ var (
 	ErrElectionNotFound                 = apirest.APIerror{Code: 4046, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("election not found")}
 	ErrCensusNotFound                   = apirest.APIerror{Code: 4047, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("census not found")}
 	ErrNoElectionKeys                   = apirest.APIerror{Code: 4048, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("no election keys available")}
+	ErrKeyNotFoundInCensus              = apirest.APIerror{Code: 4049, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("key not found in census")}
 	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
 	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
 	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}
@@ -92,4 +93,6 @@ var (
 	ErrElectionResultsNotYetAvailable   = apirest.APIerror{Code: 5024, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("election results are not yet available")}
 	ErrElectionResultsIsNil             = apirest.APIerror{Code: 5025, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("election results is nil")}
 	ErrElectionResultsMismatch          = apirest.APIerror{Code: 5026, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("election results don't match reported ones")}
+	ErrCantGetCircomSiblings            = apirest.APIerror{Code: 5027, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot get circom siblings")}
+	ErrCensusProofVerificationFailed    = apirest.APIerror{Code: 5028, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("census proof verification failed")}
 )

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -24,11 +24,11 @@ func (a *API) electionSummaryList(pids ...[]byte) ([]*ElectionSummary, error) {
 		// TODO(mvdan): ProcessInfo could give us the results envelope height as well.
 		procInfo, err := a.indexer.ProcessInfo(pid)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrCantFetchElection, err)
+			return nil, ErrCantFetchElection.WithErr(err)
 		}
 		count, err := a.indexer.GetEnvelopeHeight(pid)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrCantFetchEnvelopeHeight, err)
+			return nil, ErrCantFetchEnvelopeHeight.WithErr(err)
 		}
 		processes = append(processes, &ElectionSummary{
 			ElectionID:     procInfo.ID,
@@ -135,7 +135,7 @@ func encodeEVMResultsArgs(electionId common.Hash,
 	}
 	abiEncodedResultsBytes, err := args.Pack(electionId, organizationId, censusRoot, sourceContractAddress, resultsStd)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrCantABIEncodeResults, err)
+		return "", ErrCantABIEncodeResults.WithErr(err)
 	}
 	return fmt.Sprintf("0x%s", hex.EncodeToString(abiEncodedResultsBytes)), nil
 }


### PR DESCRIPTION
a couple of fmt.Errorf were introduced recently, fix them. (they don't produce JSON replies, breaking interop)