### PR TITLE
end2endtest refactoring

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,6 +127,7 @@ jobs:
           COMPOSE_HOST_PATH: ${{ github.workspace }}/dockerfiles/testsuite
           LOG_PANIC_ON_INVALIDCHARS: true # check that log lines contains no invalid chars (evidence of format mismatch)
           GOCOVERDIR: "./gocoverage/" # collect code coverage when running binaries
+          CONCURRENT: 1 # run all the start_test.sh tests concurrently
         run: |
           cd dockerfiles/testsuite && ./start_test.sh
       - name: Set up Go environment

--- a/apiclient/election.go
+++ b/apiclient/election.go
@@ -396,3 +396,20 @@ func (c *HTTPclient) ElectionFilterPaginated(organizationId types.HexBytes,
 	}
 	return &elections, nil
 }
+
+// ElectionKeys fetches the encryption keys for an election.
+// Note that only elections that are SecretUntilTheEnd will return keys
+func (c *HTTPclient) ElectionKeys(electionID types.HexBytes) (*api.ElectionKeys, error) {
+	resp, code, err := c.Request("GET", nil, "elections", electionID.String(), "keys")
+	if err != nil {
+		return nil, err
+	}
+	if code != 200 {
+		return nil, fmt.Errorf("%s: %d (%s)", errCodeNot200, code, resp)
+	}
+	electionKeys := &api.ElectionKeys{}
+	if err = json.Unmarshal(resp, &electionKeys); err != nil {
+		return nil, fmt.Errorf("could not unmarshal response: %w", err)
+	}
+	return electionKeys, nil
+}

--- a/apiclient/helpers.go
+++ b/apiclient/helpers.go
@@ -18,7 +18,11 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const pollInterval = 4 * time.Second
+const (
+	TimeBetweenBlocks = 6 * time.Second
+	WaitTimeout       = 3 * TimeBetweenBlocks
+	PollInterval      = TimeBetweenBlocks / 6
+)
 
 func (c *HTTPclient) DateToHeight(date time.Time) (uint32, error) {
 	resp, code, err := c.Request(HTTPGET, nil, "chain", "dateToBlock", fmt.Sprintf("%d", date.Unix()))
@@ -67,7 +71,7 @@ func (c *HTTPclient) WaitUntilNBlocks(ctx context.Context, n uint32) {
 		info, err := c.ChainInfo()
 		if err != nil {
 			log.Error(err)
-			time.Sleep(pollInterval)
+			time.Sleep(PollInterval)
 			continue
 		}
 		c.WaitUntilHeight(ctx, info.Height+n)
@@ -92,7 +96,7 @@ func (c *HTTPclient) WaitUntilHeight(ctx context.Context, height uint32) error {
 			return nil
 		}
 		select {
-		case <-time.After(pollInterval):
+		case <-time.After(PollInterval):
 			continue
 		case <-ctx.Done():
 			return ctx.Err()
@@ -137,7 +141,7 @@ func (c *HTTPclient) WaitUntilElectionStatus(ctx context.Context,
 			return election, nil
 		}
 		select {
-		case <-time.After(pollInterval):
+		case <-time.After(PollInterval):
 			continue
 		case <-ctx.Done():
 			return nil, fmt.Errorf("election %v never reached status %s: %w", electionID, status, ctx.Err())
@@ -154,10 +158,29 @@ func (c *HTTPclient) WaitUntilTxIsMined(ctx context.Context,
 			return tr, nil
 		}
 		select {
-		case <-time.After(pollInterval):
+		case <-time.After(PollInterval):
 			continue
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+	}
+}
+
+// WaitUntilElectionKeys waits until the election has published its encryption keys,
+// and returns them.
+func (c *HTTPclient) WaitUntilElectionKeys(ctx context.Context, electionID types.HexBytes) (
+	*api.ElectionKeys, error) {
+	log.Infof("waiting for election %s to publish keys...", electionID)
+	for {
+		ek, err := c.ElectionKeys(electionID)
+		if err == nil {
+			return ek, nil
+		}
+		select {
+		case <-time.After(PollInterval):
+			continue
+		case <-ctx.Done():
+			return nil, fmt.Errorf("election %s keys not yet published: %w", electionID, ctx.Err())
 		}
 	}
 }

--- a/cmd/end2endtest/account.go
+++ b/cmd/end2endtest/account.go
@@ -57,7 +57,7 @@ func (t *E2ETokenTxs) Setup(api *apiclient.HTTPclient, config *config) error {
 	}
 
 	// get faucet package for alice
-	t.aliceFP, err = getFaucetPackage(t.config, t.alice.Address().Hex())
+	t.aliceFP, err = getFaucetPackage(t.config.faucet, t.config.faucetAuthToken, t.alice.Address().Hex())
 	if err != nil {
 		return err
 	}

--- a/cmd/end2endtest/account.go
+++ b/cmd/end2endtest/account.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"net/url"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 	apipkg "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -20,51 +19,74 @@ import (
 	"go.vocdoni.io/proto/build/go/models"
 )
 
-func testTokenTransactions(c config) {
+func init() {
+	ops["tokentxs"] = operation{
+		test:        &E2ETokenTxs{},
+		description: "Tests all token related transactions",
+		example: os.Args[0] + " --operation=tokentxs " +
+			"--host http://127.0.0.1:9090/v2",
+	}
+}
+
+var _ VochainTest = (*E2ETokenTxs)(nil)
+
+type E2ETokenTxs struct {
+	api    *apiclient.HTTPclient
+	config *config
+
+	alice, bob *ethereum.SignKeys
+	aliceFP    *models.FaucetPackage
+}
+
+func (t *E2ETokenTxs) Setup(api *apiclient.HTTPclient, config *config) error {
+	t.api = api
+	t.config = config
 
 	// create alice signer
-	alice := &ethereum.SignKeys{}
-	if err := alice.Generate(); err != nil {
-		log.Fatal(err)
+	t.alice = ethereum.NewSignKeys()
+	err := t.alice.Generate()
+	if err != nil {
+		return err
 	}
 
 	// create bob signer
-	bob := &ethereum.SignKeys{}
-	if err := bob.Generate(); err != nil {
-		log.Fatal(err)
+	t.bob = ethereum.NewSignKeys()
+	err = t.bob.Generate()
+	if err != nil {
+		return err
 	}
 
-	// Connect to the API host
-	hostURL, err := url.Parse(c.host)
+	// get faucet package for alice
+	t.aliceFP, err = getFaucetPackage(t.config, t.alice.Address().Hex())
 	if err != nil {
-		log.Fatal(err)
-	}
-	log.Debugw("connecting to API", "host", hostURL.String())
-
-	token := uuid.New()
-	api, err := apiclient.NewHTTPclient(hostURL, &token)
-	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// check transaction cost
-	if err := testGetTxCost(api); err != nil {
+	if err := testGetTxCost(t.api); err != nil {
 		log.Fatal(err)
 	}
 
-	fp, err := getFaucetPackage(c, alice.Address().Hex())
-	if err != nil {
-		log.Fatal(err)
-	}
 	// check create and set account
-	if err := testCreateAndSetAccount(api, fp, alice, bob); err != nil {
+	if err := testCreateAndSetAccount(t.api, t.aliceFP, t.alice, t.bob); err != nil {
 		log.Fatal(err)
 	}
 
+	return nil
+}
+
+func (t *E2ETokenTxs) Teardown() error {
+	// nothing to do here
+	return nil
+}
+
+func (t *E2ETokenTxs) Run() error {
 	// check send tokens
-	if err := testSendTokens(api, alice, bob); err != nil {
+	if err := testSendTokens(t.api, t.alice, t.bob); err != nil {
 		log.Fatal(err)
 	}
+
+	return nil
 }
 
 func testGetTxCost(api *apiclient.HTTPclient) error {
@@ -189,6 +211,13 @@ func testSendTokens(api *apiclient.HTTPclient, aliceKeys, bobKeys *ethereum.Sign
 		return err
 	}
 	log.Debugf("mined, tx refs are %+v and %+v", txrefa, txrefb)
+
+	// after a tx is mined in a block, the indexer takes some time to update the balances
+	// (i.e. seconds, if there are votes to be indexed)
+	// give it one more block time
+	ctx, cancel = context.WithTimeout(context.Background(), apiclient.WaitTimeout)
+	defer cancel()
+	api.WaitUntilNextBlock(ctx)
 
 	// now check the resulting state
 	err = checkAccountNonceAndBalance(alice, aliceAcc.Nonce+1,

--- a/cmd/end2endtest/encrypted.go
+++ b/cmd/end2endtest/encrypted.go
@@ -1,0 +1,375 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	vapi "go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/apiclient"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/dvote/util"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+func init() {
+	ops["encryptedelection"] = operation{
+		test:        &E2EEncryptedElection{},
+		description: "Publishes a census and a non-anonymous, secret-until-the-end election, emits N votes and verifies the results",
+		example:     os.Args[0] + " --operation=encryptedelection --votes=1000",
+	}
+}
+
+var _ VochainTest = (*E2EEncryptedElection)(nil)
+
+type E2EEncryptedElection struct {
+	api    *apiclient.HTTPclient
+	config *config
+
+	election      *vapi.Election
+	voterAccounts []*ethereum.SignKeys
+	proofs        map[string]*apiclient.CensusProof
+}
+
+func (t *E2EEncryptedElection) Setup(api *apiclient.HTTPclient, c *config) error {
+	t.api = api
+	t.config = c
+
+	// Set the account in the API client, so we can sign transactions
+	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
+		log.Fatal(err)
+	}
+
+	// If the account does not exist, create a new one
+	// TODO: check if the account balance is low and use the faucet
+	acc, err := api.Account("")
+	if err != nil {
+		log.Infof("getting faucet package")
+		faucetPkg, err := getFaucetPackage(c, api.MyAddress().Hex())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Create the organization account and bootstraping with the faucet package
+		log.Infof("creating Vocdoni account %s", api.MyAddress().Hex())
+		log.Debugf("faucetPackage is %x", faucetPkg)
+		hash, err := api.AccountBootstrap(faucetPkg, &vapi.AccountMetadata{
+			Name:        map[string]string{"default": "test account " + api.MyAddress().Hex()},
+			Description: map[string]string{"default": "test description"},
+			Version:     "1.0",
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+		defer cancel()
+		if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
+			log.Fatalf("gave up waiting for tx %x to be mined: %s", hash, err)
+		}
+
+		acc, err = api.Account("")
+		if err != nil {
+			log.Fatal(err)
+		}
+		if c.faucet != "" && acc.Balance == 0 {
+			log.Fatal("account balance is 0")
+		}
+	}
+
+	log.Infof("account %s balance is %d", api.MyAddress().Hex(), acc.Balance)
+
+	// Create a new census
+	censusID, err := api.NewCensus(vapi.CensusTypeWeighted)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("new census created with id %s", censusID.String())
+
+	// Generate 10 participant accounts
+	t.voterAccounts = ethereum.NewSignKeysBatch(c.nvotes)
+
+	// Add the accounts to the census by batches
+	participants := &vapi.CensusParticipants{}
+	for i, voterAccount := range t.voterAccounts {
+		participants.Participants = append(participants.Participants,
+			vapi.CensusParticipant{
+				Key:    voterAccount.Address().Bytes(),
+				Weight: (*types.BigInt)(new(big.Int).SetUint64(10)),
+			})
+		if i == len(t.voterAccounts)-1 || ((i+1)%vapi.MaxCensusAddBatchSize == 0) {
+			if err := api.CensusAddParticipants(censusID, participants); err != nil {
+				log.Fatal(err)
+			}
+			log.Infof("added %d participants to census %s",
+				len(participants.Participants), censusID.String())
+			participants = &vapi.CensusParticipants{}
+		}
+	}
+
+	// Check census size
+	size, err := api.CensusSize(censusID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if size != uint64(c.nvotes) {
+		log.Fatalf("census size is %d, expected %d", size, c.nvotes)
+	}
+	log.Infof("census %s size is %d", censusID.String(), size)
+
+	// Publish the census
+	root, censusURI, err := api.CensusPublish(censusID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("census published with root %s", root.String())
+
+	// Check census size (of the published census)
+	size, err = api.CensusSize(root)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if size != uint64(c.nvotes) {
+		log.Fatalf("published census size is %d, expected %d", size, c.nvotes)
+	}
+
+	// Create a new Election
+	electionID, err := api.NewElection(&vapi.ElectionDescription{
+		Title:       map[string]string{"default": fmt.Sprintf("Test election %s", util.RandomHex(8))},
+		Description: map[string]string{"default": "Test election description"},
+		EndDate:     time.Now().Add(time.Minute * 20),
+
+		VoteType: vapi.VoteType{
+			UniqueChoices:     false,
+			MaxVoteOverwrites: 1,
+		},
+
+		ElectionType: vapi.ElectionType{
+			Autostart:         true,
+			Interruptible:     true,
+			Anonymous:         false,
+			SecretUntilTheEnd: true,
+			DynamicCensus:     false,
+		},
+
+		Census: vapi.CensusTypeDescription{
+			RootHash: root,
+			URL:      censusURI,
+			Type:     "weighted",
+			Size:     uint64(len(t.voterAccounts)),
+		},
+
+		Questions: []vapi.Question{
+			{
+				Title:       map[string]string{"default": "Test question 1"},
+				Description: map[string]string{"default": "Test question 1 description"},
+				Choices: []vapi.ChoiceMetadata{
+					{
+						Title: map[string]string{"default": "Yes"},
+						Value: 0,
+					},
+					{
+						Title: map[string]string{"default": "No"},
+						Value: 1,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("created new election with id %s", electionID.String())
+
+	t.proofs = t.votingProofs(root, t.voterAccounts)
+
+	// Wait for the election to start
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+	t.election, err = api.WaitUntilElectionStarts(ctx, electionID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Debugf("election details: %+v", *t.election)
+
+	return nil
+}
+
+// votingProofs generates the voting proofs (parallelized)
+func (t *E2EEncryptedElection) votingProofs(root types.HexBytes,
+	voterAccounts []*ethereum.SignKeys) map[string]*apiclient.CensusProof {
+	type voterProof struct {
+		proof   *apiclient.CensusProof
+		address string
+	}
+	proofs := make(map[string]*apiclient.CensusProof, t.config.nvotes)
+	proofCh := make(chan *voterProof)
+	stopProofs := make(chan bool)
+	go func() {
+		for {
+			select {
+			case p := <-proofCh:
+				proofs[p.address] = p.proof
+			case <-stopProofs:
+				return
+			}
+		}
+	}()
+
+	addNaccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
+		defer wg.Done()
+		log.Infof("generating %d voting proofs", len(accounts))
+		for _, acc := range accounts {
+			pr, err := t.api.CensusGenProof(root, acc.Address().Bytes())
+			if err != nil {
+				log.Fatal(err)
+			}
+			pr.KeyType = models.ProofArbo_ADDRESS
+			proofCh <- &voterProof{
+				proof:   pr,
+				address: acc.Address().Hex(),
+			}
+		}
+	}
+
+	pcount := t.config.nvotes / t.config.parallelCount
+	var wg sync.WaitGroup
+	for i := 0; i < len(t.voterAccounts); i += pcount {
+		end := i + pcount
+		if end > len(t.voterAccounts) {
+			end = len(t.voterAccounts)
+		}
+		wg.Add(1)
+		go addNaccounts(t.voterAccounts[i:end], &wg)
+	}
+
+	wg.Wait()
+	time.Sleep(time.Second) // wait a grace time for the last proof to be added
+	log.Debugf("%d/%d voting proofs generated successfully", len(proofs), len(t.voterAccounts))
+	stopProofs <- true
+
+	return proofs
+}
+
+func (t *E2EEncryptedElection) Teardown() error {
+	// nothing to do here
+	return nil
+}
+
+func (t *E2EEncryptedElection) Run() error {
+	c := t.config
+	api := t.api
+
+	// Send the votes (parallelized)
+	startTime := time.Now()
+	wg := sync.WaitGroup{}
+	voteAccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
+		defer wg.Done()
+		log.Infof("sending %d votes", len(accounts))
+		// We use maps instead of slices to have the capacity of resending votes
+		// without repeating them.
+		accountsMap := make(map[int]*ethereum.SignKeys, len(accounts))
+		for i, acc := range accounts {
+			accountsMap[i] = acc
+		}
+		// Send the votes
+		votesSent := 0
+		for {
+			contextDeadlines := 0
+			for i, voterAccount := range accountsMap {
+				c := api.Clone(fmt.Sprintf("%x", voterAccount.PrivateKey()))
+				_, err := c.Vote(&apiclient.VoteData{
+					ElectionID:  t.election.ElectionID,
+					ProofMkTree: t.proofs[voterAccount.Address().Hex()],
+					Choices:     []int{i % 2},
+				})
+				// if the context deadline is reached, we don't need to print it (let's just retry)
+				if err != nil && errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+					contextDeadlines++
+					continue
+				} else if err != nil && !strings.Contains(err.Error(), "already exists") {
+					// if the error is not "vote already exists", we need to print it
+					log.Warn(err)
+					continue
+				}
+				// if the vote was sent successfully or already exists, we remove it from the accounts map
+				votesSent++
+				delete(accountsMap, i)
+
+			}
+			if len(accountsMap) == 0 {
+				break
+			}
+			log.Infof("sent %d/%d votes... got %d HTTP errors", votesSent, len(accounts), contextDeadlines)
+			time.Sleep(time.Second * 5)
+		}
+		log.Infof("successfully sent %d votes", votesSent)
+		time.Sleep(time.Second * 2)
+	}
+
+	pcount := c.nvotes / c.parallelCount
+	for i := 0; i < len(t.voterAccounts); i += pcount {
+		end := i + pcount
+		if end > len(t.voterAccounts) {
+			end = len(t.voterAccounts)
+		}
+		wg.Add(1)
+		go voteAccounts(t.voterAccounts[i:end], &wg)
+	}
+
+	wg.Wait()
+	log.Infof("%d votes submitted successfully, took %s (%d votes/second)",
+		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
+
+	// Wait for all the votes to be verified
+	log.Infof("waiting for all the votes to be registered...")
+	for {
+		count, err := api.ElectionVoteCount(t.election.ElectionID)
+		if err != nil {
+			log.Warn(err)
+		}
+		if count == uint32(c.nvotes) {
+			break
+		}
+		time.Sleep(time.Second * 5)
+		log.Infof("verified %d/%d votes", count, c.nvotes)
+		if time.Since(startTime) > c.timeout {
+			log.Fatalf("timeout waiting for votes to be registered")
+		}
+	}
+
+	log.Infof("%d votes registered successfully, took %s (%d votes/second)",
+		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
+
+	// Set the account back to the organization account
+	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
+		log.Fatal(err)
+	}
+
+	// End the election by setting the status to ENDED
+	log.Infof("ending election...")
+	_, err := api.SetElectionStatus(t.election.ElectionID, "ENDED")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Wait for the election to be in RESULTS state
+	ctx, cancel := context.WithTimeout(context.Background(), apiclient.WaitTimeout)
+	defer cancel()
+	election, err := api.WaitUntilElectionStatus(ctx, t.election.ElectionID, "RESULTS")
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("election %s status is RESULTS", t.election.ElectionID.String())
+	log.Infof("election results: %v", election.Results)
+
+	return nil
+}

--- a/cmd/end2endtest/encrypted.go
+++ b/cmd/end2endtest/encrypted.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"os"
 	"strings"
 	"sync"
@@ -15,9 +14,6 @@ import (
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
-	"go.vocdoni.io/dvote/types"
-	"go.vocdoni.io/dvote/util"
-	"go.vocdoni.io/proto/build/go/models"
 )
 
 func init() {
@@ -31,232 +27,28 @@ func init() {
 var _ VochainTest = (*E2EEncryptedElection)(nil)
 
 type E2EEncryptedElection struct {
-	api    *apiclient.HTTPclient
-	config *config
-
-	election      *vapi.Election
-	voterAccounts []*ethereum.SignKeys
-	proofs        map[string]*apiclient.CensusProof
+	e2eElection
 }
 
 func (t *E2EEncryptedElection) Setup(api *apiclient.HTTPclient, c *config) error {
 	t.api = api
 	t.config = c
 
-	// Set the account in the API client, so we can sign transactions
-	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
-		log.Fatal(err)
+	ed := newTestElectionDescription()
+	ed.ElectionType = vapi.ElectionType{
+		Autostart:         true,
+		Interruptible:     true,
+		SecretUntilTheEnd: true,
 	}
+	ed.VoteType = vapi.VoteType{MaxVoteOverwrites: 1}
+	ed.Census = vapi.CensusTypeDescription{Type: vapi.CensusTypeWeighted}
 
-	// If the account does not exist, create a new one
-	// TODO: check if the account balance is low and use the faucet
-	acc, err := api.Account("")
-	if err != nil {
-		log.Infof("getting faucet package")
-		faucetPkg, err := getFaucetPackage(c, api.MyAddress().Hex())
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Create the organization account and bootstraping with the faucet package
-		log.Infof("creating Vocdoni account %s", api.MyAddress().Hex())
-		log.Debugf("faucetPackage is %x", faucetPkg)
-		hash, err := api.AccountBootstrap(faucetPkg, &vapi.AccountMetadata{
-			Name:        map[string]string{"default": "test account " + api.MyAddress().Hex()},
-			Description: map[string]string{"default": "test description"},
-			Version:     "1.0",
-		})
-		if err != nil {
-			log.Fatal(err)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-		defer cancel()
-		if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
-			log.Fatalf("gave up waiting for tx %x to be mined: %s", hash, err)
-		}
-
-		acc, err = api.Account("")
-		if err != nil {
-			log.Fatal(err)
-		}
-		if c.faucet != "" && acc.Balance == 0 {
-			log.Fatal("account balance is 0")
-		}
-	}
-
-	log.Infof("account %s balance is %d", api.MyAddress().Hex(), acc.Balance)
-
-	// Create a new census
-	censusID, err := api.NewCensus(vapi.CensusTypeWeighted)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("new census created with id %s", censusID.String())
-
-	// Generate 10 participant accounts
-	t.voterAccounts = ethereum.NewSignKeysBatch(c.nvotes)
-
-	// Add the accounts to the census by batches
-	participants := &vapi.CensusParticipants{}
-	for i, voterAccount := range t.voterAccounts {
-		participants.Participants = append(participants.Participants,
-			vapi.CensusParticipant{
-				Key:    voterAccount.Address().Bytes(),
-				Weight: (*types.BigInt)(new(big.Int).SetUint64(10)),
-			})
-		if i == len(t.voterAccounts)-1 || ((i+1)%vapi.MaxCensusAddBatchSize == 0) {
-			if err := api.CensusAddParticipants(censusID, participants); err != nil {
-				log.Fatal(err)
-			}
-			log.Infof("added %d participants to census %s",
-				len(participants.Participants), censusID.String())
-			participants = &vapi.CensusParticipants{}
-		}
-	}
-
-	// Check census size
-	size, err := api.CensusSize(censusID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if size != uint64(c.nvotes) {
-		log.Fatalf("census size is %d, expected %d", size, c.nvotes)
-	}
-	log.Infof("census %s size is %d", censusID.String(), size)
-
-	// Publish the census
-	root, censusURI, err := api.CensusPublish(censusID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("census published with root %s", root.String())
-
-	// Check census size (of the published census)
-	size, err = api.CensusSize(root)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if size != uint64(c.nvotes) {
-		log.Fatalf("published census size is %d, expected %d", size, c.nvotes)
-	}
-
-	// Create a new Election
-	electionID, err := api.NewElection(&vapi.ElectionDescription{
-		Title:       map[string]string{"default": fmt.Sprintf("Test election %s", util.RandomHex(8))},
-		Description: map[string]string{"default": "Test election description"},
-		EndDate:     time.Now().Add(time.Minute * 20),
-
-		VoteType: vapi.VoteType{
-			UniqueChoices:     false,
-			MaxVoteOverwrites: 1,
-		},
-
-		ElectionType: vapi.ElectionType{
-			Autostart:         true,
-			Interruptible:     true,
-			Anonymous:         false,
-			SecretUntilTheEnd: true,
-			DynamicCensus:     false,
-		},
-
-		Census: vapi.CensusTypeDescription{
-			RootHash: root,
-			URL:      censusURI,
-			Type:     "weighted",
-			Size:     uint64(len(t.voterAccounts)),
-		},
-
-		Questions: []vapi.Question{
-			{
-				Title:       map[string]string{"default": "Test question 1"},
-				Description: map[string]string{"default": "Test question 1 description"},
-				Choices: []vapi.ChoiceMetadata{
-					{
-						Title: map[string]string{"default": "Yes"},
-						Value: 0,
-					},
-					{
-						Title: map[string]string{"default": "No"},
-						Value: 1,
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("created new election with id %s", electionID.String())
-
-	t.proofs = t.votingProofs(root, t.voterAccounts)
-
-	// Wait for the election to start
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-	defer cancel()
-	t.election, err = api.WaitUntilElectionStarts(ctx, electionID)
-	if err != nil {
-		log.Fatal(err)
+	if err := t.setupElection(ed); err != nil {
+		return err
 	}
 
 	log.Debugf("election details: %+v", *t.election)
-
 	return nil
-}
-
-// votingProofs generates the voting proofs (parallelized)
-func (t *E2EEncryptedElection) votingProofs(root types.HexBytes,
-	voterAccounts []*ethereum.SignKeys) map[string]*apiclient.CensusProof {
-	type voterProof struct {
-		proof   *apiclient.CensusProof
-		address string
-	}
-	proofs := make(map[string]*apiclient.CensusProof, t.config.nvotes)
-	proofCh := make(chan *voterProof)
-	stopProofs := make(chan bool)
-	go func() {
-		for {
-			select {
-			case p := <-proofCh:
-				proofs[p.address] = p.proof
-			case <-stopProofs:
-				return
-			}
-		}
-	}()
-
-	addNaccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
-		defer wg.Done()
-		log.Infof("generating %d voting proofs", len(accounts))
-		for _, acc := range accounts {
-			pr, err := t.api.CensusGenProof(root, acc.Address().Bytes())
-			if err != nil {
-				log.Fatal(err)
-			}
-			pr.KeyType = models.ProofArbo_ADDRESS
-			proofCh <- &voterProof{
-				proof:   pr,
-				address: acc.Address().Hex(),
-			}
-		}
-	}
-
-	pcount := t.config.nvotes / t.config.parallelCount
-	var wg sync.WaitGroup
-	for i := 0; i < len(t.voterAccounts); i += pcount {
-		end := i + pcount
-		if end > len(t.voterAccounts) {
-			end = len(t.voterAccounts)
-		}
-		wg.Add(1)
-		go addNaccounts(t.voterAccounts[i:end], &wg)
-	}
-
-	wg.Wait()
-	time.Sleep(time.Second) // wait a grace time for the last proof to be added
-	log.Debugf("%d/%d voting proofs generated successfully", len(proofs), len(t.voterAccounts))
-	stopProofs <- true
-
-	return proofs
 }
 
 func (t *E2EEncryptedElection) Teardown() error {
@@ -362,7 +154,7 @@ func (t *E2EEncryptedElection) Run() error {
 	}
 
 	// Wait for the election to be in RESULTS state
-	ctx, cancel := context.WithTimeout(context.Background(), apiclient.WaitTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
 	defer cancel()
 	election, err := api.WaitUntilElectionStatus(ctx, t.election.ElectionID, "RESULTS")
 	if err != nil {

--- a/cmd/end2endtest/helpers.go
+++ b/cmd/end2endtest/helpers.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	vapi "go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/apiclient"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/zk"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/dvote/util"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+func newTestElectionDescription() *vapi.ElectionDescription {
+	return &vapi.ElectionDescription{
+		Title:       map[string]string{"default": fmt.Sprintf("Test election %s", util.RandomHex(8))},
+		Description: map[string]string{"default": "Test election description"},
+		EndDate:     time.Now().Add(time.Minute * 20),
+
+		Questions: []vapi.Question{
+			{
+				Title:       map[string]string{"default": "Test question 1"},
+				Description: map[string]string{"default": "Test question 1 description"},
+				Choices: []vapi.ChoiceMetadata{
+					{
+						Title: map[string]string{"default": "Yes"},
+						Value: 0,
+					},
+					{
+						Title: map[string]string{"default": "No"},
+						Value: 1,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t e2eElection) createAccount(address string) (*vapi.Account, error) {
+	faucetPkg, err := getFaucetPackage(t.config.faucet, t.config.faucetAuthToken, address)
+	if err != nil {
+		return nil, err
+	}
+
+	accountMetadata := &vapi.AccountMetadata{
+		Name:        map[string]string{"default": "test account " + address},
+		Description: map[string]string{"default": "test description"},
+		Version:     "1.0",
+	}
+
+	log.Infof("creating Vocdoni account %s", address)
+	hash, err := t.api.AccountBootstrap(faucetPkg, accountMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	if _, err := t.api.WaitUntilTxIsMined(ctx, hash); err != nil {
+		log.Errorf("gave up waiting for tx %x to be mined: %s", hash, err)
+		return nil, err
+	}
+
+	// check the account
+	acc, err := t.api.Account("")
+	if err != nil {
+		return nil, err
+	}
+	if t.config.faucet != "" && acc.Balance == 0 {
+		log.Error("account balance is 0")
+		return nil, err
+	}
+	return acc, nil
+
+}
+
+func (t e2eElection) addParticipantsCensus(censusType string, censusID types.HexBytes) error {
+	participants := &vapi.CensusParticipants{}
+
+	for i, voterAccount := range t.voterAccounts {
+		keyAddr, err := getCensusParticipantKey(voterAccount, censusType)
+		if err != nil {
+			return err
+		}
+		participants.Participants = append(participants.Participants,
+			vapi.CensusParticipant{
+				Key:    keyAddr,
+				Weight: (*types.BigInt)(new(big.Int).SetUint64(10)),
+			})
+
+		if i == len(t.voterAccounts)-1 || ((i+1)%vapi.MaxCensusAddBatchSize == 0) {
+			if err := t.api.CensusAddParticipants(censusID, participants); err != nil {
+				return err
+			}
+
+			log.Infof("added %d participants to census %s",
+				len(participants.Participants), censusID.String())
+
+			participants = &vapi.CensusParticipants{}
+		}
+	}
+	return nil
+}
+
+func (t e2eElection) isCensusSizeValid(censusID types.HexBytes) bool {
+	size, err := t.api.CensusSize(censusID)
+	if err != nil {
+		log.Errorf("unable to get census size from api")
+		return false
+	}
+	if size != uint64(t.config.nvotes) {
+		log.Errorf("census size is %d, expected %d", size, t.config.nvotes)
+		return false
+	}
+	log.Infof("census %s size is %d", censusID.String(), size)
+	return true
+}
+
+func (t e2eElection) createElection(electionDescrip *vapi.ElectionDescription) (*vapi.Election, error) {
+	electionID, err := t.api.NewElection(electionDescrip)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("created new election with id %s - now wait until it starts", electionID.String())
+
+	// Wait for the election to start
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*80)
+	defer cancel()
+	election, err := t.api.WaitUntilElectionStarts(ctx, electionID)
+	if err != nil {
+		return nil, err
+	}
+	election.ElectionID = electionID
+
+	return election, nil
+}
+
+func (t e2eElection) generateProofs(root types.HexBytes, isAnonymousVoting bool) map[string]*apiclient.CensusProof {
+	type voterProof struct {
+		proof   *apiclient.CensusProof
+		address string
+	}
+	proofs := make(map[string]*apiclient.CensusProof, t.config.nvotes)
+	proofCh := make(chan *voterProof)
+	stopProofs := make(chan bool)
+	go func() {
+		for {
+			select {
+			case p := <-proofCh:
+				proofs[p.address] = p.proof
+			case <-stopProofs:
+				return
+			}
+		}
+	}()
+
+	apiClientMtx := &sync.Mutex{}
+	addNaccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
+		defer wg.Done()
+		log.Infof("generating %d voting proofs", len(accounts))
+		for _, acc := range accounts {
+			voterKey := acc.Address().Bytes()
+
+			if isAnonymousVoting {
+				apiClientMtx.Lock()
+				privKey := acc.PrivateKey()
+				if err := t.api.SetAccount(privKey.String()); err != nil {
+					apiClientMtx.Unlock()
+					log.Fatal(err)
+					return
+				}
+				voterKey = t.api.MyZkAddress().Bytes()
+			}
+
+			pr, err := t.api.CensusGenProof(root, voterKey)
+			if isAnonymousVoting {
+				apiClientMtx.Unlock()
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if !isAnonymousVoting {
+				pr.KeyType = models.ProofArbo_ADDRESS
+			}
+			proofCh <- &voterProof{
+				proof:   pr,
+				address: acc.Address().Hex(),
+			}
+		}
+	}
+
+	pcount := t.config.nvotes / t.config.parallelCount
+	var wg sync.WaitGroup
+	for i := 0; i < len(t.voterAccounts); i += pcount {
+		end := i + pcount
+		if end > len(t.voterAccounts) {
+			end = len(t.voterAccounts)
+		}
+		wg.Add(1)
+		go addNaccounts(t.voterAccounts[i:end], &wg)
+	}
+
+	wg.Wait()
+	time.Sleep(time.Second) // wait a grace time for the last proof to be added
+	log.Debugf("%d/%d voting proofs generated successfully", len(proofs), len(t.voterAccounts))
+	stopProofs <- true
+
+	return proofs
+}
+
+func (t *e2eElection) setupElection(ed *vapi.ElectionDescription) error {
+	// Set the account in the API client, so we can sign transactions
+	if err := t.api.SetAccount(hex.EncodeToString(t.config.accountKeys[0].PrivateKey())); err != nil {
+		return err
+	}
+
+	// If the account does not exist, create a new one
+	// TODO: check if the account balance is low and use the faucet
+	acc, err := t.api.Account("")
+	if err != nil {
+		acc, err = t.createAccount(t.api.MyAddress().Hex())
+		if err != nil {
+			return err
+		}
+	}
+	log.Infof("account %s balance is %d", t.api.MyAddress().Hex(), acc.Balance)
+
+	// Create a new census
+	censusID, err := t.api.NewCensus(ed.Census.Type)
+	if err != nil {
+		return err
+	}
+	log.Infof("new census created with id %s", censusID.String())
+
+	// Generate 10 participant accounts
+	t.voterAccounts = ethereum.NewSignKeysBatch(t.config.nvotes)
+
+	// Add the accounts to the census by batches
+	if err := t.addParticipantsCensus(ed.Census.Type, censusID); err != nil {
+		return err
+	}
+
+	// Check census size
+	if !t.isCensusSizeValid(censusID) {
+		return err
+	}
+
+	// Publish the census
+	root, censusURI, err := t.api.CensusPublish(censusID)
+	if err != nil {
+		return err
+	}
+	log.Infof("census published with root %s", root.String())
+	ed.Census.RootHash = root
+	ed.Census.URL = censusURI
+	ed.Census.Size = uint64(t.config.nvotes)
+
+	// Check census size (of the published census)
+	if !t.isCensusSizeValid(root) {
+		return err
+	}
+
+	t.election, err = t.createElection(ed)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("created new election with id %s", t.election.ElectionID.String())
+
+	// Wait for the election to start
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+	t.election, err = t.api.WaitUntilElectionStarts(ctx, t.election.ElectionID)
+	if err != nil {
+		return err
+	}
+
+	t.proofs = t.generateProofs(root, ed.ElectionType.Anonymous)
+
+	return nil
+}
+
+func getFaucetPackage(faucet, faucetAuthToken, myAddress string) (*models.FaucetPackage, error) {
+	switch faucet {
+	case "":
+		return nil, fmt.Errorf("need to pass a valid --faucet")
+	case "dev":
+		return apiclient.GetFaucetPackageFromDevService(myAddress)
+	default:
+		return apiclient.GetFaucetPackageFromRemoteService(faucet+myAddress, faucetAuthToken)
+	}
+}
+
+func getCensusParticipantKey(voterAccount *ethereum.SignKeys, censusType string) ([]byte, error) {
+	var key []byte
+
+	switch censusType {
+	case vapi.CensusTypeWeighted:
+		key = voterAccount.Address().Bytes()
+	case vapi.CensusTypeZKWeighted:
+		zkAddr, err := zk.AddressFromSignKeys(voterAccount)
+		if err != nil {
+			return nil, err
+		}
+		key = zkAddr.Bytes()
+	}
+	return key, nil
+}

--- a/cmd/end2endtest/main.go
+++ b/cmd/end2endtest/main.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/google/uuid"
 	flag "github.com/spf13/pflag"
+	vapi "go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/internal"
-	"go.vocdoni.io/proto/build/go/models"
-
-	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
 )
@@ -33,6 +32,15 @@ type VochainTest interface {
 	Setup(api *apiclient.HTTPclient, config *config) error
 	Run() error
 	Teardown() error
+}
+
+type e2eElection struct {
+	api    *apiclient.HTTPclient
+	config *config
+
+	election      *vapi.Election
+	voterAccounts []*ethereum.SignKeys
+	proofs        map[string]*apiclient.CensusProof
 }
 
 type operation struct {
@@ -175,16 +183,4 @@ func privKeyToSigner(key string) (*ethereum.SignKeys, error) {
 		}
 	}
 	return skey, nil
-}
-
-func getFaucetPackage(c *config, account string) (*models.FaucetPackage, error) {
-	if c.faucet == "" {
-		return nil, fmt.Errorf("need to pass a valid --faucet")
-	}
-	if c.faucet == "dev" {
-		return apiclient.GetFaucetPackageFromDevService(account)
-	} else {
-		return apiclient.GetFaucetPackageFromRemoteService(c.faucet+account,
-			c.faucetAuthToken)
-	}
 }

--- a/cmd/end2endtest/main.go
+++ b/cmd/end2endtest/main.go
@@ -1,26 +1,18 @@
 package main
 
 import (
-	"context"
-	"encoding/hex"
-	"errors"
 	"fmt"
-	"math/big"
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	flag "github.com/spf13/pflag"
-	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/internal"
-	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/proto/build/go/models"
 
-	"github.com/google/uuid"
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
@@ -31,39 +23,29 @@ import (
 // * how many times to retry opening a connection to an endpoint before giving up
 const retries = 10
 
+// VochainTest is the interface that tests should comply with.
+// Duration of each step will be measured and reported.
+//
+//   - Setup() is intended to create accounts, elections, etc.
+//   - Run() can be, for example, to emit votes.
+//   - Teardown() can be used to clean up afterwards.
+type VochainTest interface {
+	Setup(api *apiclient.HTTPclient, config *config) error
+	Run() error
+	Teardown() error
+}
+
 type operation struct {
-	fn func(c config)
+	test VochainTest
 
-	name, description, example string
+	description, example string
 }
 
-var ops = []operation{
-	{
-		fn:          mkTreeVoteTest,
-		name:        "vtest",
-		description: "Performs a complete test, from creating a census to voting and validating votes",
-		example: os.Args[0] + " --operation=vtest --votes=1000 " +
-			"--oracleKey=6aae1d165dd9776c580b8fdaf8622e39c5f943c715e20690080bbfce2c760223",
-	},
-	{
-		fn:          testTokenTransactions,
-		name:        "tokentransactions",
-		description: "Tests all token related transactions",
-		example: os.Args[0] + " --operation=tokentransactions " +
-			"--host http://127.0.0.1:9090/v2",
-	},
-	{
-		fn:          mkTreeAnonVoteTest,
-		name:        "anonvoting",
-		description: "Performs a complete test of anonymous election, from creating a census to voting and validating votes",
-		example: os.Args[0] + " --operation=anonvoting --votes=1000 " +
-			"--oracleKey=6aae1d165dd9776c580b8fdaf8622e39c5f943c715e20690080bbfce2c760223",
-	},
-}
+var ops = map[string]operation{}
 
 func opNames() (names []string) {
-	for _, op := range ops {
-		names = append(names, op.name)
+	for name := range ops {
+		names = append(names, name)
 	}
 	return names
 }
@@ -87,10 +69,10 @@ func main() {
 	// For the sake of including the version in the log, it's also included in a log line later on.
 	fmt.Fprintf(os.Stderr, "vocdoni version %q\n", internal.Version)
 
-	c := config{}
+	c := &config{}
 	flag.StringVar(&c.host, "host", "https://api-dev.vocdoni.net/v2", "API host to connect to")
 	flag.StringVar(&c.logLevel, "logLevel", "info", "log level (debug, info, warn, error, fatal)")
-	flag.StringVar(&c.operation, "operation", "vtest",
+	flag.StringVar(&c.operation, "operation", "",
 		fmt.Sprintf("set operation mode: %v", opNames()))
 	flag.StringSliceVarP(&c.accountPrivKeys, "accountPrivKey", "k", []string{},
 		"account private key (optional)")
@@ -107,8 +89,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nSome examples of different operation modes:\n")
-		for _, op := range ops {
-			fmt.Fprintf(os.Stderr, "### %s\n", op.name)
+		for name, op := range ops {
+			fmt.Fprintf(os.Stderr, "### %s\n", name)
 			fmt.Fprintf(os.Stderr, "\t"+op.description+"\n")
 			fmt.Fprintf(os.Stderr, op.example+"\n")
 			fmt.Fprintf(os.Stderr, "\n")
@@ -136,358 +118,52 @@ func main() {
 		log.Infof("privkey %x = account %s", ak.PrivateKey(), ak.AddressString())
 	}
 
-	found := false
-	for _, op := range ops {
-		if op.name == c.operation {
-			op.fn(c)
-			found = true
-		}
-	}
-
+	op, found := ops[c.operation]
 	if !found {
 		log.Fatal("no valid operation mode specified")
 	}
 
-}
-
-func mkTreeVoteTest(c config) {
-	// Connect to the API host
-	hostURL, err := url.Parse(c.host)
+	api, err := NewAPIclient(c.host)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	startTime := time.Now()
+	err = op.test.Setup(api, c)
+	duration := time.Since(startTime)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infow("setup done", "test", c.operation, "duration", duration.String())
+
+	startTime = time.Now()
+	err = op.test.Run()
+	duration = time.Since(startTime)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infow("run finished", "test", c.operation, "duration", duration.String())
+
+	startTime = time.Now()
+	err = op.test.Teardown()
+	duration = time.Since(startTime)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infow("teardown done", "test", c.operation, "duration", duration.String())
+}
+
+// NewAPIclient connects to the API host and returns the handle
+func NewAPIclient(host string) (*apiclient.HTTPclient, error) {
+	hostURL, err := url.Parse(host)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	log.Debugf("connecting to %s", hostURL.String())
 
 	token := uuid.New()
-	api, err := apiclient.NewHTTPclient(hostURL, &token)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Set the account in the API client, so we can sign transactions
-	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
-		log.Fatal(err)
-	}
-
-	// If the account does not exist, create a new one
-	// TODO: check if the account balance is low and use the faucet
-	acc, err := api.Account("")
-	if err != nil {
-		log.Infof("getting faucet package")
-		faucetPkg, err := getFaucetPackage(c, api.MyAddress().Hex())
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Create the organization account and bootstraping with the faucet package
-		log.Infof("creating Vocdoni account %s", api.MyAddress().Hex())
-		log.Debugf("faucetPackage is %x", faucetPkg)
-		hash, err := api.AccountBootstrap(faucetPkg, &vapi.AccountMetadata{
-			Name:        map[string]string{"default": "test account " + api.MyAddress().Hex()},
-			Description: map[string]string{"default": "test description"},
-			Version:     "1.0",
-		})
-		if err != nil {
-			log.Fatal(err)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-		defer cancel()
-		if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
-			log.Fatalf("gave up waiting for tx %x to be mined: %s", hash, err)
-		}
-
-		acc, err = api.Account("")
-		if err != nil {
-			log.Fatal(err)
-		}
-		if c.faucet != "" && acc.Balance == 0 {
-			log.Fatal("account balance is 0")
-		}
-	}
-
-	log.Infof("account %s balance is %d", api.MyAddress().Hex(), acc.Balance)
-
-	// Create a new census
-	censusID, err := api.NewCensus("weighted")
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("new census created with id %s", censusID.String())
-
-	// Generate 10 participant accounts
-	voterAccounts := ethereum.NewSignKeysBatch(c.nvotes)
-
-	// Add the accounts to the census by batches
-	participants := &vapi.CensusParticipants{}
-	for i, voterAccount := range voterAccounts {
-		participants.Participants = append(participants.Participants,
-			vapi.CensusParticipant{
-				Key:    voterAccount.Address().Bytes(),
-				Weight: (*types.BigInt)(new(big.Int).SetUint64(10)),
-			})
-		if i == len(voterAccounts)-1 || ((i+1)%vapi.MaxCensusAddBatchSize == 0) {
-			if err := api.CensusAddParticipants(censusID, participants); err != nil {
-				log.Fatal(err)
-			}
-			log.Infof("added %d participants to census %s",
-				len(participants.Participants), censusID.String())
-			participants = &vapi.CensusParticipants{}
-		}
-	}
-
-	// Check census size
-	size, err := api.CensusSize(censusID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if size != uint64(c.nvotes) {
-		log.Fatalf("census size is %d, expected %d", size, c.nvotes)
-	}
-	log.Infof("census %s size is %d", censusID.String(), size)
-
-	// Publish the census
-	root, censusURI, err := api.CensusPublish(censusID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("census published with root %s", root.String())
-
-	// Check census size (of the published census)
-	size, err = api.CensusSize(root)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if size != uint64(c.nvotes) {
-		log.Fatalf("published census size is %d, expected %d", size, c.nvotes)
-	}
-
-	// Generate the voting proofs (parallelized)
-	type voterProof struct {
-		proof   *apiclient.CensusProof
-		address string
-	}
-	proofs := make(map[string]*apiclient.CensusProof, c.nvotes)
-	proofCh := make(chan *voterProof)
-	stopProofs := make(chan bool)
-	go func() {
-		for {
-			select {
-			case p := <-proofCh:
-				proofs[p.address] = p.proof
-			case <-stopProofs:
-				return
-			}
-		}
-	}()
-
-	addNaccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
-		defer wg.Done()
-		log.Infof("generating %d voting proofs", len(accounts))
-		for _, acc := range accounts {
-			pr, err := api.CensusGenProof(root, acc.Address().Bytes())
-			if err != nil {
-				log.Fatal(err)
-			}
-			pr.KeyType = models.ProofArbo_ADDRESS
-			proofCh <- &voterProof{
-				proof:   pr,
-				address: acc.Address().Hex(),
-			}
-		}
-	}
-
-	pcount := c.nvotes / c.parallelCount
-	var wg sync.WaitGroup
-	for i := 0; i < len(voterAccounts); i += pcount {
-		end := i + pcount
-		if end > len(voterAccounts) {
-			end = len(voterAccounts)
-		}
-		wg.Add(1)
-		go addNaccounts(voterAccounts[i:end], &wg)
-	}
-
-	wg.Wait()
-	time.Sleep(time.Second) // wait a grace time for the last proof to be added
-	log.Debugf("%d/%d voting proofs generated successfully", len(proofs), len(voterAccounts))
-	stopProofs <- true
-
-	// Create a new Election
-	electionID, err := api.NewElection(&vapi.ElectionDescription{
-		Title:       map[string]string{"default": fmt.Sprintf("Test election %s", util.RandomHex(8))},
-		Description: map[string]string{"default": "Test election description"},
-		EndDate:     time.Now().Add(time.Minute * 20),
-
-		VoteType: vapi.VoteType{
-			UniqueChoices:     false,
-			MaxVoteOverwrites: 1,
-		},
-
-		ElectionType: vapi.ElectionType{
-			Autostart:         true,
-			Interruptible:     true,
-			Anonymous:         false,
-			SecretUntilTheEnd: false,
-			DynamicCensus:     false,
-		},
-
-		Census: vapi.CensusTypeDescription{
-			RootHash: root,
-			URL:      censusURI,
-			Type:     "weighted",
-			Size:     uint64(len(voterAccounts)),
-		},
-
-		Questions: []vapi.Question{
-			{
-				Title:       map[string]string{"default": "Test question 1"},
-				Description: map[string]string{"default": "Test question 1 description"},
-				Choices: []vapi.ChoiceMetadata{
-					{
-						Title: map[string]string{"default": "Yes"},
-						Value: 0,
-					},
-					{
-						Title: map[string]string{"default": "No"},
-						Value: 1,
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("created new election with id %s - now wait until it starts", electionID.String())
-
-	// Wait for the election to start
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-	defer cancel()
-	election, err := api.WaitUntilElectionStarts(ctx, electionID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Debugf("election details: %+v", *election)
-
-	// Send the votes (parallelized)
-	startTime := time.Now()
-	wg = sync.WaitGroup{}
-	voteAccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
-		defer wg.Done()
-		log.Infof("sending %d votes", len(accounts))
-		// We use maps instead of slices to have the capacity of resending votes
-		// without repeating them.
-		accountsMap := make(map[int]*ethereum.SignKeys, len(accounts))
-		for i, acc := range accounts {
-			accountsMap[i] = acc
-		}
-		// Send the votes
-		votesSent := 0
-		for {
-			contextDeadlines := 0
-			for i, voterAccount := range accountsMap {
-				c := api.Clone(fmt.Sprintf("%x", voterAccount.PrivateKey()))
-				_, err := c.Vote(&apiclient.VoteData{
-					ElectionID:  electionID,
-					ProofMkTree: proofs[voterAccount.Address().Hex()],
-					Choices:     []int{i % 2},
-				})
-				// if the context deadline is reached, we don't need to print it (let's jus retry)
-				if err != nil && errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
-					contextDeadlines++
-					continue
-				} else if err != nil && !strings.Contains(err.Error(), "already exists") {
-					// if the error is not "vote already exists", we need to print it
-					log.Warn(err)
-					continue
-				}
-				// if the vote was sent successfully or already exists, we remove it from the accounts map
-				votesSent++
-				delete(accountsMap, i)
-
-			}
-			if len(accountsMap) == 0 {
-				break
-			}
-			log.Infof("sent %d/%d votes... got %d HTTP errors", votesSent, len(accounts), contextDeadlines)
-			time.Sleep(time.Second * 5)
-		}
-		log.Infof("successfully sent %d votes", votesSent)
-		time.Sleep(time.Second * 2)
-	}
-
-	pcount = c.nvotes / c.parallelCount
-	for i := 0; i < len(voterAccounts); i += pcount {
-		end := i + pcount
-		if end > len(voterAccounts) {
-			end = len(voterAccounts)
-		}
-		wg.Add(1)
-		go voteAccounts(voterAccounts[i:end], &wg)
-	}
-
-	wg.Wait()
-	log.Infof("%d votes submitted successfully, took %s (%d votes/second)",
-		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
-
-	// Wait for all the votes to be verified
-	log.Infof("waiting for all the votes to be registered...")
-	for {
-		count, err := api.ElectionVoteCount(electionID)
-		if err != nil {
-			log.Warn(err)
-		}
-		if count == uint32(c.nvotes) {
-			break
-		}
-		time.Sleep(time.Second * 5)
-		log.Infof("verified %d/%d votes", count, c.nvotes)
-		if time.Since(startTime) > c.timeout {
-			log.Fatalf("timeout waiting for votes to be registered")
-		}
-	}
-
-	log.Infof("%d votes registered successfully, took %s (%d votes/second)",
-		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
-
-	// Set the account back to the organization account
-	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
-		log.Fatal(err)
-	}
-
-	// End the election by setting the status to ENDED
-	log.Infof("ending election...")
-	hash, err := api.SetElectionStatus(electionID, "ENDED")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Check the election status is actually ENDED
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*40)
-	defer cancel()
-	if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
-		log.Fatalf("gave up waiting for tx %s to be mined: %s", hash, err)
-	}
-
-	election, err = api.Election(electionID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if election.Status != "ENDED" {
-		log.Fatal("election status is not ENDED")
-	}
-	log.Infof("election %s status is ENDED", electionID.String())
-
-	// Wait for the election to be in RESULTS state
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*300)
-	defer cancel()
-	election, err = api.WaitUntilElectionStatus(ctx, electionID, "RESULTS")
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("election %s status is RESULTS", electionID.String())
-	log.Infof("election results: %v", election.Results)
+	return apiclient.NewHTTPclient(hostURL, &token)
 }
 
 func privKeyToSigner(key string) (*ethereum.SignKeys, error) {
@@ -501,7 +177,7 @@ func privKeyToSigner(key string) (*ethereum.SignKeys, error) {
 	return skey, nil
 }
 
-func getFaucetPackage(c config, account string) (*models.FaucetPackage, error) {
+func getFaucetPackage(c *config, account string) (*models.FaucetPackage, error) {
 	if c.faucet == "" {
 		return nil, fmt.Errorf("need to pass a valid --faucet")
 	}

--- a/cmd/end2endtest/plaintext.go
+++ b/cmd/end2endtest/plaintext.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -12,7 +14,6 @@ import (
 	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/zk"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
@@ -20,37 +21,37 @@ import (
 )
 
 func init() {
-	ops["anonelection"] = operation{
-		test:        &E2EAnonElection{},
-		description: "Performs a complete test of anonymous election, from creating a census to voting and validating votes",
-		example:     os.Args[0] + " --operation=anonelection --votes=1000",
+	ops["plaintextelection"] = operation{
+		test:        &E2EPlaintextElection{},
+		description: "Publishes a census and a non-anonymous, non-secret election, emits N votes and verifies the results",
+		example:     os.Args[0] + " --operation=plaintextelection --votes=1000",
 	}
 }
 
-var _ VochainTest = (*E2EAnonElection)(nil)
+var _ VochainTest = (*E2EPlaintextElection)(nil)
 
-type E2EAnonElection struct {
+type E2EPlaintextElection struct {
 	api    *apiclient.HTTPclient
 	config *config
 }
 
-func (t *E2EAnonElection) Setup(api *apiclient.HTTPclient, config *config) error {
+func (t *E2EPlaintextElection) Setup(api *apiclient.HTTPclient, config *config) error {
 	t.api = api
 	t.config = config
 	return nil
 }
 
-func (t *E2EAnonElection) Teardown() error {
+func (t *E2EPlaintextElection) Teardown() error {
 	// nothing to do here
 	return nil
 }
 
-func (t *E2EAnonElection) Run() error {
+func (t *E2EPlaintextElection) Run() error {
 	c := t.config
 	api := t.api
 
 	// Set the account in the API client, so we can sign transactions
-	if err := api.SetAccount(c.accountPrivKeys[0]); err != nil {
+	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
 		log.Fatal(err)
 	}
 
@@ -58,20 +59,12 @@ func (t *E2EAnonElection) Run() error {
 	// TODO: check if the account balance is low and use the faucet
 	acc, err := api.Account("")
 	if err != nil {
-		var faucetPkg *models.FaucetPackage
-		if c.faucet != "" {
-			// Get the faucet package of bootstrap tokens
-			log.Infof("getting faucet package")
-			if c.faucet == "dev" {
-				faucetPkg, err = apiclient.GetFaucetPackageFromDevService(api.MyAddress().Hex())
-			} else {
-				faucetPkg, err = apiclient.GetFaucetPackageFromRemoteService(c.faucet+api.MyAddress().Hex(), c.faucetAuthToken)
-			}
-
-			if err != nil {
-				log.Fatal(err)
-			}
+		log.Infof("getting faucet package")
+		faucetPkg, err := getFaucetPackage(c, api.MyAddress().Hex())
+		if err != nil {
+			log.Fatal(err)
 		}
+
 		// Create the organization account and bootstraping with the faucet package
 		log.Infof("creating Vocdoni account %s", api.MyAddress().Hex())
 		log.Debugf("faucetPackage is %x", faucetPkg)
@@ -101,26 +94,21 @@ func (t *E2EAnonElection) Run() error {
 	log.Infof("account %s balance is %d", api.MyAddress().Hex(), acc.Balance)
 
 	// Create a new census
-	censusID, err := api.NewCensus(vapi.CensusTypeZKWeighted)
+	censusID, err := api.NewCensus("weighted")
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Infof("new census created with id %s", censusID.String())
 
-	// Generate n participant accounts
+	// Generate 10 participant accounts
 	voterAccounts := ethereum.NewSignKeysBatch(c.nvotes)
 
 	// Add the accounts to the census by batches
 	participants := &vapi.CensusParticipants{}
 	for i, voterAccount := range voterAccounts {
-		zkAddr, err := zk.AddressFromSignKeys(voterAccount)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		participants.Participants = append(participants.Participants,
 			vapi.CensusParticipant{
-				Key:    zkAddr.Bytes(),
+				Key:    voterAccount.Address().Bytes(),
 				Weight: (*types.BigInt)(new(big.Int).SetUint64(10)),
 			})
 		if i == len(voterAccounts)-1 || ((i+1)%vapi.MaxCensusAddBatchSize == 0) {
@@ -159,6 +147,57 @@ func (t *E2EAnonElection) Run() error {
 		log.Fatalf("published census size is %d, expected %d", size, c.nvotes)
 	}
 
+	// Generate the voting proofs (parallelized)
+	type voterProof struct {
+		proof   *apiclient.CensusProof
+		address string
+	}
+	proofs := make(map[string]*apiclient.CensusProof, c.nvotes)
+	proofCh := make(chan *voterProof)
+	stopProofs := make(chan bool)
+	go func() {
+		for {
+			select {
+			case p := <-proofCh:
+				proofs[p.address] = p.proof
+			case <-stopProofs:
+				return
+			}
+		}
+	}()
+
+	addNaccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
+		defer wg.Done()
+		log.Infof("generating %d voting proofs", len(accounts))
+		for _, acc := range accounts {
+			pr, err := api.CensusGenProof(root, acc.Address().Bytes())
+			if err != nil {
+				log.Fatal(err)
+			}
+			pr.KeyType = models.ProofArbo_ADDRESS
+			proofCh <- &voterProof{
+				proof:   pr,
+				address: acc.Address().Hex(),
+			}
+		}
+	}
+
+	pcount := c.nvotes / c.parallelCount
+	var wg sync.WaitGroup
+	for i := 0; i < len(voterAccounts); i += pcount {
+		end := i + pcount
+		if end > len(voterAccounts) {
+			end = len(voterAccounts)
+		}
+		wg.Add(1)
+		go addNaccounts(voterAccounts[i:end], &wg)
+	}
+
+	wg.Wait()
+	time.Sleep(time.Second) // wait a grace time for the last proof to be added
+	log.Debugf("%d/%d voting proofs generated successfully", len(proofs), len(voterAccounts))
+	stopProofs <- true
+
 	// Create a new Election
 	electionID, err := api.NewElection(&vapi.ElectionDescription{
 		Title:       map[string]string{"default": fmt.Sprintf("Test election %s", util.RandomHex(8))},
@@ -173,7 +212,7 @@ func (t *E2EAnonElection) Run() error {
 		ElectionType: vapi.ElectionType{
 			Autostart:         true,
 			Interruptible:     true,
-			Anonymous:         true,
+			Anonymous:         false,
 			SecretUntilTheEnd: false,
 			DynamicCensus:     false,
 		},
@@ -181,8 +220,8 @@ func (t *E2EAnonElection) Run() error {
 		Census: vapi.CensusTypeDescription{
 			RootHash: root,
 			URL:      censusURI,
-			Type:     vapi.CensusTypeZKWeighted,
-			Size:     size,
+			Type:     "weighted",
+			Size:     uint64(len(voterAccounts)),
 		},
 
 		Questions: []vapi.Question{
@@ -205,108 +244,78 @@ func (t *E2EAnonElection) Run() error {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Wait for the election creation
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-	defer cancel()
-	election, err := api.WaitUntilElectionCreated(ctx, electionID)
-	if err != nil {
-		log.Errorw(err, "error creating the election")
-		return
-	}
-	log.Debugf("election details: %+v", *election)
 	log.Infof("created new election with id %s - now wait until it starts", electionID.String())
 
 	// Wait for the election to start
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*40)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 	defer cancel()
-	election, err = api.WaitUntilElectionStarts(ctx, electionID)
+	election, err := api.WaitUntilElectionStarts(ctx, electionID)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	log.Debugf("election details: %+v", *election)
 
+	// Send the votes (parallelized)
 	startTime := time.Now()
-	successProofs, successVotes := 0, 0
-	proofCh, voteCh, stopCh := make(chan bool), make(chan bool), make(chan bool)
-	go func() {
-		for {
-			select {
-			case <-proofCh:
-				successProofs++
-			case <-voteCh:
-				successVotes++
-			case <-stopCh:
-				return
-			}
-		}
-	}()
-
-	apiClientMtx := &sync.Mutex{}
-	addNaccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
+	wg = sync.WaitGroup{}
+	voteAccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
 		defer wg.Done()
-		log.Infof("generating %d voting proofs", len(accounts))
+		log.Infof("sending %d votes", len(accounts))
+		// We use maps instead of slices to have the capacity of resending votes
+		// without repeating them.
+		accountsMap := make(map[int]*ethereum.SignKeys, len(accounts))
 		for i, acc := range accounts {
-			apiClientMtx.Lock()
-
-			privKey := acc.PrivateKey()
-			if err = api.SetAccount(privKey.String()); err != nil {
-				apiClientMtx.Unlock()
-				log.Fatal(err)
-				return
-			}
-
-			pr, err := api.CensusGenProof(root, api.MyZkAddress().Bytes())
-			if err != nil {
-				apiClientMtx.Unlock()
-				log.Warnw(err.Error(),
-					"current", i,
-					"total", c.nvotes)
-				continue
-			}
-
-			log.Debugw("census proof generated",
-				"current", i,
-				"total", len(accounts))
-			proofCh <- true
-
-			_, err = api.Vote(&apiclient.VoteData{
-				ElectionID:   electionID,
-				ProofMkTree:  pr,
-				Choices:      []int{i % 2},
-				VotingWeight: new(big.Int).SetUint64(8),
-			})
-			apiClientMtx.Unlock()
-			if err != nil && !strings.Contains(err.Error(), "already exists") {
-				// if the error is not "vote already exists", we need to print it
-				log.Warn(err.Error())
-				continue
-			}
-			log.Debugw("vote sent",
-				"current", i,
-				"total", len(accounts))
-			voteCh <- true
-			pr = nil
+			accountsMap[i] = acc
 		}
+		// Send the votes
+		votesSent := 0
+		for {
+			contextDeadlines := 0
+			for i, voterAccount := range accountsMap {
+				c := api.Clone(fmt.Sprintf("%x", voterAccount.PrivateKey()))
+				_, err := c.Vote(&apiclient.VoteData{
+					ElectionID:  electionID,
+					ProofMkTree: proofs[voterAccount.Address().Hex()],
+					Choices:     []int{i % 2},
+				})
+				// if the context deadline is reached, we don't need to print it (let's jus retry)
+				if err != nil && errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+					contextDeadlines++
+					continue
+				} else if err != nil && !strings.Contains(err.Error(), "already exists") {
+					// if the error is not "vote already exists", we need to print it
+					log.Warn(err)
+					continue
+				}
+				// if the vote was sent successfully or already exists, we remove it from the accounts map
+				votesSent++
+				delete(accountsMap, i)
+
+			}
+			if len(accountsMap) == 0 {
+				break
+			}
+			log.Infof("sent %d/%d votes... got %d HTTP errors", votesSent, len(accounts), contextDeadlines)
+			time.Sleep(time.Second * 5)
+		}
+		log.Infof("successfully sent %d votes", votesSent)
+		time.Sleep(time.Second * 2)
 	}
 
-	pcount := c.nvotes / c.parallelCount
-	var wg sync.WaitGroup
+	pcount = c.nvotes / c.parallelCount
 	for i := 0; i < len(voterAccounts); i += pcount {
 		end := i + pcount
 		if end > len(voterAccounts) {
 			end = len(voterAccounts)
 		}
 		wg.Add(1)
-		go addNaccounts(voterAccounts[i:end], &wg)
+		go voteAccounts(voterAccounts[i:end], &wg)
 	}
 
 	wg.Wait()
-	time.Sleep(time.Second) // wait a grace time for the last proof to be added
-	log.Debugf("%d/%d voting proofs generated successfully", successProofs, len(voterAccounts))
-	log.Debugf("%d/%d votes sent successfully", successVotes, len(voterAccounts))
-	stopCh <- true
+	log.Infof("%d votes submitted successfully, took %s (%d votes/second)",
+		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
 
 	// Wait for all the votes to be verified
 	log.Infof("waiting for all the votes to be registered...")
@@ -325,11 +334,11 @@ func (t *E2EAnonElection) Run() error {
 		}
 	}
 
-	log.Infof("%d votes registered successfully, took %s (%f votes/second)",
-		c.nvotes, time.Since(startTime), float64(c.nvotes)/time.Since(startTime).Seconds())
+	log.Infof("%d votes registered successfully, took %s (%d votes/second)",
+		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
 
 	// Set the account back to the organization account
-	if err := api.SetAccount(c.accountPrivKeys[0]); err != nil {
+	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/end2endtest/plaintext.go
+++ b/cmd/end2endtest/plaintext.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"os"
 	"strings"
 	"sync"
@@ -15,9 +14,6 @@ import (
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
-	"go.vocdoni.io/dvote/types"
-	"go.vocdoni.io/dvote/util"
-	"go.vocdoni.io/proto/build/go/models"
 )
 
 func init() {
@@ -31,13 +27,26 @@ func init() {
 var _ VochainTest = (*E2EPlaintextElection)(nil)
 
 type E2EPlaintextElection struct {
-	api    *apiclient.HTTPclient
-	config *config
+	e2eElection
 }
 
-func (t *E2EPlaintextElection) Setup(api *apiclient.HTTPclient, config *config) error {
+func (t *E2EPlaintextElection) Setup(api *apiclient.HTTPclient, c *config) error {
 	t.api = api
-	t.config = config
+	t.config = c
+
+	ed := newTestElectionDescription()
+	ed.ElectionType = vapi.ElectionType{
+		Autostart:     true,
+		Interruptible: true,
+	}
+	ed.VoteType = vapi.VoteType{MaxVoteOverwrites: 1}
+	ed.Census = vapi.CensusTypeDescription{Type: vapi.CensusTypeWeighted}
+
+	if err := t.setupElection(ed); err != nil {
+		return err
+	}
+
+	log.Debugf("election details: %+v", *t.election)
 	return nil
 }
 
@@ -50,215 +59,9 @@ func (t *E2EPlaintextElection) Run() error {
 	c := t.config
 	api := t.api
 
-	// Set the account in the API client, so we can sign transactions
-	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
-		log.Fatal(err)
-	}
-
-	// If the account does not exist, create a new one
-	// TODO: check if the account balance is low and use the faucet
-	acc, err := api.Account("")
-	if err != nil {
-		log.Infof("getting faucet package")
-		faucetPkg, err := getFaucetPackage(c, api.MyAddress().Hex())
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Create the organization account and bootstraping with the faucet package
-		log.Infof("creating Vocdoni account %s", api.MyAddress().Hex())
-		log.Debugf("faucetPackage is %x", faucetPkg)
-		hash, err := api.AccountBootstrap(faucetPkg, &vapi.AccountMetadata{
-			Name:        map[string]string{"default": "test account " + api.MyAddress().Hex()},
-			Description: map[string]string{"default": "test description"},
-			Version:     "1.0",
-		})
-		if err != nil {
-			log.Fatal(err)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-		defer cancel()
-		if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
-			log.Fatalf("gave up waiting for tx %x to be mined: %s", hash, err)
-		}
-
-		acc, err = api.Account("")
-		if err != nil {
-			log.Fatal(err)
-		}
-		if c.faucet != "" && acc.Balance == 0 {
-			log.Fatal("account balance is 0")
-		}
-	}
-
-	log.Infof("account %s balance is %d", api.MyAddress().Hex(), acc.Balance)
-
-	// Create a new census
-	censusID, err := api.NewCensus("weighted")
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("new census created with id %s", censusID.String())
-
-	// Generate 10 participant accounts
-	voterAccounts := ethereum.NewSignKeysBatch(c.nvotes)
-
-	// Add the accounts to the census by batches
-	participants := &vapi.CensusParticipants{}
-	for i, voterAccount := range voterAccounts {
-		participants.Participants = append(participants.Participants,
-			vapi.CensusParticipant{
-				Key:    voterAccount.Address().Bytes(),
-				Weight: (*types.BigInt)(new(big.Int).SetUint64(10)),
-			})
-		if i == len(voterAccounts)-1 || ((i+1)%vapi.MaxCensusAddBatchSize == 0) {
-			if err := api.CensusAddParticipants(censusID, participants); err != nil {
-				log.Fatal(err)
-			}
-			log.Infof("added %d participants to census %s",
-				len(participants.Participants), censusID.String())
-			participants = &vapi.CensusParticipants{}
-		}
-	}
-
-	// Check census size
-	size, err := api.CensusSize(censusID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if size != uint64(c.nvotes) {
-		log.Fatalf("census size is %d, expected %d", size, c.nvotes)
-	}
-	log.Infof("census %s size is %d", censusID.String(), size)
-
-	// Publish the census
-	root, censusURI, err := api.CensusPublish(censusID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("census published with root %s", root.String())
-
-	// Check census size (of the published census)
-	size, err = api.CensusSize(root)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if size != uint64(c.nvotes) {
-		log.Fatalf("published census size is %d, expected %d", size, c.nvotes)
-	}
-
-	// Generate the voting proofs (parallelized)
-	type voterProof struct {
-		proof   *apiclient.CensusProof
-		address string
-	}
-	proofs := make(map[string]*apiclient.CensusProof, c.nvotes)
-	proofCh := make(chan *voterProof)
-	stopProofs := make(chan bool)
-	go func() {
-		for {
-			select {
-			case p := <-proofCh:
-				proofs[p.address] = p.proof
-			case <-stopProofs:
-				return
-			}
-		}
-	}()
-
-	addNaccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
-		defer wg.Done()
-		log.Infof("generating %d voting proofs", len(accounts))
-		for _, acc := range accounts {
-			pr, err := api.CensusGenProof(root, acc.Address().Bytes())
-			if err != nil {
-				log.Fatal(err)
-			}
-			pr.KeyType = models.ProofArbo_ADDRESS
-			proofCh <- &voterProof{
-				proof:   pr,
-				address: acc.Address().Hex(),
-			}
-		}
-	}
-
-	pcount := c.nvotes / c.parallelCount
-	var wg sync.WaitGroup
-	for i := 0; i < len(voterAccounts); i += pcount {
-		end := i + pcount
-		if end > len(voterAccounts) {
-			end = len(voterAccounts)
-		}
-		wg.Add(1)
-		go addNaccounts(voterAccounts[i:end], &wg)
-	}
-
-	wg.Wait()
-	time.Sleep(time.Second) // wait a grace time for the last proof to be added
-	log.Debugf("%d/%d voting proofs generated successfully", len(proofs), len(voterAccounts))
-	stopProofs <- true
-
-	// Create a new Election
-	electionID, err := api.NewElection(&vapi.ElectionDescription{
-		Title:       map[string]string{"default": fmt.Sprintf("Test election %s", util.RandomHex(8))},
-		Description: map[string]string{"default": "Test election description"},
-		EndDate:     time.Now().Add(time.Minute * 20),
-
-		VoteType: vapi.VoteType{
-			UniqueChoices:     false,
-			MaxVoteOverwrites: 1,
-		},
-
-		ElectionType: vapi.ElectionType{
-			Autostart:         true,
-			Interruptible:     true,
-			Anonymous:         false,
-			SecretUntilTheEnd: false,
-			DynamicCensus:     false,
-		},
-
-		Census: vapi.CensusTypeDescription{
-			RootHash: root,
-			URL:      censusURI,
-			Type:     "weighted",
-			Size:     uint64(len(voterAccounts)),
-		},
-
-		Questions: []vapi.Question{
-			{
-				Title:       map[string]string{"default": "Test question 1"},
-				Description: map[string]string{"default": "Test question 1 description"},
-				Choices: []vapi.ChoiceMetadata{
-					{
-						Title: map[string]string{"default": "Yes"},
-						Value: 0,
-					},
-					{
-						Title: map[string]string{"default": "No"},
-						Value: 1,
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("created new election with id %s - now wait until it starts", electionID.String())
-
-	// Wait for the election to start
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-	defer cancel()
-	election, err := api.WaitUntilElectionStarts(ctx, electionID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Debugf("election details: %+v", *election)
-
 	// Send the votes (parallelized)
 	startTime := time.Now()
-	wg = sync.WaitGroup{}
+	wg := sync.WaitGroup{}
 	voteAccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
 		defer wg.Done()
 		log.Infof("sending %d votes", len(accounts))
@@ -275,8 +78,8 @@ func (t *E2EPlaintextElection) Run() error {
 			for i, voterAccount := range accountsMap {
 				c := api.Clone(fmt.Sprintf("%x", voterAccount.PrivateKey()))
 				_, err := c.Vote(&apiclient.VoteData{
-					ElectionID:  electionID,
-					ProofMkTree: proofs[voterAccount.Address().Hex()],
+					ElectionID:  t.election.ElectionID,
+					ProofMkTree: t.proofs[voterAccount.Address().Hex()],
 					Choices:     []int{i % 2},
 				})
 				// if the context deadline is reached, we don't need to print it (let's jus retry)
@@ -303,14 +106,14 @@ func (t *E2EPlaintextElection) Run() error {
 		time.Sleep(time.Second * 2)
 	}
 
-	pcount = c.nvotes / c.parallelCount
-	for i := 0; i < len(voterAccounts); i += pcount {
+	pcount := c.nvotes / c.parallelCount
+	for i := 0; i < len(t.voterAccounts); i += pcount {
 		end := i + pcount
-		if end > len(voterAccounts) {
-			end = len(voterAccounts)
+		if end > len(t.voterAccounts) {
+			end = len(t.voterAccounts)
 		}
 		wg.Add(1)
-		go voteAccounts(voterAccounts[i:end], &wg)
+		go voteAccounts(t.voterAccounts[i:end], &wg)
 	}
 
 	wg.Wait()
@@ -320,7 +123,7 @@ func (t *E2EPlaintextElection) Run() error {
 	// Wait for all the votes to be verified
 	log.Infof("waiting for all the votes to be registered...")
 	for {
-		count, err := api.ElectionVoteCount(electionID)
+		count, err := api.ElectionVoteCount(t.election.ElectionID)
 		if err != nil {
 			log.Warn(err)
 		}
@@ -344,36 +147,36 @@ func (t *E2EPlaintextElection) Run() error {
 
 	// End the election by setting the status to ENDED
 	log.Infof("ending election...")
-	hash, err := api.SetElectionStatus(electionID, "ENDED")
+	hash, err := api.SetElectionStatus(t.election.ElectionID, "ENDED")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Check the election status is actually ENDED
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*40)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 	defer cancel()
 	if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
 		log.Fatalf("gave up waiting for tx %s to be mined: %s", hash, err)
 	}
 
-	election, err = api.Election(electionID)
+	t.election, err = api.Election(t.election.ElectionID)
 	if err != nil {
 		log.Fatal(err)
 	}
-	if election.Status != "ENDED" {
+	if t.election.Status != "ENDED" {
 		log.Fatal("election status is not ENDED")
 	}
-	log.Infof("election %s status is ENDED", electionID.String())
+	log.Infof("election %s status is ENDED", t.election.ElectionID.String())
 
 	// Wait for the election to be in RESULTS state
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second*300)
 	defer cancel()
-	election, err = api.WaitUntilElectionStatus(ctx, electionID, "RESULTS")
+	t.election, err = api.WaitUntilElectionStatus(ctx, t.election.ElectionID, "RESULTS")
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("election %s status is RESULTS", electionID.String())
-	log.Infof("election results: %v", election.Results)
+	log.Infof("election %s status is RESULTS", t.election.ElectionID.String())
+	log.Infof("election results: %v", t.election.Results)
 
 	return nil
 }

--- a/cmd/end2endtest/zkweighted.go
+++ b/cmd/end2endtest/zkweighted.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 	"os"
 	"strings"
@@ -12,11 +12,7 @@ import (
 	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/zk"
 	"go.vocdoni.io/dvote/log"
-	"go.vocdoni.io/dvote/types"
-	"go.vocdoni.io/dvote/util"
-	"go.vocdoni.io/proto/build/go/models"
 )
 
 func init() {
@@ -30,13 +26,26 @@ func init() {
 var _ VochainTest = (*E2EAnonElection)(nil)
 
 type E2EAnonElection struct {
-	api    *apiclient.HTTPclient
-	config *config
+	e2eElection
 }
 
-func (t *E2EAnonElection) Setup(api *apiclient.HTTPclient, config *config) error {
+func (t *E2EAnonElection) Setup(api *apiclient.HTTPclient, c *config) error {
 	t.api = api
-	t.config = config
+	t.config = c
+
+	ed := newTestElectionDescription()
+	ed.ElectionType = vapi.ElectionType{
+		Autostart:     true,
+		Interruptible: true,
+		Anonymous:     true,
+	}
+	ed.VoteType = vapi.VoteType{MaxVoteOverwrites: 1}
+	ed.Census = vapi.CensusTypeDescription{Type: vapi.CensusTypeZKWeighted}
+
+	if err := t.setupElection(ed); err != nil {
+		return err
+	}
+	log.Debugf("election details: %+v", *t.election)
 	return nil
 }
 
@@ -49,269 +58,82 @@ func (t *E2EAnonElection) Run() error {
 	c := t.config
 	api := t.api
 
-	// Set the account in the API client, so we can sign transactions
-	if err := api.SetAccount(c.accountPrivKeys[0]); err != nil {
-		log.Fatal(err)
-	}
-
-	// If the account does not exist, create a new one
-	// TODO: check if the account balance is low and use the faucet
-	acc, err := api.Account("")
-	if err != nil {
-		var faucetPkg *models.FaucetPackage
-		if c.faucet != "" {
-			// Get the faucet package of bootstrap tokens
-			log.Infof("getting faucet package")
-			if c.faucet == "dev" {
-				faucetPkg, err = apiclient.GetFaucetPackageFromDevService(api.MyAddress().Hex())
-			} else {
-				faucetPkg, err = apiclient.GetFaucetPackageFromRemoteService(c.faucet+api.MyAddress().Hex(), c.faucetAuthToken)
-			}
-
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
-		// Create the organization account and bootstraping with the faucet package
-		log.Infof("creating Vocdoni account %s", api.MyAddress().Hex())
-		log.Debugf("faucetPackage is %x", faucetPkg)
-		hash, err := api.AccountBootstrap(faucetPkg, &vapi.AccountMetadata{
-			Name:        map[string]string{"default": "test account " + api.MyAddress().Hex()},
-			Description: map[string]string{"default": "test description"},
-			Version:     "1.0",
-		})
-		if err != nil {
-			log.Fatal(err)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-		defer cancel()
-		if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
-			log.Fatalf("gave up waiting for tx %x to be mined: %s", hash, err)
-		}
-
-		acc, err = api.Account("")
-		if err != nil {
-			log.Fatal(err)
-		}
-		if c.faucet != "" && acc.Balance == 0 {
-			log.Fatal("account balance is 0")
-		}
-	}
-
-	log.Infof("account %s balance is %d", api.MyAddress().Hex(), acc.Balance)
-
-	// Create a new census
-	censusID, err := api.NewCensus(vapi.CensusTypeZKWeighted)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("new census created with id %s", censusID.String())
-
-	// Generate n participant accounts
-	voterAccounts := ethereum.NewSignKeysBatch(c.nvotes)
-
-	// Add the accounts to the census by batches
-	participants := &vapi.CensusParticipants{}
-	for i, voterAccount := range voterAccounts {
-		zkAddr, err := zk.AddressFromSignKeys(voterAccount)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		participants.Participants = append(participants.Participants,
-			vapi.CensusParticipant{
-				Key:    zkAddr.Bytes(),
-				Weight: (*types.BigInt)(new(big.Int).SetUint64(10)),
-			})
-		if i == len(voterAccounts)-1 || ((i+1)%vapi.MaxCensusAddBatchSize == 0) {
-			if err := api.CensusAddParticipants(censusID, participants); err != nil {
-				log.Fatal(err)
-			}
-			log.Infof("added %d participants to census %s",
-				len(participants.Participants), censusID.String())
-			participants = &vapi.CensusParticipants{}
-		}
-	}
-
-	// Check census size
-	size, err := api.CensusSize(censusID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if size != uint64(c.nvotes) {
-		log.Fatalf("census size is %d, expected %d", size, c.nvotes)
-	}
-	log.Infof("census %s size is %d", censusID.String(), size)
-
-	// Publish the census
-	root, censusURI, err := api.CensusPublish(censusID)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("census published with root %s", root.String())
-
-	// Check census size (of the published census)
-	size, err = api.CensusSize(root)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if size != uint64(c.nvotes) {
-		log.Fatalf("published census size is %d, expected %d", size, c.nvotes)
-	}
-
-	// Create a new Election
-	electionID, err := api.NewElection(&vapi.ElectionDescription{
-		Title:       map[string]string{"default": fmt.Sprintf("Test election %s", util.RandomHex(8))},
-		Description: map[string]string{"default": "Test election description"},
-		EndDate:     time.Now().Add(time.Minute * 20),
-
-		VoteType: vapi.VoteType{
-			UniqueChoices:     false,
-			MaxVoteOverwrites: 1,
-		},
-
-		ElectionType: vapi.ElectionType{
-			Autostart:         true,
-			Interruptible:     true,
-			Anonymous:         true,
-			SecretUntilTheEnd: false,
-			DynamicCensus:     false,
-		},
-
-		Census: vapi.CensusTypeDescription{
-			RootHash: root,
-			URL:      censusURI,
-			Type:     vapi.CensusTypeZKWeighted,
-			Size:     size,
-		},
-
-		Questions: []vapi.Question{
-			{
-				Title:       map[string]string{"default": "Test question 1"},
-				Description: map[string]string{"default": "Test question 1 description"},
-				Choices: []vapi.ChoiceMetadata{
-					{
-						Title: map[string]string{"default": "Yes"},
-						Value: 0,
-					},
-					{
-						Title: map[string]string{"default": "No"},
-						Value: 1,
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Wait for the election creation
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-	defer cancel()
-	election, err := api.WaitUntilElectionCreated(ctx, electionID)
-	if err != nil {
-		log.Errorw(err, "error creating the election")
-		return
-	}
-	log.Debugf("election details: %+v", *election)
-	log.Infof("created new election with id %s - now wait until it starts", electionID.String())
-
-	// Wait for the election to start
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*40)
-	defer cancel()
-	election, err = api.WaitUntilElectionStarts(ctx, electionID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Debugf("election details: %+v", *election)
-
+	// Send the votes (parallelized)
 	startTime := time.Now()
-	successProofs, successVotes := 0, 0
-	proofCh, voteCh, stopCh := make(chan bool), make(chan bool), make(chan bool)
-	go func() {
-		for {
-			select {
-			case <-proofCh:
-				successProofs++
-			case <-voteCh:
-				successVotes++
-			case <-stopCh:
-				return
-			}
-		}
-	}()
 
+	wg := sync.WaitGroup{}
 	apiClientMtx := &sync.Mutex{}
-	addNaccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
+	voteAccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
 		defer wg.Done()
-		log.Infof("generating %d voting proofs", len(accounts))
+		log.Infof("sending %d votes", len(accounts))
+		// We use maps instead of slices to have the capacity of resending votes
+		// without repeating them.
+		accountsMap := make(map[int]*ethereum.SignKeys, len(accounts))
 		for i, acc := range accounts {
-			apiClientMtx.Lock()
-
-			privKey := acc.PrivateKey()
-			if err = api.SetAccount(privKey.String()); err != nil {
-				apiClientMtx.Unlock()
-				log.Fatal(err)
-				return
-			}
-
-			pr, err := api.CensusGenProof(root, api.MyZkAddress().Bytes())
-			if err != nil {
-				apiClientMtx.Unlock()
-				log.Warnw(err.Error(),
-					"current", i,
-					"total", c.nvotes)
-				continue
-			}
-
-			log.Debugw("census proof generated",
-				"current", i,
-				"total", len(accounts))
-			proofCh <- true
-
-			_, err = api.Vote(&apiclient.VoteData{
-				ElectionID:   electionID,
-				ProofMkTree:  pr,
-				Choices:      []int{i % 2},
-				VotingWeight: new(big.Int).SetUint64(8),
-			})
-			apiClientMtx.Unlock()
-			if err != nil && !strings.Contains(err.Error(), "already exists") {
-				// if the error is not "vote already exists", we need to print it
-				log.Warn(err.Error())
-				continue
-			}
-			log.Debugw("vote sent",
-				"current", i,
-				"total", len(accounts))
-			voteCh <- true
-			pr = nil
+			accountsMap[i] = acc
 		}
+		// Send the votes
+		votesSent := 0
+		for {
+			contextDeadlines := 0
+			for i, voterAccount := range accountsMap {
+				apiClientMtx.Lock()
+				privKey := voterAccount.PrivateKey()
+				if err := api.SetAccount(privKey.String()); err != nil {
+					apiClientMtx.Unlock()
+					log.Fatal(err)
+					return
+				}
+
+				_, err := api.Vote(&apiclient.VoteData{
+					ElectionID:   t.election.ElectionID,
+					ProofMkTree:  t.proofs[voterAccount.Address().Hex()],
+					Choices:      []int{i % 2},
+					VotingWeight: new(big.Int).SetUint64(8),
+				})
+				apiClientMtx.Unlock()
+				// if the context deadline is reached, we don't need to print it (let's jus retry)
+				if err != nil && errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+					contextDeadlines++
+					continue
+				} else if err != nil && !strings.Contains(err.Error(), "already exists") {
+					// if the error is not "vote already exists", we need to print it
+					log.Warn(err)
+					continue
+				}
+				// if the vote was sent successfully or already exists, we remove it from the accounts map
+				votesSent++
+				delete(accountsMap, i)
+
+			}
+			if len(accountsMap) == 0 {
+				break
+			}
+			log.Infof("sent %d/%d votes... got %d HTTP errors", votesSent, len(accounts), contextDeadlines)
+			time.Sleep(time.Second * 5)
+		}
+		log.Infof("successfully sent %d votes", votesSent)
+		time.Sleep(time.Second * 2)
 	}
 
 	pcount := c.nvotes / c.parallelCount
-	var wg sync.WaitGroup
-	for i := 0; i < len(voterAccounts); i += pcount {
+	for i := 0; i < len(t.voterAccounts); i += pcount {
 		end := i + pcount
-		if end > len(voterAccounts) {
-			end = len(voterAccounts)
+		if end > len(t.voterAccounts) {
+			end = len(t.voterAccounts)
 		}
 		wg.Add(1)
-		go addNaccounts(voterAccounts[i:end], &wg)
+		go voteAccounts(t.voterAccounts[i:end], &wg)
 	}
 
 	wg.Wait()
-	time.Sleep(time.Second) // wait a grace time for the last proof to be added
-	log.Debugf("%d/%d voting proofs generated successfully", successProofs, len(voterAccounts))
-	log.Debugf("%d/%d votes sent successfully", successVotes, len(voterAccounts))
-	stopCh <- true
+	log.Infof("%d votes submitted successfully, took %s (%d votes/second)",
+		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
 
 	// Wait for all the votes to be verified
 	log.Infof("waiting for all the votes to be registered...")
 	for {
-		count, err := api.ElectionVoteCount(electionID)
+		count, err := api.ElectionVoteCount(t.election.ElectionID)
 		if err != nil {
 			log.Warn(err)
 		}
@@ -335,36 +157,36 @@ func (t *E2EAnonElection) Run() error {
 
 	// End the election by setting the status to ENDED
 	log.Infof("ending election...")
-	hash, err := api.SetElectionStatus(electionID, "ENDED")
+	hash, err := api.SetElectionStatus(t.election.ElectionID, "ENDED")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Check the election status is actually ENDED
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*40)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 	defer cancel()
 	if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
 		log.Fatalf("gave up waiting for tx %s to be mined: %s", hash, err)
 	}
 
-	election, err = api.Election(electionID)
+	t.election, err = api.Election(t.election.ElectionID)
 	if err != nil {
 		log.Fatal(err)
 	}
-	if election.Status != "ENDED" {
+	if t.election.Status != "ENDED" {
 		log.Fatal("election status is not ENDED")
 	}
-	log.Infof("election %s status is ENDED", electionID.String())
+	log.Infof("election %s status is ENDED", t.election.ElectionID.String())
 
 	// Wait for the election to be in RESULTS state
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second*300)
 	defer cancel()
-	election, err = api.WaitUntilElectionStatus(ctx, electionID, "RESULTS")
+	t.election, err = api.WaitUntilElectionStatus(ctx, t.election.ElectionID, "RESULTS")
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Infof("election %s status is RESULTS", electionID.String())
-	log.Infof("election results: %v", election.Results)
+	log.Infof("election %s status is RESULTS", t.election.ElectionID.String())
+	log.Infof("election results: %v", t.election.Results)
 
 	return nil
 }

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # bash start_test.sh [testname] [testname] [...]
 #  (if no argument is passed, run all tests)
-#  merkle_vote_plaintext: run poll vote test
-#  merkle_vote_encrypted: run encrypted vote test
-#  e2etest_anonvoting: run anonymous vote test
-#  cspvoting: run csp vote test
-#  e2etest_tokentxs: run token transactions test (end-user voting is not included)
+#  legacy_cspvoting: run (rpc_client) csp vote test
+#  e2etest_plaintextelection: run poll vote test
+#  e2etest_encryptedelection: run encrypted vote test
+#  e2etest_anonelection: run anonymous vote test
+#  e2etest_tokentxs: run token transactions test (no end-user voting at all)
 
 export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 COMPOSE_INTERACTIVE_NO_CLI=1
 [ -n "$GOCOVERDIR" ] && export BUILDARGS="-cover" # docker-compose build passes this to go 1.20 so that binaries collect code coverage
@@ -44,10 +44,10 @@ log() { echo $(date --rfc-3339=s) "$@" ; }
 ### newtest() { whatever ; }
 
 tests_to_run=(
-	"tokentransactions"
-	"merkle_vote_encrypted"
-	"cspvoting"
-	"e2etest_anonvoting"
+	"legacy_cspvoting"
+	"e2etest_plaintextelection"
+	"e2etest_encryptedelection"
+	"e2etest_anonelection"
 	"e2etest_tokentxs"
 )
 
@@ -68,38 +68,7 @@ tests_to_run=(
 # if any arg is passed, treat them as the tests to run, overriding the default list
 [ $# != 0 ] && tests_to_run=($@)
 
-initaccounts() {
-	$COMPOSE_CMD_RUN --name ${TEST_PREFIX}_${FUNCNAME[0]}_${RANDOMID} test timeout 300 \
-		./vochaintest --gwHost $GWHOST \
-		  --logLevel=$LOGLEVEL \
-		  --operation=initaccounts \
-		  --oracleKey=$ORACLE_KEY \
-		  --treasurerKey=$TREASURER_KEY \
-		  --accountKeys=$(echo -n "$ACCOUNT_KEYS" | tr -d ' ','\t' | tr '\n' ',')
-}
-
-merkle_vote() {
-	$COMPOSE_CMD_RUN --name ${TEST_PREFIX}_${FUNCNAME[0]}-${1}_${RANDOMID} test timeout 300 \
-		./vochaintest --gwHost $GWHOST \
-		  --logLevel=$LOGLEVEL \
-		  --operation=vtest \
-		  --oracleKey=$ORACLE_KEY \
-		  --treasurerKey=$TREASURER_KEY \
-		  --electionSize=$ELECTION_SIZE \
-		  --electionType=$1 \
-		  --withWeight=2 \
-		  --accountKeys=$(echo $ACCOUNT_KEYS | awk '{print $1}')
-}
-
-merkle_vote_plaintext() {
-	merkle_vote poll-vote
-}
-
-merkle_vote_encrypted() {
-	merkle_vote encrypted-poll
-}
-
-cspvoting() {
+legacy_cspvoting() {
 	$COMPOSE_CMD_RUN --name ${TEST_PREFIX}_${FUNCNAME[0]}_${RANDOMID} test timeout 300 \
 		./vochaintest --gwHost $GWHOST \
 		  --logLevel=$LOGLEVEL \
@@ -110,31 +79,29 @@ cspvoting() {
 		  --accountKeys=$(echo $ACCOUNT_KEYS | awk '{print $3}')
 }
 
-tokentransactions() {
-	$COMPOSE_CMD_RUN --name ${TEST_PREFIX}_${FUNCNAME[0]}_${RANDOMID} test timeout 300 \
-		./vochaintest --gwHost $GWHOST \
+e2etest() {
+	$COMPOSE_CMD_RUN --name ${TEST_PREFIX}_${FUNCNAME[0]}-${1}_${RANDOMID} test timeout 300 \
+		./end2endtest --host $APIHOST --faucet=$FAUCET \
 		  --logLevel=$LOGLEVEL \
-		  --operation=tokentransactions \
-		  --oracleKey=$ORACLE_KEY \
-		  --treasurerKey=$TREASURER_KEY \
-		  --accountKeys=$(echo $ACCOUNT_KEYS | awk '{print $1}')
+		  --operation=$1
 }
 
-e2etest_anonvoting() {
-	$COMPOSE_CMD_RUN --name ${TEST_PREFIX}_${FUNCNAME[0]}_${RANDOMID} test timeout 300 \
-		./end2endtest --host $APIHOST \
-		  --logLevel=$LOGLEVEL \
-		  --operation=anonvoting \
-		  --faucet=$FAUCET
+e2etest_plaintextelection() {
+	e2etest plaintextelection
+}
+
+e2etest_encryptedelection() {
+	e2etest encryptedelection
+}
+
+e2etest_anonelection() {
+	e2etest anonelection
 }
 
 e2etest_tokentxs() {
-	$COMPOSE_CMD_RUN --name ${TEST_PREFIX}_${FUNCNAME[0]}_${RANDOMID} test timeout 300 \
-		./end2endtest --host $APIHOST \
-		  --logLevel=$LOGLEVEL \
-		  --operation=tokentransactions \
-		  --faucet=$FAUCET
+	e2etest tokentxs
 }
+
 ### end tests definition
 
 # useful for debugging bash flow


### PR DESCRIPTION
* move mkTreeVoteTest out of main.go into its own file, rename to something less cryptic (plaintextElectionTest), operation `plaintextelection` instead of `vtest`