### PR TITLE
Bug/pubkey support legacy code

### DIFF
--- a/api/census_test.go
+++ b/api/census_test.go
@@ -234,7 +234,7 @@ func TestCensusProof(t *testing.T) {
 		models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED,
 		censusData.CensusID,
 		electionID,
-		state.NewVoterID(state.VoterIDTypeAddress, key.Address().Bytes()),
+		state.NewVoterID(state.VoterIDTypeECDSA, key.PublicKey()),
 	)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, valid, qt.IsTrue)

--- a/api/census_test.go
+++ b/api/census_test.go
@@ -234,7 +234,7 @@ func TestCensusProof(t *testing.T) {
 		models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED,
 		censusData.CensusID,
 		electionID,
-		state.NewVoterID(state.VoterIDTypeECDSA, key.PublicKey()),
+		state.NewVoterID(state.VoterIDTypeAddress, key.Address().Bytes()),
 	)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, valid, qt.IsTrue)

--- a/api/census_test.go
+++ b/api/census_test.go
@@ -72,7 +72,7 @@ func TestCensus(t *testing.T) {
 	cparts := CensusParticipants{}
 	for i := 1; i < 11; i++ {
 		cparts.Participants = append(cparts.Participants, CensusParticipant{
-			Key:    rnd.RandomBytes(32),
+			Key:    rnd.RandomBytes(20),
 			Weight: (*types.BigInt)(big.NewInt(int64(i))),
 		})
 		weight += i
@@ -93,7 +93,7 @@ func TestCensus(t *testing.T) {
 	qt.Assert(t, censusData.Size, qt.Equals, index)
 
 	// add one more key and check proof
-	key := rnd.RandomBytes(32)
+	key := rnd.RandomBytes(20)
 	keyWeight := (*types.BigInt)(big.NewInt(100))
 	_, code = c.Request("POST", &CensusParticipants{
 		Participants: []CensusParticipant{{Key: key, Weight: keyWeight}},
@@ -122,7 +122,7 @@ func TestCensus(t *testing.T) {
 	qt.Assert(t, censusData.Valid, qt.IsTrue)
 
 	// try an invalid proof
-	proof.Key = rnd.RandomBytes(32)
+	proof.Key = rnd.RandomBytes(20)
 	qt.Assert(t, err, qt.IsNil)
 	_, code = c.Request("POST", proof, id2, "verify")
 	qt.Assert(t, code, qt.Equals, 400)

--- a/api/census_test.go
+++ b/api/census_test.go
@@ -185,9 +185,9 @@ func TestCensusProof(t *testing.T) {
 	// add a bunch of keys and values (weights)
 	rnd := testutil.NewRandom(1)
 	cparts := CensusParticipants{}
-	for i := 1; i < 11; i++ {
+	for i, acc := range ethereum.NewSignKeysBatch(11) {
 		cparts.Participants = append(cparts.Participants, CensusParticipant{
-			Key:    rnd.RandomBytes(32),
+			Key:    acc.Address().Bytes(),
 			Weight: (*types.BigInt)(big.NewInt(int64(i))),
 		})
 	}
@@ -195,7 +195,6 @@ func TestCensusProof(t *testing.T) {
 	qt.Assert(t, code, qt.Equals, 200)
 
 	// add the last participant and keep the key for verifying the proof
-	// key := rnd.RandomBytes(32)
 	key := ethereum.NewSignKeys()
 	qt.Assert(t, key.Generate(), qt.IsNil)
 	_, code = c.Request("POST", &CensusParticipants{Participants: []CensusParticipant{{

--- a/api/censuses.go
+++ b/api/censuses.go
@@ -228,7 +228,7 @@ func (a *API) censusAddHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext
 
 		leafKey := p.Key
 		if len(leafKey) > censustree.DefaultMaxKeyLen {
-			return ErrParticipanKeyLengthInvalid.Withf("can not be longer than %d bytes", censustree.DefaultMaxKeyLen)
+			return ErrInvalidCensusKeyLength.Withf("the census key cannot be longer than %d bytes", censustree.DefaultMaxKeyLen)
 		}
 
 		if ref.CensusType != int32(models.Census_ARBO_POSEIDON) {

--- a/api/censuses.go
+++ b/api/censuses.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -229,9 +228,7 @@ func (a *API) censusAddHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext
 
 		leafKey := p.Key
 		if len(leafKey) > censustree.DefaultMaxKeyLen {
-			deprecationMsg = []byte(fmt.Sprintf("census keys must not be longer "+
-				"than %d, the key provided has been truncated to this length",
-				censustree.DefaultMaxKeyLen))
+			return ErrParticipanKeyLengthInvalid.Withf("can not be longer than %d bytes", censustree.DefaultMaxKeyLen)
 		}
 
 		if ref.CensusType != int32(models.Census_ARBO_POSEIDON) {
@@ -240,12 +237,7 @@ func (a *API) censusAddHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext
 			if err != nil {
 				return ErrCantComputeKeyHash.WithErr(err)
 			}
-			// If the provided key is longer than the defined maximum length
-			// truncate it.
-			// TODO: return an error if the other key lengths are deprecated
-			if len(leafKey) > censustree.DefaultMaxKeyLen {
-				leafKey = leafKey[:censustree.DefaultMaxKeyLen]
-			}
+			leafKey = leafKey[:censustree.DefaultMaxKeyLen]
 		}
 
 		keys = append(keys, leafKey)

--- a/api/errors.go
+++ b/api/errors.go
@@ -67,6 +67,7 @@ var (
 	ErrNoElectionKeys                   = apirest.APIerror{Code: 4048, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("no election keys available")}
 	ErrKeyNotFoundInCensus              = apirest.APIerror{Code: 4049, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("key not found in census")}
 	ErrInvalidStatus                    = apirest.APIerror{Code: 4050, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("invalid status")}
+	ErrParticipanKeyLengthInvalid       = apirest.APIerror{Code: 4051, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("participant census key length is wrong")}
 	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
 	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
 	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}

--- a/api/errors.go
+++ b/api/errors.go
@@ -67,7 +67,7 @@ var (
 	ErrNoElectionKeys                   = apirest.APIerror{Code: 4048, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("no election keys available")}
 	ErrKeyNotFoundInCensus              = apirest.APIerror{Code: 4049, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("key not found in census")}
 	ErrInvalidStatus                    = apirest.APIerror{Code: 4050, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("invalid status")}
-	ErrParticipanKeyLengthInvalid       = apirest.APIerror{Code: 4051, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("participant census key length is wrong")}
+	ErrInvalidCensusKeyLength           = apirest.APIerror{Code: 4051, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("invalid census key length")}
 	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
 	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
 	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}

--- a/apiclient/vote.go
+++ b/apiclient/vote.go
@@ -30,7 +30,8 @@ import (
 // ProofCSP is the proof of the vote fore a CSP election.
 //
 // KeyType is the type of the key used when the census was created. It can be
-// either models.ProofArbo_ADDRESS or models.ProofArbo_PUBKEY (default).
+// either models.ProofArbo_ADDRESS (default) or models.ProofArbo_PUBKEY
+// (deprecated).
 type VoteData struct {
 	Choices      []int
 	ElectionID   types.HexBytes

--- a/rpcclient/api.go
+++ b/rpcclient/api.go
@@ -1254,14 +1254,16 @@ func (c *Client) CreateCensus(signer *ethereum.SignKeys, censusSigners []*ethere
 			if currentSize < 1 {
 				break
 			}
+			var pub []byte
 			if censusSigners != nil {
-				hexpub, _ = censusSigners[currentSize-1].HexString()
+				// hexpub, _ = censusSigners[currentSize-1].HexString()
+				pub = censusSigners[currentSize-1].Address().Bytes()
 			} else {
 				hexpub = censusPubKeys[currentSize-1]
-			}
-			pub, err := hex.DecodeString(hexpub)
-			if err != nil {
-				return nil, "", err
+				pub, err = hex.DecodeString(hexpub)
+				if err != nil {
+					return nil, "", err
+				}
 			}
 			claims = append(claims, pub)
 			if len(censusValues) > 0 {

--- a/rpcclient/api.go
+++ b/rpcclient/api.go
@@ -271,7 +271,7 @@ func (c *Client) GetMerkleProofBatch(signers []*ethereum.SignKeys,
 	// Generate merkle proofs
 	log.Infof("generating proofs...")
 	for i, s := range signers {
-		siblings, value, err := c.GetProof(s.PublicKey(), root, false)
+		siblings, value, err := c.GetProof(s.Address().Bytes(), root, false)
 		if err != nil {
 			if tolerateError {
 				continue

--- a/test/api_test.go
+++ b/test/api_test.go
@@ -49,7 +49,7 @@ func TestAPIcensusAndVote(t *testing.T) {
 	cparts := api.CensusParticipants{}
 	for i := 1; i < 10; i++ {
 		cparts.Participants = append(cparts.Participants, api.CensusParticipant{
-			Key:    rnd.RandomBytes(32),
+			Key:    rnd.RandomBytes(20),
 			Weight: (*types.BigInt)(big.NewInt(int64(1))),
 		})
 	}

--- a/test/api_test.go
+++ b/test/api_test.go
@@ -61,7 +61,7 @@ func TestAPIcensusAndVote(t *testing.T) {
 	qt.Assert(t, voterKey.Generate(), qt.IsNil)
 
 	_, code = c.Request("POST", &api.CensusParticipants{Participants: []api.CensusParticipant{{
-		Key:    voterKey.PublicKey(),
+		Key:    voterKey.Address().Bytes(),
 		Weight: (*types.BigInt)(big.NewInt(1)),
 	}}}, "censuses", id1, "participants")
 	qt.Assert(t, code, qt.Equals, 200)
@@ -72,7 +72,7 @@ func TestAPIcensusAndVote(t *testing.T) {
 	qt.Assert(t, censusData.CensusID, qt.IsNotNil)
 	root := censusData.CensusID
 
-	resp, code = c.Request("GET", nil, "censuses", root.String(), "proof", fmt.Sprintf("%x", voterKey.PublicKey()))
+	resp, code = c.Request("GET", nil, "censuses", root.String(), "proof", fmt.Sprintf("%x", voterKey.Address().Bytes()))
 	qt.Assert(t, code, qt.Equals, 200)
 	qt.Assert(t, json.Unmarshal(resp, censusData), qt.IsNil)
 	qt.Assert(t, censusData.Weight.String(), qt.Equals, "1")

--- a/test/testcommon/testvoteproof/voteproof.go
+++ b/test/testcommon/testvoteproof/voteproof.go
@@ -59,7 +59,7 @@ func CreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys, []b
 	keys := ethereum.NewSignKeysBatch(size)
 	hashedKeys := [][]byte{}
 	for _, k := range keys {
-		c, err := tr.Hash(k.PublicKey())
+		c, err := tr.Hash(k.Address().Bytes())
 		qt.Check(t, err, qt.IsNil)
 		c = c[:censustree.DefaultMaxKeyLen]
 		err = tr.Add(c, nil)
@@ -94,7 +94,7 @@ func BuildSignedVoteForOffChainTree(t *testing.T, electionID []byte, key *ethere
 				Arbo: &models.ProofArbo{
 					Type:     models.ProofArbo_BLAKE2B,
 					Siblings: proof,
-					KeyType:  models.ProofArbo_PUBKEY,
+					KeyType:  models.ProofArbo_ADDRESS,
 				},
 			},
 		},

--- a/vochain/app_benchmark_test.go
+++ b/vochain/app_benchmark_test.go
@@ -51,7 +51,7 @@ func prepareBenchCheckTx(b *testing.B, app *BaseApplication,
 	}
 	claims := []string{}
 	for _, k := range keys {
-		c := k.PublicKey()
+		c := k.Address().Bytes()
 		if err := tr.Add(c, nil); err != nil {
 			b.Error(err)
 		}

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -546,7 +546,7 @@ func TestResults(t *testing.T) {
 				Arbo: &models.ProofArbo{
 					Type:     models.ProofArbo_BLAKE2B,
 					Siblings: proofs[i],
-					KeyType:  models.ProofArbo_PUBKEY,
+					KeyType:  models.ProofArbo_ADDRESS,
 				}}},
 			ProcessId:            pid,
 			VotePackage:          vp,
@@ -1125,7 +1125,7 @@ func TestOverwriteVotes(t *testing.T) {
 			Arbo: &models.ProofArbo{
 				Type:     models.ProofArbo_BLAKE2B,
 				Siblings: proofs[0],
-				KeyType:  models.ProofArbo_PUBKEY,
+				KeyType:  models.ProofArbo_ADDRESS,
 			}}},
 		ProcessId:   pid,
 		VotePackage: vp,
@@ -1220,7 +1220,7 @@ func TestOverwriteVotes(t *testing.T) {
 			Arbo: &models.ProofArbo{
 				Type:     models.ProofArbo_BLAKE2B,
 				Siblings: proofs[1],
-				KeyType:  models.ProofArbo_PUBKEY,
+				KeyType:  models.ProofArbo_ADDRESS,
 			}}},
 		ProcessId:   pid,
 		VotePackage: vp,

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -83,7 +83,7 @@ func TestMerkleTreeProof(t *testing.T) {
 				},
 			},
 		},
-		VotePackage: []byte("[1, 2, 3, 4}]"),
+		VotePackage: []byte("[1, 2, 3, 4]"),
 	}
 
 	for i := 0; i < 10; i++ {

--- a/vochain/state/voterid.go
+++ b/vochain/state/voterid.go
@@ -17,6 +17,7 @@ const (
 	VoterIDTypeUndefined VoterIDType = 0
 	VoterIDTypeECDSA     VoterIDType = 1
 	VoterIDTypeZkSnark   VoterIDType = 2
+	VoterIDTypeAddress   VoterIDType = 3
 )
 
 // Enum value map for VoterIDType.
@@ -24,6 +25,7 @@ var voterIDTypeName = map[VoterIDType]string{
 	VoterIDTypeUndefined: "UNDEFINED",
 	VoterIDTypeECDSA:     "ECDSA",
 	VoterIDTypeZkSnark:   "ZKSNARK",
+	VoterIDTypeAddress:   "Address",
 }
 
 // NewVoterID creates a new VoterID from a VoterIDType and a key.
@@ -72,7 +74,7 @@ func (v VoterID) Address() []byte {
 			return nil
 		}
 		return ethAddr.Bytes()
-	case VoterIDTypeZkSnark:
+	case VoterIDTypeZkSnark, VoterIDTypeAddress:
 		return v[1:]
 	default:
 		return nil

--- a/vochain/state/voterid.go
+++ b/vochain/state/voterid.go
@@ -17,7 +17,6 @@ const (
 	VoterIDTypeUndefined VoterIDType = 0
 	VoterIDTypeECDSA     VoterIDType = 1
 	VoterIDTypeZkSnark   VoterIDType = 2
-	VoterIDTypeAddress   VoterIDType = 3
 )
 
 // Enum value map for VoterIDType.
@@ -25,7 +24,6 @@ var voterIDTypeName = map[VoterIDType]string{
 	VoterIDTypeUndefined: "UNDEFINED",
 	VoterIDTypeECDSA:     "ECDSA",
 	VoterIDTypeZkSnark:   "ZKSNARK",
-	VoterIDTypeAddress:   "Address",
 }
 
 // NewVoterID creates a new VoterID from a VoterIDType and a key.
@@ -74,7 +72,7 @@ func (v VoterID) Address() []byte {
 			return nil
 		}
 		return ethAddr.Bytes()
-	case VoterIDTypeZkSnark, VoterIDTypeAddress:
+	case VoterIDTypeZkSnark:
 		return v[1:]
 	default:
 		return nil

--- a/vochain/transaction/proof.go
+++ b/vochain/transaction/proof.go
@@ -99,9 +99,7 @@ func VerifyProofOffChainTree(process *models.Process, proof *models.Proof,
 		}
 		// check if the proof key is for an address (default) or a pubKey
 		key := vID.Address()
-		if p.GetKeyType().String() == "PUBKEY" {
-			key = vID.Bytes()
-		}
+
 		hashedKey, err := hashFunc.Hash(key)
 		if err != nil {
 			return false, nil, fmt.Errorf("cannot hash proof key: %w", err)

--- a/vochain/vote_test.go
+++ b/vochain/vote_test.go
@@ -28,7 +28,7 @@ func testCreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys,
 	keys := ethereum.NewSignKeysBatch(size)
 	hashedKeys := [][]byte{}
 	for _, k := range keys {
-		c, err := tr.Hash(k.PublicKey())
+		c, err := tr.Hash(k.Address().Bytes())
 		qt.Check(t, err, qt.IsNil)
 		c = c[:censustree.DefaultMaxKeyLen]
 		err = tr.Add(c, nil)
@@ -62,7 +62,7 @@ func testBuildSignedVote(t *testing.T, electionID []byte, key *ethereum.SignKeys
 				Arbo: &models.ProofArbo{
 					Type:     models.ProofArbo_BLAKE2B,
 					Siblings: proof,
-					KeyType:  models.ProofArbo_PUBKEY,
+					KeyType:  models.ProofArbo_ADDRESS,
 				},
 			},
 		},


### PR DESCRIPTION
We found some parts of the vochain that contains legacy code regarding the support to PublicKey as census key. This feature is deprecated and this code needs to be removed or upgraded. Read more here: #875.

Changes made and related commits:
 - The references to old census key type (`models.ProofArbo_PUBKEY`) was removed and replaced to the new default type (`models.ProofArbo_ADDRESS`): 449d701475287c1ce9af84d8899cb2043e8242d7
 - The tests that implements public key as census type was replaced to use the voter address instead: 9b91fde9edccc3b9af1d0d2bd7e6f2bab134231a 40c92a993ab7825a08b73d0ba8cb60744dc48ae0
 - A proposal to create the VoterID using the voter address. To achieve this, a new VoterID type was introduced (`VoterIDTypeAddress `). Check out an example here: 4d05be309e9fd40ea76e415274d33842bf9c81da