### PR TITLE
vochain/indexer: move transactions and token transfers to the sql blockTx

### DIFF
--- a/types/big.go
+++ b/types/big.go
@@ -16,7 +16,7 @@ func (i BigInt) MarshalText() ([]byte, error) {
 func (i *BigInt) UnmarshalText(data []byte) error {
 	i2, ok := new(big.Int).SetString(string(data), 0)
 	if !ok {
-		return fmt.Errorf("wrong format for bigInt")
+		return fmt.Errorf("wrong format for bigInt: %q", string(data))
 	}
 	*i = (BigInt)(*i2)
 	return nil

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -1290,7 +1290,6 @@ func TestTxIndexer(t *testing.T) {
 		}
 	}
 	qt.Assert(t, idx.Commit(0), qt.IsNil)
-	idx.WaitIdle()
 
 	count, err := idx.TransactionCount()
 	qt.Assert(t, err, qt.IsNil)


### PR DESCRIPTION
(see commit messages - please do not squash)

As a plus, the concept of "live goroutines" and waiting for them is now gone, because we now commit `blockTx` as part of `Indexer.Commit`, and that is synchronous.