### PR TITLE
log: add proper tests, add benchmark, small speed-up

### DIFF
--- a/benchmark/vochain_benchmark_csp_test.go
+++ b/benchmark/vochain_benchmark_csp_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func BenchmarkVochainCSP(b *testing.B) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	b.ReportAllocs()
 	var dvoteServer testcommon.DvoteAPIServer
 	host := *hostFlag

--- a/benchmark/vochain_benchmark_test.go
+++ b/benchmark/vochain_benchmark_test.go
@@ -26,7 +26,7 @@ const (
 )
 
 func BenchmarkVochainBatchProof(b *testing.B) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	b.ReportAllocs()
 	var dvoteServer testcommon.DvoteAPIServer
 	host := *hostFlag
@@ -81,7 +81,7 @@ func BenchmarkVochainBatchProof(b *testing.B) {
 }
 
 func BenchmarkVochainSingleProof(b *testing.B) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	b.ReportAllocs()
 	var dvoteServer testcommon.DvoteAPIServer
 	host := *hostFlag

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -44,7 +44,7 @@ func main() {
 	logLevel := flag.String("logLevel", "error", "log level")
 	cfgFile := flag.String("config", filepath.Join(home, ".vocdoni-cli.json"), "config file")
 	flag.Parse()
-	log.Init(*logLevel, "stdout")
+	log.Init(*logLevel, "stdout", nil)
 	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
 
 	cli, err := NewVocdoniCLI(*cfgFile, *host)

--- a/cmd/end2endtest/main.go
+++ b/cmd/end2endtest/main.go
@@ -110,7 +110,7 @@ func main() {
 	flag.CommandLine.SortFlags = false
 	flag.Parse()
 
-	log.Init(c.logLevel, "stdout")
+	log.Init(c.logLevel, "stdout", nil)
 	log.Infow("starting "+filepath.Base(os.Args[0]),
 		"version", internal.Version,
 		"operation", c.operation,

--- a/cmd/vochaininspector/inspector.go
+++ b/cmd/vochaininspector/inspector.go
@@ -55,7 +55,7 @@ func main() {
 	flag.StringVar(&pid, "processId", "", "processId as hexadecimal string")
 
 	flag.Parse()
-	log.Init(logLevel, "stdout")
+	log.Init(logLevel, "stdout", nil)
 	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
 
 	switch action {

--- a/cmd/vochaintest/vochaintest.go
+++ b/cmd/vochaintest/vochaintest.go
@@ -108,7 +108,7 @@ func main() {
 				"wss://gw1test.vocdoni.net/dvote\n")
 	}
 	flag.Parse()
-	log.Init(*loglevel, "stdout")
+	log.Init(*loglevel, "stdout", nil)
 	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
 
 	accountKeys := make([]*ethereum.SignKeys, len(*accountPrivKeys))

--- a/cmd/voconed/voconed.go
+++ b/cmd/voconed/voconed.go
@@ -158,7 +158,7 @@ func main() {
 	}
 
 	// start the program
-	log.Init(config.logLevel, "stdout")
+	log.Init(config.logLevel, "stdout", nil)
 	log.Infow("starting "+filepath.Base(os.Args[0]), "version", internal.Version)
 
 	log.Infof("using data directory at %s", config.dir)

--- a/ipfsconnect/subpub/example_test.go
+++ b/ipfsconnect/subpub/example_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Example() {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 
 	messages := make(chan *subpub.Message)
 	groupKey := []byte("test")

--- a/log/log.go
+++ b/log/log.go
@@ -91,7 +91,7 @@ func (*invalidCharChecker) Write(p []byte) (int, error) {
 // Init initializes the logger. Output can be either "stdout/stderr/<filePath>".
 // Log level can be "debug/info/warn/error".
 // errorOutput is an optional filename which only receives Warning and Error messages.
-func Init(logLevel, output string, errorOutput io.Writer) {
+func Init(level, output string, errorOutput io.Writer) {
 	var out io.Writer
 	switch output {
 	case "stdout":
@@ -141,25 +141,25 @@ func Init(logLevel, output string, errorOutput io.Writer) {
 		return fmt.Sprintf("%s/%s:%d", path.Base(path.Dir(file)), path.Base(file), line)
 	}
 
-	switch logLevel {
+	switch level {
 	case LogLevelDebug:
-		log.Level(zerolog.DebugLevel)
+		log = log.Level(zerolog.DebugLevel)
 	case LogLevelInfo:
-		log.Level(zerolog.InfoLevel)
+		log = log.Level(zerolog.InfoLevel)
 	case LogLevelWarn:
-		log.Level(zerolog.WarnLevel)
+		log = log.Level(zerolog.WarnLevel)
 	case LogLevelError:
-		log.Level(zerolog.ErrorLevel)
+		log = log.Level(zerolog.ErrorLevel)
 	default:
-		panic("invalid log level")
+		panic(fmt.Sprintf("invalid log level: %q", level))
 	}
 
-	log.Info().Msgf("logger construction succeeded at level %s with output %s", logLevel, output)
+	log.Info().Msgf("logger construction succeeded at level %s with output %s", level, output)
 }
 
 // Level returns the current log level
 func Level() string {
-	switch log.GetLevel() {
+	switch level := log.GetLevel(); level {
 	case zerolog.DebugLevel:
 		return LogLevelDebug
 	case zerolog.InfoLevel:
@@ -169,7 +169,7 @@ func Level() string {
 	case zerolog.ErrorLevel:
 		return LogLevelError
 	default:
-		panic("invalid log level")
+		panic(fmt.Sprintf("invalid log level: %q", level))
 	}
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -25,7 +24,7 @@ var (
 	log      zerolog.Logger
 	errorLog *os.File
 	// panicOnInvalidChars is set based on env LOG_PANIC_ON_INVALIDCHARS (parsed as bool)
-	panicOnInvalidChars bool
+	panicOnInvalidChars = os.Getenv("LOG_PANIC_ON_INVALIDCHARS") == "true"
 )
 
 func init() {
@@ -107,12 +106,6 @@ func Init(logLevel string, output string) {
 	}
 
 	log.Info().Msgf("logger construction succeeded at level %s with output %s", logLevel, output)
-
-	if s := os.Getenv("LOG_PANIC_ON_INVALIDCHARS"); s != "" {
-		// ignore ParseBool errors, if anything fails panicOnInvalidChars will stay false which is good
-		b, _ := strconv.ParseBool(s)
-		panicOnInvalidChars = b
-	}
 }
 
 // SetFileErrorLog if set writes the Warning and Error messages to a file.

--- a/log/log.go
+++ b/log/log.go
@@ -94,13 +94,13 @@ func Init(logLevel string, output string) {
 
 	switch logLevel {
 	case LogLevelDebug:
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		log.Level(zerolog.DebugLevel)
 	case LogLevelInfo:
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		log.Level(zerolog.InfoLevel)
 	case LogLevelWarn:
-		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+		log.Level(zerolog.WarnLevel)
 	case LogLevelError:
-		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+		log.Level(zerolog.ErrorLevel)
 	default:
 		panic("invalid log level")
 	}
@@ -145,7 +145,7 @@ func checkInvalidChars(args ...interface{}) {
 
 // Level returns the current log level
 func Level() string {
-	switch zerolog.GlobalLevel() {
+	switch log.GetLevel() {
 	case zerolog.DebugLevel:
 		return LogLevelDebug
 	case zerolog.InfoLevel:
@@ -161,7 +161,7 @@ func Level() string {
 
 // Debug sends a debug level log message
 func Debug(args ...interface{}) {
-	if zerolog.GlobalLevel() > zerolog.DebugLevel {
+	if log.GetLevel() > zerolog.DebugLevel {
 		return
 	}
 	log.Debug().Msg(fmt.Sprint(args...))
@@ -216,7 +216,7 @@ func FormatProto(arg protoreflect.ProtoMessage) string {
 
 // Debugf sends a formatted debug level log message
 func Debugf(template string, args ...interface{}) {
-	if zerolog.GlobalLevel() > zerolog.DebugLevel {
+	if log.GetLevel() > zerolog.DebugLevel {
 		return
 	}
 	Logger().Debug().Msgf(template, args...)
@@ -251,7 +251,7 @@ func Fatalf(template string, args ...interface{}) {
 
 // Debugw sends a debug level log message with key-value pairs.
 func Debugw(msg string, keyvalues ...interface{}) {
-	if zerolog.GlobalLevel() > zerolog.DebugLevel {
+	if log.GetLevel() > zerolog.DebugLevel {
 		return
 	}
 	Logger().Debug().Fields(keyvalues).Msg(msg)

--- a/log/log.go
+++ b/log/log.go
@@ -223,9 +223,6 @@ func FormatProto(arg protoreflect.ProtoMessage) string {
 
 // Debugf sends a formatted debug level log message
 func Debugf(template string, args ...interface{}) {
-	if log.GetLevel() > zerolog.DebugLevel {
-		return
-	}
 	Logger().Debug().Msgf(template, args...)
 }
 
@@ -251,9 +248,6 @@ func Fatalf(template string, args ...interface{}) {
 
 // Debugw sends a debug level log message with key-value pairs.
 func Debugw(msg string, keyvalues ...interface{}) {
-	if log.GetLevel() > zerolog.DebugLevel {
-		return
-	}
 	Logger().Debug().Fields(keyvalues).Msg(msg)
 }
 

--- a/log/log_error_test_out.txt
+++ b/log/log_error_test_out.txt
@@ -1,0 +1,3 @@
+2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:29 > cannot commit to blockstore: some error
+2006-01-02 15:04:05 +0000 UTC WRN log/log_test.go:30 > various types duration=1000 list=[10,0,-10]
+2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:35 > some error

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -69,6 +69,8 @@ func TestLoggerOutput(t *testing.T) {
 	logTestWriter = &buf
 	Init("debug", logTestWriterName, &errorBuf)
 
+	qt.Assert(t, Level(), qt.Equals, "debug")
+
 	doLogs()
 
 	got := buf.String()

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -36,14 +36,16 @@ func doLogs() {
 }
 
 func TestCheckInvalidChars(t *testing.T) {
+	t.Cleanup(func() { panicOnInvalidChars = false })
+
 	v := []byte{'h', 'e', 'l', 'l', 'o', 0xff, 'w', 'o', 'r', 'l', 'd'}
-	_ = os.Setenv("LOG_PANIC_ON_INVALIDCHARS", "false")
+	panicOnInvalidChars = false
 	Init("debug", "stderr")
 	Debugf("%s", v)
 	// should not panic since env var is false. if it panics, test will fail
 
 	// now enable panic and try again: should recover() and never reach t.Errorf()
-	_ = os.Setenv("LOG_PANIC_ON_INVALIDCHARS", "true")
+	panicOnInvalidChars = true
 	Init("debug", "stderr")
 	defer func() { recover() }()
 	Debugf("%s", v)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ func doLogs() {
 		"duration", sampleDuration,
 		"time", sampleTime,
 	)
+	Error(errSample)
 }
 
 func TestCheckInvalidChars(t *testing.T) {
@@ -69,5 +71,16 @@ func TestLoggerOutput(t *testing.T) {
 		qt.Assert(t, err, qt.IsNil)
 	} else {
 		qt.Assert(t, got, qt.Equals, want)
+	}
+}
+
+func BenchmarkLogger(b *testing.B) {
+	logTestWriter = io.Discard // to not grow a buffer
+	Init("debug", logTestWriterName)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		doLogs()
 	}
 }

--- a/log/log_test_out.txt
+++ b/log/log_test_out.txt
@@ -1,0 +1,5 @@
+2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:61 > logger construction succeeded at level debug with output log_test_writer
+2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:26 > added 3 keys to census 313233
+2006-01-02 15:04:05 +0000 UTC DBG log/log_test.go:27 > importing census root=abc123 type=type1
+2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:28 > cannot commit to blockstore: some error
+2006-01-02 15:04:05 +0000 UTC WRN log/log_test.go:29 > various types duration=1000 list=[10,0,-10]

--- a/log/log_test_out.txt
+++ b/log/log_test_out.txt
@@ -1,4 +1,4 @@
-2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:63 > logger construction succeeded at level debug with output log_test_writer
+2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:65 > logger construction succeeded at level debug with output log_test_writer
 2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:27 > added 3 keys to census 313233
 2006-01-02 15:04:05 +0000 UTC DBG log/log_test.go:28 > importing census root=abc123 type=type1
 2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:29 > cannot commit to blockstore: some error

--- a/log/log_test_out.txt
+++ b/log/log_test_out.txt
@@ -1,5 +1,6 @@
-2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:61 > logger construction succeeded at level debug with output log_test_writer
-2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:26 > added 3 keys to census 313233
-2006-01-02 15:04:05 +0000 UTC DBG log/log_test.go:27 > importing census root=abc123 type=type1
-2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:28 > cannot commit to blockstore: some error
-2006-01-02 15:04:05 +0000 UTC WRN log/log_test.go:29 > various types duration=1000 list=[10,0,-10]
+2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:63 > logger construction succeeded at level debug with output log_test_writer
+2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:27 > added 3 keys to census 313233
+2006-01-02 15:04:05 +0000 UTC DBG log/log_test.go:28 > importing census root=abc123 type=type1
+2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:29 > cannot commit to blockstore: some error
+2006-01-02 15:04:05 +0000 UTC WRN log/log_test.go:30 > various types duration=1000 list=[10,0,-10]
+2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:35 > some error

--- a/log/log_test_out.txt
+++ b/log/log_test_out.txt
@@ -1,6 +1,6 @@
-2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:65 > logger construction succeeded at level debug with output log_test_writer
-2006-01-02 15:04:05 +0000 UTC INF log/log_test.go:27 > added 3 keys to census 313233
-2006-01-02 15:04:05 +0000 UTC DBG log/log_test.go:28 > importing census root=abc123 type=type1
-2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:29 > cannot commit to blockstore: some error
-2006-01-02 15:04:05 +0000 UTC WRN log/log_test.go:30 > various types duration=1000 list=[10,0,-10]
-2006-01-02 15:04:05 +0000 UTC ERR log/log_test.go:35 > some error
+[90m2006-01-02 15:04:05 +0000 UTC[0m [32mINF[0m [1mlog/log_test.go:70[0m[36m >[0m logger construction succeeded at level debug with output log_test_writer
+[90m2006-01-02 15:04:05 +0000 UTC[0m [32mINF[0m [1mlog/log_test.go:27[0m[36m >[0m added 3 keys to census 313233
+[90m2006-01-02 15:04:05 +0000 UTC[0m [33mDBG[0m [1mlog/log_test.go:28[0m[36m >[0m importing census [36mroot=[0mabc123 [36mtype=[0mtype1
+[90m2006-01-02 15:04:05 +0000 UTC[0m [1m[31mERR[0m[0m [1mlog/log_test.go:29[0m[36m >[0m cannot commit to blockstore: some error
+[90m2006-01-02 15:04:05 +0000 UTC[0m [31mWRN[0m [1mlog/log_test.go:30[0m[36m >[0m various types [36mduration=[0m1000 [36mlist=[0m[10,0,-10]
+[90m2006-01-02 15:04:05 +0000 UTC[0m [1m[31mERR[0m[0m [1mlog/log_test.go:35[0m[36m >[0m some error

--- a/vochain/state/state_test.go
+++ b/vochain/state/state_test.go
@@ -35,7 +35,7 @@ func TestStateReopen(t *testing.T) {
 
 func TestStateBasic(t *testing.T) {
 	rng := testutil.NewRandom(0)
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	s, err := NewState(db.TypePebble, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -107,7 +107,7 @@ func TestStateBasic(t *testing.T) {
 }
 
 func TestBalanceTransfer(t *testing.T) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -195,7 +195,7 @@ func (l *Listener) Commit(height uint32) (err error) {
 func (l *Listener) Rollback() {}
 
 func TestOnProcessStart(t *testing.T) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -251,7 +251,7 @@ func TestOnProcessStart(t *testing.T) {
 // database transaction in the StateDB in a real scenario.
 func TestBlockMemoryUsage(t *testing.T) {
 	rng := testutil.NewRandom(0)
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -310,7 +310,7 @@ func TestBlockMemoryUsage(t *testing.T) {
 }
 
 func TestStateTreasurer(t *testing.T) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -344,7 +344,7 @@ func TestStateTreasurer(t *testing.T) {
 }
 
 func TestStateIsTreasurer(t *testing.T) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -366,7 +366,7 @@ func TestStateIsTreasurer(t *testing.T) {
 }
 
 func TestIncrementTreasurerNonce(t *testing.T) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()
@@ -389,7 +389,7 @@ func TestIncrementTreasurerNonce(t *testing.T) {
 }
 
 func TestStateSetGetTxCostByTxType(t *testing.T) {
-	log.Init("info", "stdout")
+	log.Init("info", "stdout", nil)
 	s, err := NewState(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	defer s.Close()


### PR DESCRIPTION
(see commit messages - please do not squash)

I'd like us to move to Go's upcoming official structured logger (https://pkg.go.dev/golang.org/x/exp/slog), but first I wanted to make sure we properly covered the existing behavior with tests.