### PR TITLE
 Add endpoint to get transactions references of a specific block

### DIFF
--- a/api/api_types.go
+++ b/api/api_types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/dvote/vochain/indexer/indexertypes"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -168,6 +169,12 @@ type Transaction struct {
 type TransactionReference struct {
 	Height uint32 `json:"blockHeight"`
 	Index  uint32 `json:"transactionIndex"`
+}
+
+type BlockTransactionsInfo struct {
+	BlockNumber        uint64                    `json:"blockNumber"`
+	TransactionsNumber uint32                    `json:"transactionNumber"`
+	Transactions       []indexertypes.TxMetadata `json:"transactions"`
 }
 
 type ChainInfo struct {

--- a/api/api_types.go
+++ b/api/api_types.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/uuid"
 	"go.vocdoni.io/dvote/types"
-	"go.vocdoni.io/dvote/vochain/indexer/indexertypes"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -171,10 +170,17 @@ type TransactionReference struct {
 	Index  uint32 `json:"transactionIndex"`
 }
 
+type TransactionMetadata struct {
+	Type   string         `json:"type"`
+	Height uint32         `json:"height"`
+	Index  int32          `json:"index"`
+	Hash   types.HexBytes `json:"hash"`
+}
+
 type BlockTransactionsInfo struct {
-	BlockNumber        uint64                    `json:"blockNumber"`
-	TransactionsNumber uint32                    `json:"transactionNumber"`
-	Transactions       []indexertypes.TxMetadata `json:"transactions"`
+	BlockNumber       uint64                `json:"blockNumber"`
+	TransactionsCount uint32                `json:"transactionCount"`
+	Transactions      []TransactionMetadata `json:"transactions"`
 }
 
 type ChainInfo struct {

--- a/api/chain.go
+++ b/api/chain.go
@@ -473,10 +473,11 @@ func (a *API) chainTxByIndexHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCo
 
 // chainTxByHeightHandler
 //
-// @Summary	Returns the list of transactions for a given block
-// @Description	Given a block returns the list of transactions for that block
-// @Success	200	{object}	TransactionList
-// @Router	/chain/transactions/reference/height/{height} [get]
+//	@Summary		Returns the list of transactions for a given block
+//	@Description	Given a block returns the list of transactions for that block
+//	@Success		200	{object}	TransactionList
+//
+//	@Router			/chain/transactions/reference/height/{height} [get]
 func (a *API) chainTxByHeightHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	height, err := strconv.ParseUint(ctx.URLParam("height"), 10, 64)
 	if err != nil {
@@ -487,28 +488,33 @@ func (a *API) chainTxByHeightHandler(msg *apirest.APIdata, ctx *httprouter.HTTPC
 		return ErrBlockNotFound
 	}
 	blockTxs := &BlockTransactionsInfo{
-		BlockNumber:        height,
-		TransactionsNumber: uint32(len(block.Txs)),
-		Transactions:       make([]indexertypes.TxMetadata, len(block.Txs)),
+		BlockNumber:       height,
+		TransactionsCount: uint32(len(block.Txs)),
+		Transactions:      make([]TransactionMetadata, len(block.Txs)),
 	}
-	for i, _ := range block.Txs {
+	for i := range block.Txs {
 		signedTx := new(models.SignedTx)
 		tx := new(models.Tx)
 		var err error
-		if err = proto.Unmarshal(block.Txs[i], signedTx); err != nil {
+		if err := proto.Unmarshal(block.Txs[i], signedTx); err != nil {
 			return ErrUnmarshalingServerProto.WithErr(err)
 		}
-		if err = proto.Unmarshal(signedTx.Tx, tx); err != nil {
+		if err := proto.Unmarshal(signedTx.Tx, tx); err != nil {
 			return ErrUnmarshalingServerProto.WithErr(err)
 		}
 		txType := string(
 			tx.ProtoReflect().WhichOneof(
 				tx.ProtoReflect().Descriptor().Oneofs().Get(0)).Name())
 
-		blockTxs.Transactions = append(blockTxs.Transactions, indexertypes.TxMetadata{
-			Type:  txType,
-			Index: int32(i),
-			Hash:  block.Txs[i].Hash(),
+		txRef, err := a.indexer.GetTxHashReference(block.Txs[i].Hash())
+		if err != nil {
+			return ErrTransactionNotFound
+		}
+		blockTxs.Transactions = append(blockTxs.Transactions, TransactionMetadata{
+			Type:   txType,
+			Index:  int32(i),
+			Height: uint32(txRef.Index),
+			Hash:   block.Txs[i].Hash(),
 		})
 	}
 	data, err := json.Marshal(blockTxs)

--- a/api/errors.go
+++ b/api/errors.go
@@ -68,6 +68,8 @@ var (
 	ErrKeyNotFoundInCensus              = apirest.APIerror{Code: 4049, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("key not found in census")}
 	ErrInvalidStatus                    = apirest.APIerror{Code: 4050, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("invalid status")}
 	ErrInvalidCensusKeyLength           = apirest.APIerror{Code: 4051, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("invalid census key length")}
+	ErrUnmarshalingServerProto          = apirest.APIerror{Code: 4052, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("error unmarshaling protobuf data")}
+	ErrMarshalingServerProto            = apirest.APIerror{Code: 4053, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("error marshaling protobuf data")}
 	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
 	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
 	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}


### PR DESCRIPTION
Returns:
```
{
    "blockNumber": 123456,
    "transactionCount": 3,
    "transactions": [
        {
            "type": "transfer",
            "index": 0,
            "height": 1234,
            "hash": "0x0123456789abcdef"
        },
        {
            "type": "approve",
            "index": 1,
            "height": 1235,
            "hash": "0x0123456789abcdef"
        },
        {
            "type": "transfer",
            "index": 2,
            "height": 1236,
            "hash": "0x0123456789abcdef"
        }
    ]
}
```