### PR TITLE
testsuite: fix zkCensus artifacts cache path

### DIFF
--- a/dockerfiles/testsuite/docker-compose.yml
+++ b/dockerfiles/testsuite/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - data-seed:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/root/.cache/vocdoni/zkCircuits/
       - gocoverage-seed:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -26,7 +26,7 @@ services:
     volumes:
       - data-miner0:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/root/.cache/vocdoni/zkCircuits/
       - gocoverage-miner0:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -39,7 +39,7 @@ services:
     volumes:
       - data-miner1:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/root/.cache/vocdoni/zkCircuits/
       - gocoverage-miner1:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -52,7 +52,7 @@ services:
     volumes:
       - data-miner2:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/root/.cache/vocdoni/zkCircuits/
       - gocoverage-miner2:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -65,7 +65,7 @@ services:
     volumes:
       - data-miner3:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/root/.cache/vocdoni/zkCircuits/
       - gocoverage-miner3:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -80,7 +80,7 @@ services:
     volumes:
       - data-gateway0:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - ${COMPOSE_HOST_PATH:-.}/zkCircuits:/app/run/dev/vochain/data/txHandler/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/root/.cache/vocdoni/zkCircuits/
       - gocoverage-gateway0:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage


### PR DESCRIPTION


point the bind-mount to /tmp to avoid owner/permissions errors
inside git repo (dockerized node creates the files as root:root)

