### PR TITLE
ci: refactor github workflows 

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,5 @@
-name: Deploy dev env
+---
+name: Deploy dev
 
 on:
   push:
@@ -6,8 +7,8 @@ on:
       - master
 
 jobs:
-  build:
-    name: Deploy main branch to dev env
+  push-to-dev:
+    name: Git push main -> dev
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -18,7 +19,14 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: dev
-        force: true
-        # the force push doesn't really work if `dev` branch is protected
-        # in that case, you need to do `git push -f origin origin/master:dev`
+        # this push only works if it applies cleanly. if it fails, you need to do
+        # `git push -f origin origin/master:dev`
         # from an account authorized to do force-push, and re-run the action
+
+  call-docker-release:
+    name: Docker
+    needs: push-to-dev
+    uses: vocdoni/vocdoni-node/.github/workflows/docker-release.yml@feat/deploy-dev
+    secrets: inherit
+    with:
+      image-tag: dev

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,54 @@
+---
+name: Docker Release
+
+on:
+  workflow_call:
+    inputs:
+      image-tag:
+        required: true
+        type: string
+
+jobs:
+  job_docker_release:
+    name: Publish images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Set up vars used in next step
+        id: vars
+        shell: bash
+        run: |
+          echo "IMAGE_TAG_CLEAN=$(echo ${{ inputs.image-tag }} | tr '/' '-' )" >> $GITHUB_OUTPUT
+          echo "GIT_HASH_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "DATE_IN_SECS=$(date +%s)" >> $GITHUB_OUTPUT
+      - name: Build and Push image to Docker Hub and ghcr.io
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          # platforms: linux/amd64,linux/arm64
+          push: true     # true to upload image to registry
+          tags: |
+            vocdoni/vocdoni-node:latest,
+            vocdoni/vocdoni-node:${{ steps.vars.outputs.IMAGE_TAG_CLEAN }},
+            vocdoni/vocdoni-node:${{ steps.vars.outputs.IMAGE_TAG_CLEAN }}-${{ steps.vars.outputs.DATE_IN_SECS }}
+            vocdoni/vocdoni-node:commit-${{ steps.vars.outputs.GIT_HASH_SHORT }},
+            ghcr.io/vocdoni/vocdoni-node:latest,
+            ghcr.io/vocdoni/vocdoni-node:${{ steps.vars.outputs.IMAGE_TAG_CLEAN }},
+            ghcr.io/vocdoni/vocdoni-node:${{ steps.vars.outputs.IMAGE_TAG_CLEAN }}-${{ steps.vars.outputs.DATE_IN_SECS }}
+            ghcr.io/vocdoni/vocdoni-node:commit-${{ steps.vars.outputs.GIT_HASH_SHORT }},
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 ---
-name: Main
+name: Build and Test
 
 on:
   push:
@@ -7,6 +7,7 @@ on:
       - dev
       - stage
       - master
+      - release**
   pull_request:
 
 jobs:
@@ -77,6 +78,8 @@ jobs:
 
   job_go_test:
     runs-on: ubuntu-latest
+    env:
+      LOG_PANIC_ON_INVALIDCHARS: true # check that log lines contains no invalid chars (evidence of format mismatch)
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -85,43 +88,15 @@ jobs:
         with:
           go-version: '1.20'
       - name: Run Go test (and collect code coverage)
-        if: |
-          github.ref != 'refs/heads/master'
-          && github.ref != 'refs/heads/stage'
-          && !startsWith(github.ref, 'refs/heads/release')
-          && github.ref != 'refs/heads/dev'
+        if: github.event_name == 'pull_request' # quicker, non-race test in case it's a PR
         run: go test -coverprofile=unit.covdata.txt ./...
       - name: Run Go test -race (and collect code coverage)
-        if: |
-          github.ref == 'refs/heads/master'
-          || github.ref == 'refs/heads/stage'
-          || startsWith(github.ref, 'refs/heads/release')
-          || github.ref == 'refs/heads/dev'
-        env:
-          LOG_PANIC_ON_INVALIDCHARS: true # check that log lines contains no invalid chars (evidence of format mismatch)
+        if: github.event_name == 'push' # this is limited to selected branches at the beginning of this file
         run: go test -coverprofile=unit.covdata.txt -vet=off -timeout=15m -race ./... # note that -race can easily make the crypto stuff 10x slower
 
   job_compose_test:
     runs-on: [self-hosted, ci2-1]
-    if: |
-      github.ref == 'refs/heads/master'
-      || github.ref == 'refs/heads/stage'
-      || startsWith(github.ref, 'refs/heads/release')
-      || github.ref == 'refs/heads/dev'
-      || (startsWith(github.ref, 'refs/pull/') && endsWith(github.ref, '/merge') )
-      || github.ref == 'refs/heads/main'
     steps:
-      - name: Set non-root owner to dockerfiles/testsuite folder
-        run: |
-          dir="${{ github.workspace }}/dockerfiles/testsuite/"
-          if [ -d "$dir" ]; then
-            ls -la $dir
-            sudo chown -R $USER:sudo $dir
-            echo "Checking again permissions/owner"
-            ls -la $dir
-          else
-            echo "Seems the $dir folder doesn't exist"
-          fi
       - name: Check out the repo
         uses: actions/checkout@v3
       - name: Run compose script
@@ -135,68 +110,6 @@ jobs:
           CONCURRENT: 1 # run all the start_test.sh tests concurrently
         run: |
           cd dockerfiles/testsuite && ./start_test.sh
-
-  job_docker_release:
-    runs-on: ubuntu-latest
-    needs: [job_go_test, job_compose_test]
-    if: |
-      github.ref == 'refs/heads/master'
-      || github.ref == 'refs/heads/stage'
-      || startsWith(github.ref, 'refs/heads/release')
-      || github.ref == 'refs/heads/dev'
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Get branch name, git commit hash and current time in secs
-        id: vars
-        shell: bash
-        run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-' )" >> $GITHUB_OUTPUT
-          echo "GIT_HASH_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "DATE_IN_SECS=$(date +%s)" >> $GITHUB_OUTPUT
-      - name: Push image to Docker Hub and ghcr.io
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          # platforms: linux/amd64,linux/arm64
-          push: true     # true to upload image to registry
-          tags: |
-            vocdoni/vocdoni-node:latest,
-            vocdoni/vocdoni-node:${{ steps.vars.outputs.BRANCH_NAME }},
-            vocdoni/vocdoni-node:commit-${{ steps.vars.outputs.GIT_HASH_SHORT }},
-            vocdoni/vocdoni-node:${{ steps.vars.outputs.BRANCH_NAME }}-${{ steps.vars.outputs.DATE_IN_SECS }}
-            ghcr.io/vocdoni/vocdoni-node:latest,
-            ghcr.io/vocdoni/vocdoni-node:${{ steps.vars.outputs.BRANCH_NAME }},
-            ghcr.io/vocdoni/vocdoni-node:commit-${{ steps.vars.outputs.GIT_HASH_SHORT }},
-            ghcr.io/vocdoni/vocdoni-node:${{ steps.vars.outputs.BRANCH_NAME }}-${{ steps.vars.outputs.DATE_IN_SECS }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Push master image to dev tag in Docker Hub and ghcr.io
-        uses: docker/build-push-action@v3
-        if: github.ref == 'refs/heads/master'
-        with:
-          context: .
-          push: true     # true to upload image to registry
-          tags: |
-            vocdoni/vocdoni-node:dev,
-            vocdoni/vocdoni-node:dev-${{ steps.vars.outputs.DATE_IN_SECS }}
-            ghcr.io/vocdoni/vocdoni-node:dev,
-            ghcr.io/vocdoni/vocdoni-node:dev-${{ steps.vars.outputs.DATE_IN_SECS }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   job_go_build_for_mac:
     runs-on: ubuntu-latest
@@ -214,3 +127,11 @@ jobs:
           # It's surprisingly hard with some deps like bazil.org/fuse.
           GOOS=darwin go build ./...
 
+  call-docker-release:
+    name: Docker
+    needs: [job_go_checks, job_go_test, job_compose_test]
+    if: github.event_name == 'push' # this is limited to selected branches at the beginning of this file
+    uses: vocdoni/vocdoni-node/.github/workflows/docker-release.yml@feat/deploy-dev
+    secrets: inherit
+    with:
+      image-tag: ${{ github.ref_name }}


### PR DESCRIPTION


* make docker-release a reusable workflow
* call docker-release from main.yml when:
  * push to dev, stage, master or release**
  * will publish corresponding docker tags
* call docker-release from deploy-dev when:
  * push to master
  * master can be pushed cleanly to dev
  * will publish resulting image to dev docker tag

