### PR TITLE
ci: hotfix docker-release branch name

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,7 +26,7 @@ jobs:
   call-docker-release:
     name: Docker
     needs: push-to-dev
-    uses: vocdoni/vocdoni-node/.github/workflows/docker-release.yml@feat/deploy-dev
+    uses: vocdoni/vocdoni-node/.github/workflows/docker-release.yml@master
     secrets: inherit
     with:
       image-tag: dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
     name: Docker
     needs: [job_go_checks, job_go_test, job_compose_test]
     if: github.event_name == 'push' # this is limited to selected branches at the beginning of this file
-    uses: vocdoni/vocdoni-node/.github/workflows/docker-release.yml@feat/deploy-dev
+    uses: vocdoni/vocdoni-node/.github/workflows/docker-release.yml@master
     secrets: inherit
     with:
       image-tag: ${{ github.ref_name }}


### PR DESCRIPTION
i broke CI on https://github.com/vocdoni/vocdoni-node/pull/945 , fix it

i originally pushed this in #948 but mixed with other changes that make more sense to be reviewed separately.

and make this PR that is more urgent, trivial to review/merge