### PR TITLE
fix: indexer, duplicated entities when calling EntityList()

### DIFF
--- a/vochain/indexer/db/processes.sql.go
+++ b/vochain/indexer/db/processes.sql.go
@@ -244,7 +244,7 @@ func (q *Queries) GetTotalProcessEnvelopeHeight(ctx context.Context) (interface{
 }
 
 const searchEntities = `-- name: SearchEntities :many
-SELECT entity_id FROM processes
+SELECT DISTINCT entity_id FROM processes
 WHERE (? = '' OR (INSTR(LOWER(HEX(entity_id)), ?) > 0))
 ORDER BY creation_time DESC, id ASC
 LIMIT ?

--- a/vochain/indexer/queries/processes.sql
+++ b/vochain/indexer/queries/processes.sql
@@ -112,7 +112,7 @@ WHERE entity_id = sqlc.arg(entity_id);
 SELECT COUNT(DISTINCT entity_id) FROM processes;
 
 -- name: SearchEntities :many
-SELECT entity_id FROM processes
+SELECT DISTINCT entity_id FROM processes
 WHERE (sqlc.arg(entity_id_substr) = '' OR (INSTR(LOWER(HEX(entity_id)), sqlc.arg(entity_id_substr)) > 0))
 ORDER BY creation_time DESC, id ASC
 LIMIT ?


### PR DESCRIPTION
When `EntityList()` is called for fetching a list of entities, some of the entities returned before the fix were duplicated.

The reason behind this is that the query is made against de `processes` table in which the primary key is the `processID`. So no extra checks for duplicity on `entityID` keys are performed. When an entity creates more than 1 process the DB ends up with N processes and when `EntityList()` is called, the underlying query returns N results with duplicated `entityIDs`.

The fix is simple, add the `DISTINCT` keyword on the underlying query so duplicates are avoided.

This PR also introduces a regression test for the bug.

closes #955 