### PR TITLE
vocone: call InitChain app method

### DIFF
--- a/apiclient/election.go
+++ b/apiclient/election.go
@@ -256,7 +256,7 @@ func (c *HTTPclient) NewElection(description *api.ElectionDescription) (types.He
 		return nil, err
 	}
 	if electionCreate.MetadataURL == "" {
-		return electionCreate.ElectionID, fmt.Errorf("metadata could not be published")
+		log.Warnf("metadata could not be published")
 	}
 
 	return electionCreate.ElectionID, nil

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -217,9 +217,11 @@ func (app *BaseApplication) InitChain(req abcitypes.RequestInitChain) abcitypes.
 	}
 
 	// set treasurer address
-	log.Infof("adding genesis treasurer %x", genesisAppState.Treasurer)
-	if err := app.State.SetTreasurer(ethcommon.BytesToAddress(genesisAppState.Treasurer), 0); err != nil {
-		log.Fatalf("could not set State.Treasurer from genesis file: %s", err)
+	if genesisAppState.Treasurer != nil {
+		log.Infof("adding genesis treasurer %x", genesisAppState.Treasurer)
+		if err := app.State.SetTreasurer(ethcommon.BytesToAddress(genesisAppState.Treasurer), 0); err != nil {
+			log.Fatalf("could not set State.Treasurer from genesis file: %s", err)
+		}
 	}
 
 	// add tx costs

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -31,22 +31,21 @@ func TestVocone(t *testing.T) {
 	err = account.Generate()
 	qt.Assert(t, err, qt.IsNil)
 
-	vc, err := NewVocone(dir, &keymng)
-	qt.Assert(t, err, qt.IsNil)
-	t.Cleanup(func() { vc.storage.Stop() })
-
-	err = vc.SetBulkTxCosts(0, true)
+	vc, err := NewVocone(dir, &keymng, true)
 	qt.Assert(t, err, qt.IsNil)
 
 	vc.SetBlockTimeTarget(time.Millisecond * 500)
 	go vc.Start()
 	port := 13000 + util.RandomInt(0, 2000)
-	_, err = vc.EnableAPI("127.0.0.1", port, "/api")
+	_, err = vc.EnableAPI("127.0.0.1", port, "/v2")
 	qt.Assert(t, err, qt.IsNil)
 
 	time.Sleep(time.Second * 2) // TODO: find a more smart way to wait until everything is ready
 
-	u, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d/api", port))
+	err = vc.SetBulkTxCosts(0, true)
+	qt.Assert(t, err, qt.IsNil)
+
+	u, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d/v2", port))
 	qt.Assert(t, err, qt.IsNil)
 	token := uuid.New()
 	cli, err := apiclient.NewHTTPclient(u, &token)


### PR DESCRIPTION
Before, the network capacity was not set and
the price calculator was not created.

Now both are properly set and we use the default
app method InitChain with a dumy genesis data.
It improves compatibility with the default vochain. Around this change, some small fixes.