### PR TITLE
ci: refactor e2etest sendvote

### DIFF
--- a/api/accounts.go
+++ b/api/accounts.go
@@ -185,15 +185,9 @@ func (a *API) accountSetHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContex
 	}
 
 	// send the transaction to the blockchain
-	res, err := a.vocapp.SendTx(req.TxPayload)
+	res, err := a.sendTx(req.TxPayload)
 	if err != nil {
-		return ErrVochainSendTxFailed.WithErr(err)
-	}
-	if res == nil {
-		return ErrVochainEmptyReply
-	}
-	if res.Code != 0 {
-		return ErrVochainReturnedErrorCode.Withf("(%d) %s", res.Code, string(res.Data))
+		return err
 	}
 
 	// prepare the reply

--- a/api/elections.go
+++ b/api/elections.go
@@ -481,15 +481,9 @@ func (a *API) electionCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCo
 	}
 
 	// send the transaction
-	res, err := a.vocapp.SendTx(req.TxPayload)
+	res, err := a.sendTx(req.TxPayload)
 	if err != nil {
-		return ErrVochainSendTxFailed.WithErr(err)
-	}
-	if res == nil {
-		return ErrVochainEmptyReply
-	}
-	if res.Code != 0 {
-		return ErrVochainReturnedErrorCode.Withf("(%d) %s", res.Code, string(res.Data))
+		return err
 	}
 
 	resp := &ElectionCreate{

--- a/api/errors.go
+++ b/api/errors.go
@@ -100,4 +100,5 @@ var (
 	ErrCantGetCircomSiblings            = apirest.APIerror{Code: 5027, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot get circom siblings")}
 	ErrCensusProofVerificationFailed    = apirest.APIerror{Code: 5028, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("census proof verification failed")}
 	ErrCantCountVotes                   = apirest.APIerror{Code: 5029, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("cannot count votes")}
+	ErrVochainOverloaded                = apirest.APIerror{Code: 5030, HTTPstatus: apirest.HTTPstatusServiceUnavailable, Err: fmt.Errorf("vochain overloaded")}
 )

--- a/api/vote.go
+++ b/api/vote.go
@@ -64,18 +64,13 @@ func (a *API) submitVoteHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContex
 	}
 
 	// send the transaction to the mempool
-	res, err := a.vocapp.SendTx(req.TxPayload)
+	res, err := a.sendTx(req.TxPayload)
 	if err != nil {
 		return err
 	}
-	if res == nil {
-		return ErrVochainEmptyReply
-	}
-	if res.Code != 0 {
-		return ErrVochainReturnedErrorCode.Withf("(%d) %s", res.Code, string(res.Data))
-	}
-	var data []byte
-	if data, err = json.Marshal(Vote{VoteID: res.Data.Bytes(), TxHash: res.Hash.Bytes()}); err != nil {
+
+	data, err := json.Marshal(Vote{VoteID: res.Data.Bytes(), TxHash: res.Hash.Bytes()})
+	if err != nil {
 		return err
 	}
 	return ctx.Send(data, apirest.HTTPstatusOK)

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -117,16 +117,9 @@ func (a *API) walletSignAndSendTx(stx *models.SignedTx, wallet *ethereum.SignKey
 		return nil, err
 	}
 
-	resp, err := a.vocapp.SendTx(txData)
+	resp, err := a.sendTx(txData)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp == nil {
-		return nil, ErrVochainEmptyReply
-	}
-	if resp.Code != 0 {
-		return nil, ErrVochainReturnedErrorCode.Withf("(%d) %s", resp.Code, string(resp.Data))
 	}
 
 	return &Transaction{

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -2,7 +2,6 @@ package apiclient
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -190,7 +189,7 @@ func (c *HTTPclient) Request(method string, jsonBody any, urlPath ...string) ([]
 		})
 		if resp != nil && resp.StatusCode == apirest.HTTPstatusServiceUnavailable { // mempool is full
 			log.Warnf("mempool is full, will wait and retry (%d/%d)", i, c.retries)
-			c.WaitUntilNextBlock(context.TODO())
+			_ = c.WaitUntilNextBlock()
 			continue
 		}
 		break

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -106,8 +106,8 @@ func (c *HTTPclient) SetAccount(accountPrivateKey string) error {
 // Panics if the accountPrivateKey is not valid.
 func (c *HTTPclient) Clone(accountPrivateKey string) *HTTPclient {
 	clone := *c
-	clone.account = new(ethereum.SignKeys)
-	if err := clone.account.AddHexKey(accountPrivateKey); err != nil {
+	err := clone.SetAccount(accountPrivateKey)
+	if err != nil {
 		panic(err)
 	}
 	return &clone

--- a/apiclient/election.go
+++ b/apiclient/election.go
@@ -18,6 +18,9 @@ import (
 
 // Election returns the election details given its ID.
 func (c *HTTPclient) Election(electionID types.HexBytes) (*api.Election, error) {
+	if electionID == nil {
+		return nil, fmt.Errorf("passed electionID is nil")
+	}
 	resp, code, err := c.Request("GET", nil, "elections", electionID.String())
 	if err != nil {
 		return nil, err

--- a/cmd/end2endtest/account.go
+++ b/cmd/end2endtest/account.go
@@ -215,9 +215,7 @@ func testSendTokens(api *apiclient.HTTPclient, aliceKeys, bobKeys *ethereum.Sign
 	// after a tx is mined in a block, the indexer takes some time to update the balances
 	// (i.e. seconds, if there are votes to be indexed)
 	// give it one more block time
-	ctx, cancel = context.WithTimeout(context.Background(), apiclient.WaitTimeout)
-	defer cancel()
-	api.WaitUntilNextBlock(ctx)
+	_ = api.WaitUntilNextBlock()
 
 	// now check the resulting state
 	err = checkAccountNonceAndBalance(alice, aliceAcc.Nonce+1,
@@ -271,9 +269,7 @@ func ensureAccountExists(api *apiclient.HTTPclient,
 			}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
-		api.WaitUntilNextBlock(ctx)
+		_ = api.WaitUntilNextBlock()
 	}
 	return nil, fmt.Errorf("cannot create account %s after %d retries", api.MyAddress(), retries)
 }
@@ -301,9 +297,7 @@ func ensureAccountMetadataEquals(api *apiclient.HTTPclient,
 			}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
-		api.WaitUntilNextBlock(ctx)
+		_ = api.WaitUntilNextBlock()
 	}
 	return nil, fmt.Errorf("cannot set account %s metadata after %d retries", api.MyAddress(), retries)
 }

--- a/cmd/end2endtest/encrypted.go
+++ b/cmd/end2endtest/encrypted.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/hex"
 	"os"
-	"sync"
 	"time"
 
 	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
-	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -65,39 +63,23 @@ func (t *E2EEncryptedElection) Run() error {
 
 	// Send the votes (parallelized)
 	startTime := time.Now()
-	wg := sync.WaitGroup{}
-	voteAccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
-		defer wg.Done()
-		log.Infof("sending %d votes", len(accounts))
 
-		votesSent := 0
-		contextDeadlines := 0
-		for i, acc := range accounts {
-			ctxDeadline, err := t.sendVote(voteInfo{voterAccount: acc, choice: []int{i % 2}, keys: keys}, nil)
-			if err != nil {
-				log.Error(err)
-				break
-			}
-			contextDeadlines += ctxDeadline
-			votesSent++
-		}
-		log.Infof("successfully sent %d votes... got %d HTTP errors", votesSent, contextDeadlines)
-		time.Sleep(time.Second * 4)
+	log.Infow("enqueuing votes", "n", len(t.voterAccounts), "election", t.election.ElectionID)
+	votes := []*apiclient.VoteData{}
+	for i, acct := range t.voterAccounts {
+		votes = append(votes, &apiclient.VoteData{
+			ElectionID:   t.election.ElectionID,
+			ProofMkTree:  t.proofs[acct.Address().Hex()],
+			Choices:      []int{i % 2},
+			VoterAccount: acct,
+			Keys:         keys,
+		})
 	}
+	t.sendVotes(votes)
 
-	pcount := c.nvotes / c.parallelCount
-	for i := 0; i < len(t.voterAccounts); i += pcount {
-		end := i + pcount
-		if end > len(t.voterAccounts) {
-			end = len(t.voterAccounts)
-		}
-		wg.Add(1)
-		go voteAccounts(t.voterAccounts[i:end], &wg)
-	}
-
-	wg.Wait()
-	log.Infof("%d votes submitted successfully, took %s (%d votes/second)",
-		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
+	log.Infow("votes submitted successfully",
+		"n", len(t.voterAccounts), "time", time.Since(startTime),
+		"vps", int(float64(len(t.voterAccounts))/time.Since(startTime).Seconds()))
 
 	// Wait for all the votes to be verified
 	log.Infof("waiting for all the votes to be registered...")

--- a/cmd/end2endtest/helpers.go
+++ b/cmd/end2endtest/helpers.go
@@ -401,9 +401,7 @@ func (t *e2eElection) overwriteVote(choices []int, indexAcct int, waitType strin
 			time.Sleep(time.Second * 5)
 
 		case nextBlock:
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-			defer cancel()
-			t.api.WaitUntilNextBlock(ctx)
+			_ = t.api.WaitUntilNextBlock()
 		}
 	}
 	return contextDeadlines, nil

--- a/cmd/end2endtest/plaintext.go
+++ b/cmd/end2endtest/plaintext.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/hex"
 	"os"
-	"sync"
 	"time"
 
 	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
-	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -58,39 +56,22 @@ func (t *E2EPlaintextElection) Run() error {
 
 	// Send the votes (parallelized)
 	startTime := time.Now()
-	wg := sync.WaitGroup{}
-	voteAccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
-		defer wg.Done()
-		log.Infof("sending %d votes", len(accounts))
 
-		votesSent := 0
-		contextDeadlines := 0
-		for i, acc := range accounts {
-			ctxDeadline, err := t.sendVote(voteInfo{voterAccount: acc, choice: []int{i % 2}}, nil)
-			if err != nil {
-				log.Error(err)
-				break
-			}
-			contextDeadlines += ctxDeadline
-			votesSent++
-		}
-		log.Infof("successfully sent %d votes... got %d HTTP errors", votesSent, contextDeadlines)
-		time.Sleep(time.Second * 4)
+	log.Infof("enqueuing %d votes", len(t.voterAccounts))
+	votes := []*apiclient.VoteData{}
+	for i, acct := range t.voterAccounts {
+		votes = append(votes, &apiclient.VoteData{
+			ElectionID:   t.election.ElectionID,
+			ProofMkTree:  t.proofs[acct.Address().Hex()],
+			Choices:      []int{i % 2},
+			VoterAccount: acct,
+		})
 	}
+	t.sendVotes(votes)
 
-	pcount := c.nvotes / c.parallelCount
-	for i := 0; i < len(t.voterAccounts); i += pcount {
-		end := i + pcount
-		if end > len(t.voterAccounts) {
-			end = len(t.voterAccounts)
-		}
-		wg.Add(1)
-		go voteAccounts(t.voterAccounts[i:end], &wg)
-	}
-
-	wg.Wait()
-	log.Infof("%d votes submitted successfully, took %s (%d votes/second)",
-		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
+	log.Infow("votes submitted successfully",
+		"n", c.nvotes, "time", time.Since(startTime),
+		"vps", int(float64(c.nvotes)/time.Since(startTime).Seconds()))
 
 	// Wait for all the votes to be verified
 	log.Infof("waiting for all the votes to be registered...")

--- a/cmd/end2endtest/zkweighted.go
+++ b/cmd/end2endtest/zkweighted.go
@@ -3,12 +3,10 @@ package main
 import (
 	"context"
 	"os"
-	"sync"
 	"time"
 
 	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
-	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -58,40 +56,21 @@ func (t *E2EAnonElection) Run() error {
 	// Send the votes (parallelized)
 	startTime := time.Now()
 
-	wg := sync.WaitGroup{}
-	apiClientMtx := &sync.Mutex{}
-	voteAccounts := func(accounts []*ethereum.SignKeys, wg *sync.WaitGroup) {
-		defer wg.Done()
-		log.Infof("sending %d votes", len(accounts))
-
-		votesSent := 0
-		contextDeadlines := 0
-		for i, acc := range accounts {
-			ctxDeadline, err := t.sendVote(voteInfo{voterAccount: acc, choice: []int{i % 2}}, apiClientMtx)
-			if err != nil {
-				log.Error(err)
-				break
-			}
-			contextDeadlines += ctxDeadline
-			votesSent++
-		}
-		log.Infof("successfully sent %d votes... got %d HTTP errors", votesSent, contextDeadlines)
-		time.Sleep(time.Second * 4)
+	log.Infow("enqueuing votes", "n", len(t.voterAccounts), "election", t.election.ElectionID)
+	votes := []*apiclient.VoteData{}
+	for i, acct := range t.voterAccounts {
+		votes = append(votes, &apiclient.VoteData{
+			ElectionID:   t.election.ElectionID,
+			ProofMkTree:  t.proofs[acct.Address().Hex()],
+			Choices:      []int{i % 2},
+			VoterAccount: acct,
+		})
 	}
+	t.sendVotes(votes)
 
-	pcount := c.nvotes / c.parallelCount
-	for i := 0; i < len(t.voterAccounts); i += pcount {
-		end := i + pcount
-		if end > len(t.voterAccounts) {
-			end = len(t.voterAccounts)
-		}
-		wg.Add(1)
-		go voteAccounts(t.voterAccounts[i:end], &wg)
-	}
-
-	wg.Wait()
-	log.Infof("%d votes submitted successfully, took %s (%d votes/second)",
-		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
+	log.Infow("votes submitted successfully",
+		"n", len(t.voterAccounts), "time", time.Since(startTime),
+		"vps", int(float64(len(t.voterAccounts))/time.Since(startTime).Seconds()))
 
 	// Wait for all the votes to be verified
 	log.Infof("waiting for all the votes to be registered...")

--- a/httprouter/apirest/apirest.go
+++ b/httprouter/apirest/apirest.go
@@ -30,11 +30,12 @@ const (
 
 // HTTPstatus* equal http.Status*, simple sugar to avoid importing http everywhere
 const (
-	HTTPstatusOK          = http.StatusOK
-	HTTPstatusNoContent   = http.StatusNoContent
-	HTTPstatusBadRequest  = http.StatusBadRequest
-	HTTPstatusInternalErr = http.StatusInternalServerError
-	HTTPstatusNotFound    = http.StatusNotFound
+	HTTPstatusOK                 = http.StatusOK
+	HTTPstatusNoContent          = http.StatusNoContent
+	HTTPstatusBadRequest         = http.StatusBadRequest
+	HTTPstatusInternalErr        = http.StatusInternalServerError
+	HTTPstatusNotFound           = http.StatusNotFound
+	HTTPstatusServiceUnavailable = http.StatusServiceUnavailable
 )
 
 // API is a namespace handler for the httpRouter with Bearer authorization


### PR DESCRIPTION
* api: 'mempool is full' now produces a '503 Service Unavailable'
    
* api: new ErrVochainOverloaded that returns http.StatusServiceUnavailable (503)

* apiclient: Request now retries 3 times if mempool is full
* apiclient: WaitUntilHeight doesn't panic anymore when ChainInfo fails
* apiclient: simplify WaitUntilNextBlock

* e2etest: refactor t.sendVotes and apiclient.Vote
    
    * apiclient: Clone() now uses SetAccount() so zkAddr is properly init'd
    * apiclient: VoteData now has VoterAccount, so Vote() can use it if set
    * apiclient: Election now checks that electionID is not nil
    * e2etest: overwriteVote now uses sendVotes()
    * e2etest: plaintext now uses sendVotes()
    * e2etest: censusize replace t.sendVote with t.api.Vote
