### PR TITLE
ballot: remove maxValue overflow check

### DIFF
--- a/vochain/indexer/process.go
+++ b/vochain/indexer/process.go
@@ -213,9 +213,9 @@ func (idx *Indexer) newEmptyProcess(pid []byte) error {
 		return fmt.Errorf("newEmptyProcess: maxCount is zero")
 	}
 
-	// Check for overflows
-	if options.MaxCount > results.MaxQuestions || options.MaxValue > results.MaxOptions {
-		return fmt.Errorf("maxCount or maxValue overflows hardcoded maximums")
+	// Check for maxCount overflow
+	if options.MaxCount > results.MaxQuestions {
+		return fmt.Errorf("maxCount overflow %d", options.MaxCount)
 	}
 
 	eid := p.EntityId

--- a/vochain/results/compute.go
+++ b/vochain/results/compute.go
@@ -27,11 +27,12 @@ func ComputeResults(electionID []byte, st *state.State) (*Results, error) {
 		return nil, fmt.Errorf("cannot get process: %w", err)
 	}
 
-	if p.VoteOptions.MaxCount == 0 || p.VoteOptions.MaxValue == 0 {
-		return nil, fmt.Errorf("maxCount and/or maxValue is zero")
+	if p.VoteOptions.MaxCount == 0 {
+		p.VoteOptions.MaxCount = MaxQuestions
 	}
-	if p.VoteOptions.MaxCount > MaxQuestions || p.VoteOptions.MaxValue > MaxOptions {
-		return nil, fmt.Errorf("maxCount and/or maxValue overflows hardcoded maximum")
+
+	if p.VoteOptions.MaxCount > MaxQuestions {
+		return nil, fmt.Errorf("maxCount overflow %d", p.VoteOptions.MaxCount)
 	}
 	results := &Results{
 		Votes:        NewEmptyVotes(int(p.VoteOptions.MaxCount), int(p.VoteOptions.MaxValue)+1),
@@ -64,7 +65,7 @@ func ComputeResults(electionID []byte, st *state.State) (*Results, error) {
 			return false
 		}
 		if err = results.AddVote(vp.Votes, new(big.Int).SetBytes(vote.Weight), &lock); err != nil {
-			log.Warnf("addVote failed: %v", err)
+			log.Debugf("addVote failed: %v", err)
 			return false
 		}
 		nvotes.Add(1)

--- a/vochain/results/results.go
+++ b/vochain/results/results.go
@@ -14,8 +14,6 @@ import (
 const (
 	// MaxQuestions is the maximum number of questions allowed in a VotePackage
 	MaxQuestions = 64
-	// MaxOptions is the maximum number of options allowed in a VotePackage question
-	MaxOptions = 768
 )
 
 // Results holds the final results and relevant process info for a vochain process
@@ -135,7 +133,7 @@ func (r *Results) AddVote(voteValues []int, weight *big.Int, mutex *sync.Mutex) 
 		return fmt.Errorf("addVote: envelopeType is nil")
 	}
 	// MaxCount
-	if len(voteValues) > int(r.VoteOpts.MaxCount) || len(voteValues) > MaxOptions {
+	if len(voteValues) > int(r.VoteOpts.MaxCount) {
 		return fmt.Errorf("max count overflow %d", len(voteValues))
 	}
 

--- a/vochain/transaction/election_tx.go
+++ b/vochain/transaction/election_tx.go
@@ -36,10 +36,10 @@ func (t *TransactionHandler) NewProcessTxCheck(vtx *vochaintx.Tx,
 		return nil, ethereum.Address{}, fmt.Errorf("missing vote maxCount parameter")
 	}
 	// check for maxCount/maxValue overflows
-	if tx.Process.VoteOptions.MaxCount > results.MaxQuestions || tx.Process.VoteOptions.MaxValue > results.MaxOptions {
+	if tx.Process.VoteOptions.MaxCount > results.MaxQuestions {
 		return nil, ethereum.Address{},
-			fmt.Errorf("maxCount or maxValue overflows hardcoded maximums (%d, %d). Received (%d, %d)",
-				results.MaxQuestions, results.MaxOptions, tx.Process.VoteOptions.MaxCount, tx.Process.VoteOptions.MaxValue)
+			fmt.Errorf("maxCount overflows (%d, %d)",
+				results.MaxQuestions, tx.Process.VoteOptions.MaxCount)
 	}
 	if !(tx.Process.GetStatus() == models.ProcessStatus_READY || tx.Process.GetStatus() == models.ProcessStatus_PAUSED) {
 		return nil, ethereum.Address{}, fmt.Errorf("status must be READY or PAUSED")


### PR DESCRIPTION
While maxCount should be limited (the number of questions or options available for a voting) in order to avoid spam attacks, maxValue might not.

Allowing any maxvalue (up to uint32) brings the possibility to perform votings such as quadratic using Ethereum balances, which usually are very big numbers.