### PR TITLE
fix: do not allow transition to RESULTS status

### DIFF
--- a/cmd/end2endtest/plaintext.go
+++ b/cmd/end2endtest/plaintext.go
@@ -128,7 +128,7 @@ func (t *E2EPlaintextElection) Run() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 	defer cancel()
 	if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
-		log.Fatalf("gave up waiting for tx %s to be mined: %s", hash, err)
+		log.Fatalf("gave up waiting for tx %x to be mined: %s", hash, err)
 	}
 
 	t.election, err = api.Election(t.election.ElectionID)

--- a/vochain/genesis/genesis.go
+++ b/vochain/genesis/genesis.go
@@ -41,7 +41,7 @@ var Genesis = map[string]VochainGenesis{
 
 var devGenesis = GenesisDoc{
 	GenesisTime: time.Date(2023, time.June, 5, 10, 0, 0, 0, time.UTC),
-	ChainID:     "vocdoni-dev-7",
+	ChainID:     "vocdoni-dev-8",
 	ConsensusParams: &ConsensusParams{
 		Block: BlockParams{
 			MaxBytes: 2097152,
@@ -60,7 +60,7 @@ var devGenesis = GenesisDoc{
 	},
 	AppState: GenesisAppState{
 		MaxElectionSize: 50000,
-		NetworkCapacity: 2000,
+		NetworkCapacity: 20000,
 		Validators: []AppStateValidators{
 			{ // 0
 				Address:  types.HexStringToHexBytes("04cc36be85a0a6e2bfd09295396625e6302d7c60"),
@@ -94,7 +94,7 @@ var devGenesis = GenesisDoc{
 		Accounts: []GenesisAccount{
 			{ // faucet
 				Address: types.HexStringToHexBytes("0xC7C6E17059801b6962cc144a374eCc3ba1b8A9e0"),
-				Balance: 10000000,
+				Balance: 100000000,
 			},
 		},
 		Treasurer: types.HexStringToHexBytes("0x309Bd6959bf4289CDf9c7198cF9f4494e0244b7d"),

--- a/vochain/process_test.go
+++ b/vochain/process_test.go
@@ -158,9 +158,9 @@ func TestProcessSetStatusCheckTxDeliverTxCommitTransitions(t *testing.T) {
 	status = models.ProcessStatus_ENDED
 	qt.Assert(t, testSetProcessStatus(t, pid, keys[0], app, &status), qt.IsNil)
 
-	// Set it to RESULTS (should work)
+	// Set it to RESULTS (should not work)
 	status = models.ProcessStatus_RESULTS
-	qt.Assert(t, testSetProcessStatus(t, pid, keys[0], app, &status), qt.IsNil)
+	qt.Assert(t, testSetProcessStatus(t, pid, keys[0], app, &status), qt.IsNotNil)
 
 	// Set it to READY (should fail)
 	status = models.ProcessStatus_READY

--- a/vochain/state/process.go
+++ b/vochain/state/process.go
@@ -242,7 +242,7 @@ func (v *State) SetProcessStatus(pid []byte, newstatus models.ProcessStatus, com
 		}
 		if !process.Mode.Interruptible {
 			if v.CurrentHeight() < process.BlockCount+process.StartBlock {
-				return fmt.Errorf("process %x is not interruptible, cannot change state to %s",
+				return fmt.Errorf("process %x is not interruptible, cannot change status to %s",
 					pid, newstatus.String())
 			}
 		}

--- a/vochain/transaction/election_tx.go
+++ b/vochain/transaction/election_tx.go
@@ -195,6 +195,10 @@ func (t *TransactionHandler) SetProcessTxCheck(vtx *vochaintx.Tx, forCommit bool
 	}
 	switch tx.Txtype {
 	case models.TxType_SET_PROCESS_STATUS:
+		if tx.GetStatus() == models.ProcessStatus_RESULTS {
+			// Status can only be set to RESULTS by the internal logic of the blockchain (see IST controller).
+			return ethereum.Address{}, fmt.Errorf("not authoritzed to set process status to RESULTS")
+		}
 		return ethereum.Address(*addr), t.state.SetProcessStatus(process.ProcessId, tx.GetStatus(), false)
 	case models.TxType_SET_PROCESS_CENSUS:
 		return ethereum.Address(*addr), t.state.SetProcessCensus(process.ProcessId, tx.GetCensusRoot(), tx.GetCensusURI(), false)


### PR DESCRIPTION
Since ISTC is compupting internally the results, no external transation should be allowed for seting an election to RESULTS status.

Update dev genesis since this is a breaking change.