### PR TITLE
log: print stack trace on Fatal

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime/debug"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -205,7 +206,7 @@ func Error(args ...interface{}) {
 
 // Fatal sends a fatal level log message
 func Fatal(args ...interface{}) {
-	log.Fatal().Msg(fmt.Sprint(args...))
+	log.Fatal().Msg(fmt.Sprint(args...) + "\n" + string(debug.Stack()))
 	// We don't support log levels lower than "fatal". Help analyzers like
 	// staticcheck see that, in this package, Fatal will always exit the
 	// entire program.
@@ -243,7 +244,7 @@ func Errorf(template string, args ...interface{}) {
 
 // Fatalf sends a formatted fatal level log message
 func Fatalf(template string, args ...interface{}) {
-	Logger().Fatal().Msgf(template, args...)
+	Logger().Fatal().Msgf(template+"\n"+string(debug.Stack()), args...)
 }
 
 // Debugw sends a debug level log message with key-value pairs.


### PR DESCRIPTION
    since "switch to Zerolog" (0ff4b19a) we lost the useful feature that
    log.Error and log.Fatal did include a stack trace.
    
    Fix that regression in a simple way, only for Fatal.
    Error stays untouched, to avoid a performance hit in case of a flood of Error().
    Also, it's not as pretty as in zerolog because there's no SkipCallerCount,
    but i prefer to make this one-liner fix instead of something more complex.
