### PR TITLE
end2endtest/csp

### DIFF
--- a/cmd/end2endtest/csp.go
+++ b/cmd/end2endtest/csp.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"time"
+
+	"go.vocdoni.io/dvote/apiclient"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+func init() {
+	ops["cspelection"] = operation{
+		test:        &E2ECSPElection{},
+		description: "csp election",
+		example:     os.Args[0] + " --operation=cspelection --votes=1000",
+	}
+}
+
+var _ VochainTest = (*E2ECSPElection)(nil)
+
+type E2ECSPElection struct {
+	e2eElection
+}
+
+func (t *E2ECSPElection) Setup(api *apiclient.HTTPclient, c *config) error {
+	t.api = api
+	t.config = c
+
+	p := &models.Process{
+		StartBlock: 0,
+		BlockCount: 100,
+		Status:     models.ProcessStatus_READY,
+		EnvelopeType: &models.EnvelopeType{
+			EncryptedVotes: false,
+			UniqueValues:   true},
+		CensusOrigin: models.CensusOrigin_OFF_CHAIN_CA,
+		VoteOptions: &models.ProcessVoteOptions{
+			MaxCount: 1,
+			MaxValue: 1,
+		},
+		Mode: &models.ProcessMode{
+			AutoStart:     true,
+			Interruptible: true,
+		},
+		MaxCensusSize: uint64(t.config.nvotes),
+	}
+
+	if err := t.setupElectionRaw(p); err != nil {
+		return err
+	}
+
+	log.Debugf("election details: %+v", *t.election)
+	return nil
+}
+
+func (t *E2ECSPElection) Teardown() error {
+	// nothing to do here
+	return nil
+}
+
+func (t *E2ECSPElection) Run() error {
+	c := t.config
+	api := t.api
+
+	// Send the votes (parallelized)
+	startTime := time.Now()
+
+	log.Infow("enqueuing votes", "n", len(t.voterAccounts), "election", t.election.ElectionID)
+	votes := []*apiclient.VoteData{}
+	for _, acct := range t.voterAccounts {
+		votes = append(votes, &apiclient.VoteData{
+			ElectionID:   t.election.ElectionID,
+			ProofCSP:     t.proofs[acct.Address().Hex()].Proof,
+			Choices:      []int{0},
+			VoterAccount: acct,
+		})
+	}
+	t.sendVotes(votes)
+
+	log.Infow("votes submitted successfully",
+		"n", c.nvotes, "time", time.Since(startTime),
+		"vps", int(float64(c.nvotes)/time.Since(startTime).Seconds()))
+
+	// Wait for all the votes to be verified
+	log.Infof("waiting for all the votes to be registered...")
+	for {
+		count, err := api.ElectionVoteCount(t.election.ElectionID)
+		if err != nil {
+			log.Warn(err)
+		}
+		if count == uint32(c.nvotes) {
+			break
+		}
+		time.Sleep(time.Second * 5)
+		log.Infof("verified %d/%d votes", count, c.nvotes)
+		if time.Since(startTime) > c.timeout {
+			log.Fatalf("timeout waiting for votes to be registered")
+		}
+	}
+
+	log.Infof("%d votes registered successfully, took %s (%d votes/second)",
+		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
+
+	// Set the account back to the organization account
+	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
+		return err
+	}
+
+	// End the election by setting the status to ENDED
+	log.Infof("ending election...")
+	if _, err := api.SetElectionStatus(t.election.ElectionID, "ENDED"); err != nil {
+		return err
+	}
+
+	// Wait for the election to be in RESULTS state
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*100)
+	defer cancel()
+
+	elres, err := api.WaitUntilElectionResults(ctx, t.election.ElectionID)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("election %s status is RESULTS", t.election.ElectionID.String())
+	log.Infof("election results: %v", elres.Results)
+
+	return nil
+}

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -10,6 +10,7 @@
 #  e2etest_censusizelection: run max census size test
 #  e2etest_ballotelection: run ballot test
 #  e2etest_lifecyclelection: run lifecycle test
+#  e2etest_cspelection: run csp test
 
 export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 COMPOSE_INTERACTIVE_NO_CLI=1
 [ -n "$GOCOVERDIR" ] && export BUILDARGS="-cover" # docker-compose build passes this to go 1.20 so that binaries collect code coverage
@@ -55,6 +56,7 @@ tests_to_run=(
 	"e2etest_ballotelection"
 	"e2etest_tokentxs"
 	"e2etest_lifecyclelection"
+	"e2etest_cspelection"
 )
 
 # print help
@@ -122,6 +124,10 @@ e2etest_ballotelection() {
 
 e2etest_lifecyclelection() {
   e2etest lifecyclelection
+}
+
+e2etest_cspelection() {
+  e2etest cspelection
 }
 
 ### end tests definition


### PR DESCRIPTION
- #863 

- add csp election end2end test
- update `setupElectionRaw` to support csp election that not include setup the census
- add new method to setup account
- add `generateCSPProofs` in helpers