### PR TITLE
end2endtest: use WaitUntilElectionResults to finish the elections

### DIFF
--- a/cmd/end2endtest/ballot.go
+++ b/cmd/end2endtest/ballot.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"time"
@@ -117,7 +116,7 @@ func (t *E2EBallotElection) Run() error {
 		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
 
 	// Set the account back to the organization account
-	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
+	if err := api.SetAccount(c.accountPrivKeys[0]); err != nil {
 		return err
 	}
 

--- a/cmd/end2endtest/csp.go
+++ b/cmd/end2endtest/csp.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
 	"os"
 	"time"
 
@@ -105,7 +104,7 @@ func (t *E2ECSPElection) Run() error {
 		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
 
 	// Set the account back to the organization account
-	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
+	if err := api.SetAccount(c.accountPrivKeys[0]); err != nil {
 		return err
 	}
 

--- a/cmd/end2endtest/encrypted.go
+++ b/cmd/end2endtest/encrypted.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
 	"os"
 	"time"
 
@@ -102,7 +101,7 @@ func (t *E2EEncryptedElection) Run() error {
 		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
 
 	// Set the account back to the organization account
-	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
+	if err := api.SetAccount(c.accountPrivKeys[0]); err != nil {
 		return err
 	}
 
@@ -113,9 +112,9 @@ func (t *E2EEncryptedElection) Run() error {
 	}
 
 	// Wait for the election to be in RESULTS state
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*100)
 	defer cancel()
-	election, err := api.WaitUntilElectionStatus(ctx, t.election.ElectionID, "RESULTS")
+	election, err := api.WaitUntilElectionResults(ctx, t.election.ElectionID)
 	if err != nil {
 		return err
 	}

--- a/cmd/end2endtest/overwrite.go
+++ b/cmd/end2endtest/overwrite.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"time"
@@ -113,7 +112,7 @@ func (t *E2EOverwriteElection) Run() error {
 		c.nvotes, time.Since(startTime), int(float64(c.nvotes)/time.Since(startTime).Seconds()))
 
 	// Set the account back to the organization account
-	if err := api.SetAccount(hex.EncodeToString(c.accountKeys[0].PrivateKey())); err != nil {
+	if err := api.SetAccount(c.accountPrivKeys[0]); err != nil {
 		return err
 	}
 

--- a/cmd/end2endtest/zkweighted.go
+++ b/cmd/end2endtest/zkweighted.go
@@ -94,41 +94,25 @@ func (t *E2EAnonElection) Run() error {
 
 	// Set the account back to the organization account
 	if err := api.SetAccount(c.accountPrivKeys[0]); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// End the election by setting the status to ENDED
 	log.Infof("ending election...")
-	hash, err := api.SetElectionStatus(t.election.ElectionID, "ENDED")
-	if err != nil {
+	if _, err := api.SetElectionStatus(t.election.ElectionID, "ENDED"); err != nil {
 		return err
 	}
-
-	// Check the election status is actually ENDED
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
-	defer cancel()
-	if _, err := api.WaitUntilTxIsMined(ctx, hash); err != nil {
-		log.Fatalf("gave up waiting for tx %s to be mined: %s", hash, err)
-	}
-
-	t.election, err = api.Election(t.election.ElectionID)
-	if err != nil {
-		return err
-	}
-	if t.election.Status != "ENDED" {
-		log.Fatal("election status is not ENDED")
-	}
-	log.Infof("election %s status is ENDED", t.election.ElectionID.String())
 
 	// Wait for the election to be in RESULTS state
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*300)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*100)
 	defer cancel()
-	t.election, err = api.WaitUntilElectionStatus(ctx, t.election.ElectionID, "RESULTS")
+	election, err := api.WaitUntilElectionResults(ctx, t.election.ElectionID)
 	if err != nil {
 		return err
 	}
+
 	log.Infof("election %s status is RESULTS", t.election.ElectionID.String())
-	log.Infof("election results: %v", t.election.Results)
+	log.Infof("election results: %v", election.Results)
 
 	return nil
 }


### PR DESCRIPTION
To be consistent use the same pattern to finish the elections, in this case use  `WaitUntilElectionResults` . The code related to finish the elections could be added later in a helper to reuse code.

Also,  update to use `c.accountPrivKeys[0]` instead `hex.EncodeToString(c.accountKeys[0].PrivateKey())`