### PR TITLE
fix: deepsource issues

### DIFF
--- a/api/autoswag/main.go
+++ b/api/autoswag/main.go
@@ -158,8 +158,7 @@ func UpdateRouterTags(fset *token.FileSet, parsedFile *ast.File, fmap map[string
 	cmap := ast.NewCommentMap(fset, parsedFile, parsedFile.Comments)
 
 	ast.Inspect(parsedFile, func(n ast.Node) bool {
-		switch x := n.(type) {
-		case *ast.FuncDecl:
+		if x, ok := n.(*ast.FuncDecl); ok {
 			if pms, found := fmap[x.Name.Name]; found {
 				list := []*ast.Comment{}
 				for _, line := range cmap[x][0].List {
@@ -195,8 +194,7 @@ func InitComments(fset *token.FileSet, parsedFile *ast.File, fmap map[string][]P
 	cmap := ast.NewCommentMap(fset, parsedFile, parsedFile.Comments)
 
 	ast.Inspect(parsedFile, func(n ast.Node) bool {
-		switch x := n.(type) {
-		case *ast.FuncDecl:
+		if x, ok := n.(*ast.FuncDecl); ok {
 			if _, found := fmap[x.Name.Name]; found {
 				list := []*ast.Comment{}
 				list = append(list, &ast.Comment{

--- a/censustree/censustree.go
+++ b/censustree/censustree.go
@@ -41,15 +41,15 @@ type Options struct {
 	CensusType models.Census_Type
 }
 
-// By default, the maximum number of levels will be 160, which allows to add
+// DefaultMaxLevels is by default, the maximum number of levels will be 160, which allows to add
 // up to 2^160 leaves to the tree, with keys with up to 20 bytes. However the
-// number of levels could be setted up during the tree initialization which
+// number of levels could be set up during the tree initialization which
 // allows to support uses cases with specific restrictions such as the
 // zkweighted census, which needs to optimize some artifacts size that depends
 // of the number of levels of the tree.
 const DefaultMaxLevels = 160
 
-// The maximum length of a census tree key is defined by the number of levels of
+// DefaultMaxKeyLen is the maximum length of a census tree key is defined by the number of levels of
 // the census tree. It is the number of bytes that can fit into 'n' bits, where
 // 'n' is the number of levels of the census tree.
 const DefaultMaxKeyLen = DefaultMaxLevels / 8

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -375,7 +375,7 @@ func main() {
 	if globalCfg.Dev || globalCfg.PprofPort > 0 {
 		go func() {
 			if globalCfg.PprofPort == 0 {
-				globalCfg.PprofPort = int((time.Now().Unix() % 100)) + 61000
+				globalCfg.PprofPort = int(time.Now().Unix()%100) + 61000
 			}
 			ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", globalCfg.PprofPort))
 			if err != nil {
@@ -496,7 +496,8 @@ func main() {
 		// create the key for the validator used to sign transactions
 		signer := ethereum.SignKeys{}
 		if err := signer.AddHexKey(globalCfg.Vochain.MinerKey); err != nil {
-			log.Fatal(err)
+			log.Errorf("add hex key failed %v", err)
+			return
 		}
 		validator, err := srv.App.State.Validator(signer.Address(), true)
 		if err != nil {

--- a/cmd/vochaininspector/inspector.go
+++ b/cmd/vochaininspector/inspector.go
@@ -46,7 +46,7 @@ func main() {
 	flag.StringVar(&action, "action", "sync", `action to execute: 
 	sync = synchronize the blockchain
 	block = print a block from the blockstore
-	blockList = list blocks and numfer of transactions
+	blockList = list blocks and number of transactions
 	listProcess = list voting processes from the state at specific height
 	listVotes = list votes from the state at specific height
 	listBlockVotes = list existing votes from a block (with nullifier)
@@ -61,7 +61,7 @@ func main() {
 	switch action {
 	case "listProcess":
 		if blockHeight == 0 {
-			log.Fatal("listProcess requires a heigh value")
+			log.Fatal("listProcess requires a height value")
 		}
 		path := filepath.Join(dataDir, "data", "vcstate")
 		log.Infof("opening state database path %s", path)
@@ -69,7 +69,7 @@ func main() {
 
 	case "listVotes":
 		if blockHeight == 0 {
-			log.Fatal("listVotes requires a heigh value")
+			log.Fatal("listVotes requires a height value")
 		}
 		path := filepath.Join(dataDir, "data", "vcstate")
 		log.Infof("opening state database path %s", path)
@@ -77,13 +77,13 @@ func main() {
 
 	case "listBlockVotes":
 		if blockHeight == 0 {
-			log.Fatal("listBlockVotes requires a heigh value")
+			log.Fatal("listBlockVotes requires a height value")
 		}
 		listBlockVotes(int64(blockHeight), dataDir)
 
 	case "stateGraph":
 		if blockHeight == 0 {
-			log.Fatal("stateGraph requires a heigh value")
+			log.Fatal("stateGraph requires a height value")
 		}
 		path := filepath.Join(dataDir, "data", "vcstate")
 		graphVizMainTree(int64(blockHeight), path)
@@ -115,7 +115,8 @@ func main() {
 		vnode.Node.Stop()
 		height, err := vnode.State.LastHeight()
 		if err != nil {
-			log.Fatal(err)
+			log.Error(err)
+			return
 		}
 		log.Infof("last height is %d", height)
 		for i := uint32(1); i <= height; i++ {
@@ -213,7 +214,7 @@ func openStateAtHeight(height int64, stateDir string) *statedb.TreeView {
 	}
 	log.Infof("Last height found on state is %d", lastHeight)
 	if height > int64(lastHeight) {
-		log.Fatal("Height cannot be greather than lastHeight")
+		log.Fatal("Height cannot be greater than lastHeight")
 	}
 	root, err := sdb.VersionRoot(uint32(height))
 	if err != nil {

--- a/crypto/zk/address.go
+++ b/crypto/zk/address.go
@@ -80,7 +80,7 @@ func AddressFromBytes(seed []byte) (*ZkAddress, error) {
 		return nil, fmt.Errorf("the seed provided does not have 32 bytes at least")
 	}
 	jubjubKey := babyjub.PrivateKey{}
-	if _, err := hex.Decode(jubjubKey[:], seed[:]); err != nil {
+	if _, err := hex.Decode(jubjubKey[:], seed); err != nil {
 		return nil, fmt.Errorf("error generating babyjub key: %w", err)
 	}
 	pubKey, err := poseidon.Hash([]*big.Int{

--- a/crypto/zk/circuit/config.go
+++ b/crypto/zk/circuit/config.go
@@ -46,7 +46,7 @@ func (config ZkCircuitConfig) KeySize() int {
 	return config.Levels / 8
 }
 
-// CircuitsConfiguration stores the relation between the different vochain nets
+// CircuitsConfigurations stores the relation between the different vochain nets
 // and the associated circuit configuration. Any circuit configuration must have
 // the remote and local location of the circuits artifacts and their metadata
 // such as artifacts hash or the number of parameters.

--- a/data/ipfs/ipfsconnect/ipfsconnect.go
+++ b/data/ipfs/ipfsconnect/ipfsconnect.go
@@ -23,7 +23,7 @@ func New(groupKey string, ipfsHandler *ipfs.Handler) *IPFSConnect {
 		IPFS: ipfsHandler,
 	}
 	keyHash := ethereum.HashRaw([]byte(groupKey))
-	copy(is.GroupKey[:], keyHash[:])
+	copy(is.GroupKey[:], keyHash)
 	return is
 }
 

--- a/db/interface.go
+++ b/db/interface.go
@@ -8,7 +8,7 @@ import (
 // TypePebble defines the type of db that uses PebbleDB
 const TypePebble = "pebble"
 
-// ErrKeysNotFound is used to indicate that a key does not exist in the db.
+// ErrKeyNotFound is used to indicate that a key does not exist in the db.
 var ErrKeyNotFound = fmt.Errorf("key not found")
 
 // ErrTxnTooBig is used to indicate that a WriteTx is too big and can't include

--- a/db/prefixeddb/prefixeddb.go
+++ b/db/prefixeddb/prefixeddb.go
@@ -27,7 +27,7 @@ func prefixSlice(prefix, v []byte) []byte {
 
 // NewPrefixedDatabase creates a new PrefixedDatabase.  If the db is already a
 // PrefixedDatabase, instead of wrapping again, the prefixes are appended to
-// avoid unecessay layers.
+// avoid unnecessary layers.
 func NewPrefixedDatabase(db db.Database, prefix []byte) *PrefixedDatabase {
 	if pdb, ok := db.(*PrefixedDatabase); ok {
 		return &PrefixedDatabase{prefixSlice(pdb.prefix, prefix), pdb.db}
@@ -58,7 +58,7 @@ func (d *PrefixedDatabase) Iterate(prefix []byte, callback func(key, value []byt
 	})
 }
 
-// PrefixedDatabase wraps a db.Database prefixing all keys with `prefix`.
+// PrefixedReader wraps a Reader tx prefixing all keys with `prefix`.
 type PrefixedReader struct {
 	prefix []byte
 	rd     db.Reader
@@ -67,9 +67,9 @@ type PrefixedReader struct {
 // check that PrefixedDatabase implements the db.Database interface
 var _ db.Reader = (*PrefixedReader)(nil)
 
-// NewPrefixedDatabase creates a new PrefixedDatabase.  If the db is already a
-// PrefixedDatabase, instead of wrapping again, the prefixes are appended to
-// avoid unecessay layers.
+// NewPrefixedReader creates a new PrefixedReader.  If the rd is already a
+// PrefixedReader, instead of wrapping again, the prefixes are appended to
+// avoid unnecessary layers.
 func NewPrefixedReader(rd db.Reader, prefix []byte) *PrefixedReader {
 	if pdb, ok := rd.(*PrefixedReader); ok {
 		return &PrefixedReader{prefixSlice(pdb.prefix, prefix), pdb.rd}

--- a/httprouter/httprouter.go
+++ b/httprouter/httprouter.go
@@ -278,8 +278,11 @@ func (r *HTTProuter) generateTLScert(host string, port int) (*http.Server, *auto
 	}
 	r.TLSconfig.GetCertificate = m.GetCertificate
 	serverConfig := &http.Server{
-		Addr:      net.JoinHostPort(host, fmt.Sprintf("%d", port)),
-		TLSConfig: r.TLSconfig,
+		Addr:              net.JoinHostPort(host, fmt.Sprintf("%d", port)),
+		TLSConfig:         r.TLSconfig,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       10 * time.Second,
+		ReadHeaderTimeout: 3 * time.Second,
 	}
 	serverConfig.TLSConfig.NextProtos = append(serverConfig.TLSConfig.NextProtos, acme.ALPNProto)
 

--- a/test/testcommon/testutil/util.go
+++ b/test/testcommon/testutil/util.go
@@ -70,7 +70,7 @@ func (r *Random) RandomIntn(n int) int {
 	return r.rand.Intn(n)
 }
 
-// RandomInSnarkField returns a random litte-endian encoded element in the
+// RandomInZKField returns a random litte-endian encoded element in the
 // ZK SNARK field.
 func (r *Random) RandomInZKField() []byte {
 	b := make([]byte, 32)

--- a/tree/arbo/addbatch_test.go
+++ b/tree/arbo/addbatch_test.go
@@ -533,7 +533,7 @@ func TestSplitInBuckets(t *testing.T) {
 		k := BigIntToBytes(bLen, big.NewInt(int64(i)))
 		v := BigIntToBytes(bLen, big.NewInt(int64(i*2)))
 		keyPath := make([]byte, 32)
-		copy(keyPath[:], k)
+		copy(keyPath, k)
 		kvs[i].pos = i
 		kvs[i].keyPath = k
 		kvs[i].k = k
@@ -1108,7 +1108,7 @@ func testUpFromSubRootsWithEmpties(c *qt.C, preSubRoots [][]byte, indexEmpties [
 	tree1, tree2 := initTestUpFromSubRoots(c)
 
 	testPreSubRoots := make([][]byte, len(preSubRoots))
-	copy(testPreSubRoots[:], preSubRoots[:])
+	copy(testPreSubRoots, preSubRoots)
 	for i := 0; i < len(indexEmpties); i++ {
 		testPreSubRoots[indexEmpties[i]] = tree1.emptyHash
 	}

--- a/tree/arbo/tree.go
+++ b/tree/arbo/tree.go
@@ -131,7 +131,7 @@ func NewTree(cfg Config) (*Tree, error) {
 }
 
 // NewTreeWithTx returns a new Tree using the given db.WriteTx, which will not
-// be ccommited inside this method, if there is a Tree still in the given
+// be committed inside this method, if there is a Tree still in the given
 // database, it will load it.
 func NewTreeWithTx(wTx db.WriteTx, cfg Config) (*Tree, error) {
 	// if thresholdNLeafs is set to 0, use the DefaultThresholdNLeafs
@@ -575,7 +575,7 @@ func keyPathFromKey(maxLevels int, k []byte) ([]byte, error) {
 			len(k), maxLevels, maxKeyLen, len(k)*8, len(k))
 	}
 	keyPath := make([]byte, maxKeyLen)
-	copy(keyPath[:], k)
+	copy(keyPath, k)
 	return keyPath, nil
 }
 
@@ -770,7 +770,7 @@ func (t *Tree) newLeafValue(k, v []byte) ([]byte, []byte, error) {
 
 // newLeafValue takes a key & value from a leaf, and computes the leaf hash,
 // which is used as the leaf key. And the value is the concatenation of the
-// inputed key & value. The output of this function is used as key-value to
+// inputted key & value. The output of this function is used as key-value to
 // store the leaf in the DB.
 // [     1 byte   |     1 byte    | N bytes | M bytes ]
 // [ type of node | length of key |   key   |  value  ]
@@ -1104,7 +1104,7 @@ func CheckProof(hashFunc HashFunction, k, v, root, packedSiblings []byte) (bool,
 	}
 
 	keyPath := make([]byte, int(math.Ceil(float64(len(siblings))/float64(8))))
-	copy(keyPath[:], k)
+	copy(keyPath, k)
 
 	key, _, err := newLeafValue(hashFunc, k, v)
 	if err != nil {
@@ -1125,7 +1125,7 @@ func CheckProof(hashFunc HashFunction, k, v, root, packedSiblings []byte) (bool,
 			}
 		}
 	}
-	if bytes.Equal(key[:], root) {
+	if bytes.Equal(key, root) {
 		return true, nil
 	}
 	return false, nil

--- a/tree/arbo/utils.go
+++ b/tree/arbo/utils.go
@@ -17,8 +17,8 @@ func SwapEndianness(b []byte) []byte {
 func BigIntToBytes(blen int, bi *big.Int) []byte {
 	// TODO make the length depending on the tree.hashFunction.Len()
 	b := make([]byte, blen)
-	copy(b[:], SwapEndianness(bi.Bytes()))
-	return b[:]
+	copy(b, SwapEndianness(bi.Bytes()))
+	return b
 }
 
 // BytesToBigInt converts a byte array in Little-Endian representation into

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -48,7 +48,7 @@ func SplitBytes(buf []byte, lim int) [][]byte {
 		chunks = append(chunks, chunk)
 	}
 	if len(buf) > 0 {
-		chunks = append(chunks, buf[:])
+		chunks = append(chunks, buf)
 	}
 	return chunks
 }

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -39,7 +39,7 @@ func NewPrivateValidator(tmPrivKey, keyFilePath, stateFilePath string) (*privval
 			return nil, fmt.Errorf("cannot decode private key: (%s)", err)
 		}
 		privKey = make([]byte, crypto256k1.PrivKeySize)
-		if n := copy(privKey[:], keyBytes[:]); n != crypto256k1.PrivKeySize {
+		if n := copy(privKey[:], keyBytes); n != crypto256k1.PrivKeySize {
 			return nil, fmt.Errorf("incorrect private key length (got %d, need %d)", n, crypto25519.PrivateKeySize)
 		}
 		pv.Key.Address = privKey.PubKey().Address()

--- a/vochain/genesis/txcost.go
+++ b/vochain/genesis/txcost.go
@@ -6,7 +6,6 @@ import (
 	"go.vocdoni.io/proto/build/go/models"
 )
 
-// ________________________ TRANSACTION COSTS __________________________
 // TransactionCosts describes how much each operation should cost
 type TransactionCosts struct {
 	SetProcessStatus        uint32 `json:"Tx_SetProcessStatus"`

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -518,7 +518,7 @@ func (idx *Indexer) OnProcessesStart(pids [][]byte) {
 	}
 }
 
-// NOT USED but required for implementing the vochain.EventListener interface
+// OnSetAccount NOT USED but required for implementing the vochain.EventListener interface
 func (idx *Indexer) OnSetAccount(addr []byte, account *state.Account) {}
 
 func (idx *Indexer) OnTransferTokens(tx *vochaintx.TokenTransfer) {

--- a/vochain/processid/process_id.go
+++ b/vochain/processid/process_id.go
@@ -75,7 +75,7 @@ func (p *ProcessID) Unmarshal(pid []byte) error {
 	p.chainID = fmt.Sprintf("%x", pid[:4])
 
 	baddr := make([]byte, 20)
-	copy(baddr[:], pid[6:26])
+	copy(baddr, pid[6:26])
 	p.organizationAddr = common.BytesToAddress(baddr)
 
 	p.censusOrigin = uint8(binary.BigEndian.Uint16(append([]byte{0x00}, pid[26:27]...)))

--- a/vochain/state/balances.go
+++ b/vochain/state/balances.go
@@ -55,9 +55,9 @@ func (v *State) SetTreasurer(address common.Address, nonce uint32) error {
 }
 
 // Treasurer returns the address and the Treasurer nonce
-// When committed is false, the operation is executed also on not yet commited
+// When committed is false, the operation is executed also on not yet committed
 // data from the currently open StateDB transaction.
-// When committed is true, the operation is executed on the last commited version.
+// When committed is true, the operation is executed on the last committed version.
 func (v *State) Treasurer(committed bool) (*models.Treasurer, error) {
 	if !committed {
 		v.Tx.RLock()
@@ -123,7 +123,7 @@ func (v *State) VerifyTreasurer(addr common.Address, txNonce uint32) error {
 	return nil
 }
 
-// SetTxCost sets the given transaction cost
+// SetTxBaseCost sets the given transaction cost
 func (v *State) SetTxBaseCost(txType models.TxType, cost uint64) error {
 	key, ok := TxTypeCostToStateKey[txType]
 	if !ok {
@@ -133,14 +133,14 @@ func (v *State) SetTxBaseCost(txType models.TxType, cost uint64) error {
 	defer v.Tx.Unlock()
 	log.Debugf("setting tx cost %d for tx %s", cost, txType.String())
 	costBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(costBytes[:], cost)
-	return v.Tx.DeepSet([]byte(key), costBytes[:], StateTreeCfg(TreeExtra))
+	binary.LittleEndian.PutUint64(costBytes, cost)
+	return v.Tx.DeepSet([]byte(key), costBytes, StateTreeCfg(TreeExtra))
 }
 
 // TxBaseCost returns the base cost of a given transaction
-// When committed is false, the operation is executed also on not yet commited
+// When committed is false, the operation is executed also on not yet committed
 // data from the currently open StateDB transaction.
-// When committed is true, the operation is executed on the last commited version.
+// When committed is true, the operation is executed on the last committed version.
 func (v *State) TxBaseCost(txType models.TxType, committed bool) (uint64, error) {
 	key, ok := TxTypeCostToStateKey[txType]
 	if !ok {

--- a/vochain/state/state.go
+++ b/vochain/state/state.go
@@ -513,7 +513,8 @@ func (v *State) Rollback() {
 	v.Tx.Discard()
 	var err error
 	if v.Tx.TreeTx, err = v.Store.BeginTx(); err != nil {
-		log.Fatalf("cannot begin statedb tx: %s", err)
+		log.Errorf("cannot begin statedb tx: %s", err)
+		return
 	}
 	v.txCounter.Store(0)
 }

--- a/vochain/transaction/election_tx.go
+++ b/vochain/transaction/election_tx.go
@@ -97,24 +97,23 @@ func (t *TransactionHandler) NewProcessTxCheck(vtx *vochaintx.Tx,
 	// if organization ID is not set, use the sender address
 	if tx.Process.EntityId == nil {
 		tx.Process.EntityId = addr.Bytes()
-	} else {
-		// check if process entityID matches tx sender
-		if !bytes.Equal(tx.Process.EntityId, addr.Bytes()) {
-			// check for a delegate
-			entityAddress := ethereum.AddrFromBytes(tx.Process.EntityId)
-			entityAccount, err := t.state.GetAccount(entityAddress, false)
-			if err != nil {
-				return nil, ethereum.Address{}, fmt.Errorf(
-					"cannot get organization account for checking if the sender is a delegate: %w", err,
-				)
-			}
-			if entityAccount == nil {
-				return nil, ethereum.Address{}, fmt.Errorf("organization account %s does not exists", addr.Hex())
-			}
-			if !entityAccount.IsDelegate(*addr) {
-				return nil, ethereum.Address{}, fmt.Errorf(
-					"account %s unauthorized to create a new election on this organization", addr.Hex())
-			}
+
+	} else if !bytes.Equal(tx.Process.EntityId, addr.Bytes()) { // check if process entityID matches tx sender
+
+		// check for a delegate
+		entityAddress := ethereum.AddrFromBytes(tx.Process.EntityId)
+		entityAccount, err := t.state.GetAccount(entityAddress, false)
+		if err != nil {
+			return nil, ethereum.Address{}, fmt.Errorf(
+				"cannot get organization account for checking if the sender is a delegate: %w", err,
+			)
+		}
+		if entityAccount == nil {
+			return nil, ethereum.Address{}, fmt.Errorf("organization account %s does not exists", addr.Hex())
+		}
+		if !entityAccount.IsDelegate(*addr) {
+			return nil, ethereum.Address{}, fmt.Errorf(
+				"account %s unauthorized to create a new election on this organization", addr.Hex())
 		}
 	}
 


### PR DESCRIPTION
- #1020 

- nested if can be replaced with else if  `CRT-A0011`

- switch with single case can be rewritten as if or if-else `CRT-A0014`

- simplify slice expression to sliced value itself  `CRT-A0016`

- call to os.Exit or log.Fatal and friends made in function using defer `CRT-D0011`

- fix comments `GO-D5001, GO-D5001, GO-D5003`

- potential slowloris attack (add timeout to the server) `GO-S2112`

-  fix typos, remove unnecessary type conversion