### PR TITLE
api: avoid double-encoding Vote.VotePackage responses

### DIFF
--- a/api/api_types.go
+++ b/api/api_types.go
@@ -109,19 +109,19 @@ type Key struct {
 }
 
 type Vote struct {
-	TxPayload            []byte         `json:"txPayload,omitempty"`
-	TxHash               types.HexBytes `json:"txHash,omitempty"`
-	VoteID               types.HexBytes `json:"voteID,omitempty"`
-	EncryptionKeyIndexes []uint32       `json:"encryptionKeys,omitempty"`
-	VotePackage          string         `json:"package,omitempty"`
-	VoteWeight           string         `json:"weight,omitempty"`
-	VoteNumber           *uint32        `json:"number,omitempty"`
-	ElectionID           types.HexBytes `json:"electionID,omitempty"`
-	VoterID              types.HexBytes `json:"voterID,omitempty"`
-	BlockHeight          uint32         `json:"blockHeight,omitempty"`
-	TransactionIndex     *int32         `json:"transactionIndex,omitempty"`
-	OverwriteCount       *uint32        `json:"overwriteCount,omitempty"`
-	Date                 *time.Time     `json:"date,omitempty"`
+	TxPayload            []byte          `json:"txPayload,omitempty"`
+	TxHash               types.HexBytes  `json:"txHash,omitempty"`
+	VoteID               types.HexBytes  `json:"voteID,omitempty"`
+	EncryptionKeyIndexes []uint32        `json:"encryptionKeys,omitempty"`
+	VotePackage          json.RawMessage `json:"package,omitempty"`
+	VoteWeight           string          `json:"weight,omitempty"`
+	VoteNumber           *uint32         `json:"number,omitempty"`
+	ElectionID           types.HexBytes  `json:"electionID,omitempty"`
+	VoterID              types.HexBytes  `json:"voterID,omitempty"`
+	BlockHeight          uint32          `json:"blockHeight,omitempty"`
+	TransactionIndex     *int32          `json:"transactionIndex,omitempty"`
+	OverwriteCount       *uint32         `json:"overwriteCount,omitempty"`
+	Date                 *time.Time      `json:"date,omitempty"`
 }
 
 type CensusTypeDescription struct {

--- a/api/vote.go
+++ b/api/vote.go
@@ -114,7 +114,7 @@ func (a *API) getVoteHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) 
 
 	// If VotePackage is valid JSON, it's not encrypted, so we can include it.
 	if json.Valid(voteData.VotePackage) {
-		vote.VotePackage = string(voteData.VotePackage)
+		vote.VotePackage = voteData.VotePackage
 	}
 
 	var data []byte


### PR DESCRIPTION
(see commit message)

