### PR TITLE
indexer: GetEnvelope now includes VoterID in returned envelope

### DIFF
--- a/vochain/indexer/vote.go
+++ b/vochain/indexer/vote.go
@@ -41,6 +41,7 @@ func (idx *Indexer) GetEnvelope(nullifier []byte) (*indexertypes.EnvelopePackage
 		OverwriteCount:       uint32(voteRef.OverwriteCount),
 		Date:                 voteRef.BlockTime,
 		Meta: indexertypes.EnvelopeMetadata{
+			VoterID:   voteRef.VoterID.Address(),
 			ProcessId: voteRef.ProcessID,
 			Nullifier: nullifier,
 			TxIndex:   int32(voteRef.BlockIndex),


### PR DESCRIPTION
Until now, the returned envelope was missing this field,
causing the endpoint `GET /votes/{voteId}` to return a nil VoterID
