### PR TITLE
fix/api/err transaction not found

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -33,7 +33,7 @@ var (
 	ErrAccountAlreadyExists             = apirest.APIerror{Code: 4004, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("account already exists")}
 	ErrTreasurerNotFound                = apirest.APIerror{Code: 4005, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("treasurer account not found")}
 	ErrOrgNotFound                      = apirest.APIerror{Code: 4006, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("organization not found")}
-	ErrTransactionNotFound              = apirest.APIerror{Code: 4007, HTTPstatus: apirest.HTTPstatusNoContent, Err: fmt.Errorf("transaction hash not found")}
+	ErrTransactionNotFound              = apirest.APIerror{Code: 4007, HTTPstatus: apirest.HTTPstatusNoContent, Err: fmt.Errorf("transaction not found")}
 	ErrBlockNotFound                    = apirest.APIerror{Code: 4008, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("block not found")}
 	ErrMetadataProvidedButNoURI         = apirest.APIerror{Code: 4009, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("metadata provided but no metadata URI found in transaction")}
 	ErrMetadataURINotMatchContent       = apirest.APIerror{Code: 4010, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("metadata URI does not match metadata content")}


### PR DESCRIPTION
This PR fixes some errors and what I think are not desired behaviours, related to 204 HTTP status code and ErrTransactionNotFound:

- The ErrTransactionNotFound message changes from: "transaction hash not found" to "transaction not found" because it is used for other transaction API calls that are not limited to work with hashes.

- I've found that 204 http error code was used just in the ErrTransactionNotFound specific error case and it does make sense to keep using 404 errors for any kind of error like this. With this reasoning this commit changes the error code from 204 to 404.
Adding @marcvelmer to the conversation as probably affects the SDK.

- Finally, the Send() method of the httprouter was not writing nicely a void data stream required by the HTTP standard when handling 204 errors, aka not calling the Writer.Write() function in the server code.
This raised some errors in clients interacting with the API, returing a `HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)` error. Hopefully this will be avoided in the future with the changes.

Please do not squash. See commit messages.

cc: @selankon @mvdan @elboletaire 
