### PR TITLE
fix: deepsource issues

### DIFF
--- a/data/ipfs/metrics.go
+++ b/data/ipfs/metrics.go
@@ -38,8 +38,8 @@ func (i *Handler) registerMetrics(ma *metrics.Agent) {
 	ma.Register(FilePins)
 }
 
-// GetMetrics to be called as a loop and grab metrics
-func (i *Handler) getMetrics(ctx context.Context) error {
+// setMetrics to be called as a loop and grab metrics
+func (i *Handler) setMetrics(ctx context.Context) error {
 	peers, err := i.CoreAPI.Swarm().Peers(ctx)
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func (i *Handler) CollectMetrics(ctx context.Context, ma *metrics.Agent) error {
 		for {
 			time.Sleep(ma.RefreshInterval)
 			tctx, cancel := context.WithTimeout(ctx, time.Minute)
-			err := i.getMetrics(tctx)
+			err := i.setMetrics(tctx)
 			cancel()
 			if err != nil {
 				return err

--- a/httprouter/apirest/apirest.go
+++ b/httprouter/apirest/apirest.go
@@ -99,29 +99,33 @@ func (e APIerror) Send(ctx *httprouter.HTTPContext) error {
 }
 
 // Withf returns a copy of APIerror with the Sprintf formatted string appended at the end of e.Err
-// Original e.Err is wrapped inside, so you can still match with errors.Is()
 func (e APIerror) Withf(format string, args ...interface{}) APIerror {
-	e.Err = fmt.Errorf("%w: %v", e.Err, fmt.Sprintf(format, args...))
-	return e
+	return APIerror{
+		Err:        fmt.Errorf("%w: %v", e.Err, fmt.Sprintf(format, args...)),
+		Code:       e.Code,
+		HTTPstatus: e.HTTPstatus,
+	}
 }
 
 // With returns a copy of APIerror with the string appended at the end of e.Err
-// Original e.Err is wrapped inside, so you can still match with errors.Is()
 func (e APIerror) With(s string) APIerror {
-	e.Err = fmt.Errorf("%w: %v", e.Err, s)
-	return e
+	return APIerror{
+		Err:        fmt.Errorf("%w: %v", e.Err, s),
+		Code:       e.Code,
+		HTTPstatus: e.HTTPstatus,
+	}
 }
 
 // WithErr returns a copy of APIerror with err.Error() appended at the end of e.Err
-// Original e.Err is wrapped inside, so you can still match with errors.Is()
-//
-// TODO: wrap both errors instead, as soon as we get Go 1.20
 func (e APIerror) WithErr(err error) APIerror {
-	e.Err = fmt.Errorf("%w: %v", e.Err, err.Error())
-	return e
+	return APIerror{
+		Err:        fmt.Errorf("%w: %v", e.Err, err.Error()),
+		Code:       e.Code,
+		HTTPstatus: e.HTTPstatus,
+	}
 }
 
-// NewAPI returns a API initialized type
+// NewAPI returns an API initialized type
 func NewAPI(router *httprouter.HTTProuter, baseRoute string) (*API, error) {
 	if router == nil {
 		panic("httprouter is nil")

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func newTestIndexer(tb testing.TB, app *vochain.BaseApplication, countLiveResults bool) *Indexer {
-	idx, err := NewIndexer(tb.TempDir(), app, true)
+	idx, err := NewIndexer(tb.TempDir(), app, countLiveResults)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/vochain/processid/process_id.go
+++ b/vochain/processid/process_id.go
@@ -1,6 +1,7 @@
 package processid
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -49,11 +50,13 @@ func (p *ProcessID) Marshal() []byte {
 	envType := make([]byte, 2)
 	binary.BigEndian.PutUint16(envType, uint16(p.envType))
 
-	var id []byte
-	id = append(chainID[:6], p.organizationAddr.Bytes()[:20]...)
-	id = append(id, proofType[1:]...)
-	id = append(id, envType[1:]...)
-	return append(id, nonce[:4]...)
+	var id bytes.Buffer
+	id.Write(chainID[:6])
+	id.Write(p.organizationAddr.Bytes()[:20])
+	id.Write(proofType[1:])
+	id.Write(envType[1:])
+	id.Write(nonce[:4])
+	return id.Bytes()
 }
 
 // MarshalBinary implements the BinaryMarshaler interface

--- a/vochain/state/snapshot.go
+++ b/vochain/state/snapshot.go
@@ -387,14 +387,14 @@ func (v *State) installSnapshot(height uint32) error {
 }
 */
 
-type diskSnapshotInfo struct {
+type DiskSnapshotInfo struct {
 	ModTime time.Time
 	Height  uint32
 	Size    int64
 }
 
 // ListSnapshots returns the list of the current state snapshots stored in disk.
-func (v *State) ListSnapshots() []diskSnapshotInfo {
+func (v *State) ListSnapshots() []DiskSnapshotInfo {
 	files, err := os.ReadDir(filepath.Join(
 		v.dataDir,
 		storageDirectory,
@@ -402,7 +402,7 @@ func (v *State) ListSnapshots() []diskSnapshotInfo {
 	if err != nil {
 		log.Fatal(err)
 	}
-	var list []diskSnapshotInfo
+	var list []DiskSnapshotInfo
 	for _, file := range files {
 		if !file.IsDir() {
 			height, err := strconv.Atoi(file.Name())
@@ -415,7 +415,7 @@ func (v *State) ListSnapshots() []diskSnapshotInfo {
 				log.Errorw(err, "could not list snapshot file")
 				continue
 			}
-			list = append(list, diskSnapshotInfo{
+			list = append(list, DiskSnapshotInfo{
 				Size:    fileInfo.Size(),
 				ModTime: fileInfo.ModTime(),
 				Height:  uint32(height),

--- a/vochain/transaction/election_tx.go
+++ b/vochain/transaction/election_tx.go
@@ -19,8 +19,7 @@ import (
 )
 
 // NewProcessTxCheck is an abstraction of ABCI checkTx for creating a new process
-func (t *TransactionHandler) NewProcessTxCheck(vtx *vochaintx.Tx,
-	forCommit bool) (*models.Process, ethereum.Address, error) {
+func (t *TransactionHandler) NewProcessTxCheck(vtx *vochaintx.Tx) (*models.Process, ethereum.Address, error) {
 	if vtx.Tx == nil || vtx.Signature == nil || vtx.SignedBody == nil {
 		return nil, ethereum.Address{}, ErrNilTx
 	}
@@ -149,7 +148,7 @@ func (t *TransactionHandler) NewProcessTxCheck(vtx *vochaintx.Tx,
 }
 
 // SetProcessTxCheck is an abstraction of ABCI checkTx for canceling an existing process
-func (t *TransactionHandler) SetProcessTxCheck(vtx *vochaintx.Tx, forCommit bool) (ethereum.Address, error) {
+func (t *TransactionHandler) SetProcessTxCheck(vtx *vochaintx.Tx) (ethereum.Address, error) {
 	// check vtx.Signature available
 	if vtx.Signature == nil || vtx.Tx == nil || vtx.SignedBody == nil {
 		return ethereum.Address{}, ErrNilTx

--- a/vochain/transaction/transaction.go
+++ b/vochain/transaction/transaction.go
@@ -111,7 +111,7 @@ func (t *TransactionHandler) CheckTx(vtx *vochaintx.Tx, forCommit bool) (*Transa
 		}
 
 	case *models.Tx_NewProcess:
-		p, txSender, err := t.NewProcessTxCheck(vtx, forCommit)
+		p, txSender, err := t.NewProcessTxCheck(vtx)
 		if err != nil {
 			return nil, fmt.Errorf("newProcessTx: %w", err)
 		}
@@ -143,7 +143,7 @@ func (t *TransactionHandler) CheckTx(vtx *vochaintx.Tx, forCommit bool) (*Transa
 		}
 
 	case *models.Tx_SetProcess:
-		txSender, err := t.SetProcessTxCheck(vtx, forCommit)
+		txSender, err := t.SetProcessTxCheck(vtx)
 		if err != nil {
 			return nil, fmt.Errorf("setProcessTx: %w", err)
 		}

--- a/vochain/vochaininfo/metrics.go
+++ b/vochain/vochaininfo/metrics.go
@@ -64,8 +64,8 @@ func (vi *VochainInfo) registerMetrics(ma *metrics.Agent) {
 	ma.Register(VochainVoteCache)
 }
 
-// getMetrics updates the metrics values to the current state
-func (vi *VochainInfo) getMetrics() {
+// setMetrics updates the metrics values to the current state
+func (vi *VochainInfo) setMetrics() {
 	VochainHeight.Set(float64(vi.Height()))
 	VochainMempool.Set(float64(vi.MempoolSize()))
 	p, v, vxm := vi.TreeSizes()
@@ -83,7 +83,7 @@ func (vi *VochainInfo) CollectMetrics(ma *metrics.Agent) {
 		vi.registerMetrics(ma)
 		for {
 			time.Sleep(ma.RefreshInterval)
-			vi.getMetrics()
+			vi.setMetrics()
 		}
 	}
 }


### PR DESCRIPTION
### Issues: 

- Functions prefixed with Get should return a value RVV-A0006

Example
```
func (vi *VochainInfo) getMetrics() {

	VochainHeight.Set(float64(vi.Height()))

	VochainMempool.Set(float64(vi.MempoolSize()))

	p, v, vxm := vi.TreeSizes()
```

- Method modifies receiver RVV-B0006

Example:
```
func (e APIerror) With(s string) APIerror {

	e.Err = fmt.Errorf("%w: %v", e.Err, s)

	return e

}
```

- Append possibly assigns to a wrong variable CRT-D0001 (when is possible keep the pattern to append to the same slice)



- Exported function returning value of unexported type RVV-B0011

Example:
```
func (v *State) ListSnapshots() []diskSnapshotInfo {
...
}
```

- Unused parameter in function RVV-B0012 

Note: many recommendation for this issue was omitted in cases like:  
`func (a *API) tokenTransfersHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {} `  msg is not used

And in cases like:
`func (idx *Indexer) OnProcessStatusChange(pid []byte, status models.ProcessStatus, txIndex int32) {}`

```
func (l *Listener) OnCancel(pid []byte, txIndex int32)                                           {}

func (l *Listener) OnProcessKeys(pid []byte, encryptionPub string, txIndex int32)                {}

func (l *Listener) OnRevealKeys(pid []byte, encryptionPriv string, txIndex int32)                {}

func (l *Listener) OnProcessResults(pid []byte, results *models.ProcessResult, txIndex int32) {

}
```
