### PR TITLE
indexer: set endblock to the actual end block for an election

### DIFF
--- a/api/api_types.go
+++ b/api/api_types.go
@@ -33,6 +33,7 @@ type ElectionSummary struct {
 	VoteCount      uint64            `json:"voteCount"`
 	FinalResults   bool              `json:"finalResults"`
 	Results        [][]*types.BigInt `json:"result,omitempty"`
+	ManuallyEnded  bool              `json:"manuallyEnded"`
 }
 
 // ElectionResults is the struct used to wrap the results of an election

--- a/api/elections.go
+++ b/api/elections.go
@@ -153,6 +153,7 @@ func (a *API) electionFullListHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 			EndDate:        a.vocinfo.HeightTime(int64(e.EndBlock)),
 			FinalResults:   e.FinalResults,
 			VoteCount:      e.VoteCount,
+			ManuallyEnded:  e.EndBlock < e.StartBlock+e.BlockCount,
 		})
 	}
 	// wrap list in a struct to consistently return list in a object, return empty
@@ -198,6 +199,7 @@ func (a *API) electionHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext)
 			EndDate:        a.vocinfo.HeightTime(int64(proc.EndBlock)),
 			FinalResults:   proc.FinalResults,
 			VoteCount:      proc.VoteCount,
+			ManuallyEnded:  proc.EndBlock < proc.StartBlock+proc.BlockCount,
 		},
 		MetadataURL:  proc.Metadata,
 		CreationTime: proc.CreationTime,
@@ -680,6 +682,7 @@ func (a *API) electionFilterPaginatedHandler(msg *apirest.APIdata, ctx *httprout
 			EndDate:        a.vocinfo.HeightTime(int64(e.EndBlock)),
 			FinalResults:   e.FinalResults,
 			VoteCount:      e.VoteCount,
+			ManuallyEnded:  e.EndBlock < e.StartBlock+e.BlockCount,
 		})
 	}
 	data, err := json.Marshal(struct {

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -586,6 +586,9 @@ func (app *BaseApplication) CircuitConfigurationTag() string {
 
 // IsSynchronizing informes if the blockchain is synchronizing or not.
 func (app *BaseApplication) isSynchronizingTendermint() bool {
+	if app.Service == nil {
+		return true
+	}
 	return app.Service.(*node.Node).ConsensusReactor().WaitSync()
 }
 

--- a/vochain/indexer/db/models.go
+++ b/vochain/indexer/db/models.go
@@ -22,6 +22,7 @@ type Process struct {
 	EntityID           types.EntityID
 	StartBlock         int64
 	EndBlock           int64
+	BlockCount         int64
 	HaveResults        bool
 	FinalResults       bool
 	ResultsVotes       string

--- a/vochain/indexer/indexertypes/types.go
+++ b/vochain/indexer/indexertypes/types.go
@@ -21,6 +21,7 @@ type Process struct {
 	EntityID          types.HexBytes             `json:"entityId"`
 	StartBlock        uint32                     `json:"startBlock"`
 	EndBlock          uint32                     `json:"endBlock"`
+	BlockCount        uint32                     `json:"blockCount"`
 	CensusRoot        types.HexBytes             `json:"censusRoot"`
 	RollingCensusRoot types.HexBytes             `json:"rollingCensusRoot"`
 	CensusURI         string                     `json:"censusURI"`
@@ -66,6 +67,7 @@ func ProcessFromDB(dbproc *indexerdb.GetProcessRow) *Process {
 		EntityID:           nonEmptyBytes(dbproc.EntityID),
 		StartBlock:         uint32(dbproc.StartBlock),
 		EndBlock:           uint32(dbproc.EndBlock),
+		BlockCount:         uint32(dbproc.BlockCount),
 		HaveResults:        dbproc.HaveResults,
 		FinalResults:       dbproc.FinalResults,
 		CensusRoot:         nonEmptyBytes(dbproc.CensusRoot),

--- a/vochain/indexer/migrations/0001_create_table_processes.sql
+++ b/vochain/indexer/migrations/0001_create_table_processes.sql
@@ -4,6 +4,7 @@ CREATE TABLE processes (
   entity_id    BLOB NOT NULL,
   start_block  INTEGER NOT NULL,
   end_block    INTEGER NOT NULL,
+  block_count  INTEGER NOT NULL,
 
   have_results            BOOLEAN NOT NULL,
   final_results           BOOLEAN NOT NULL,

--- a/vochain/indexer/queries/processes.sql
+++ b/vochain/indexer/queries/processes.sql
@@ -1,6 +1,6 @@
 -- name: CreateProcess :execresult
 INSERT INTO processes (
-	id, entity_id, start_block, end_block,
+	id, entity_id, start_block, end_block, block_count,
 	have_results, final_results,
 	census_root, rolling_census_root, rolling_census_size,
 	max_census_size, census_uri, metadata,
@@ -12,7 +12,7 @@ INSERT INTO processes (
 
 	results_votes, results_weight, results_block_height
 ) VALUES (
-	?, ?, ?, ?,
+	?, ?, ?, ?, ?,
 	?, ?,
 	?, ?, ?,
 	?, ?, ?,
@@ -49,8 +49,7 @@ OFFSET sqlc.arg(offset)
 
 -- name: UpdateProcessFromState :execresult
 UPDATE processes
-SET end_block           = sqlc.arg(end_block),
-	census_root         = sqlc.arg(census_root),
+SET census_root         = sqlc.arg(census_root),
 	rolling_census_root = sqlc.arg(rolling_census_root),
 	census_uri          = sqlc.arg(census_uri),
 	private_keys        = sqlc.arg(private_keys),
@@ -110,4 +109,9 @@ SET results_votes  = sqlc.arg(votes),
     results_weight = sqlc.arg(weight),
     vote_opts_pb = sqlc.arg(vote_opts_pb),
     envelope_pb = sqlc.arg(envelope_pb)
+WHERE id = sqlc.arg(id);
+
+-- name: UpdateProcessEndBlock :execresult
+UPDATE processes
+SET end_block  = sqlc.arg(end_block)
 WHERE id = sqlc.arg(id);


### PR DESCRIPTION
If the election is ended manually, the indexer stores as endblock the current height.

Furthermore, add a new boolean value to let the API caller know that the election was ended manually.