### PR TITLE
api(swagger): split server url into schemes, host and BasePath

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -40,7 +40,10 @@ import (
 //	@tag.name			Wallet
 //	@tag.description	Operations for the wallets managed backend side
 
-//	@BasePath					https://api-dev.vocdoni.net/v2/
+//	@schemes	https
+//	@host		api-dev.vocdoni.net
+//	@BasePath	/v2
+
 //	@securityDefinitions.basic	BasicAuth
 
 // MaxPageSize defines the maximum number of results returned by the paginated endpoints


### PR DESCRIPTION
that's how it's meant to be parsed by swaggo