### PR TITLE
end2end: refactor generateProof

### DIFF
--- a/cmd/end2endtest/lifecycle.go
+++ b/cmd/end2endtest/lifecycle.go
@@ -45,7 +45,7 @@ func (t *E2ELifecycleElection) Setup(api *apiclient.HTTPclient, c *config) error
 		ed.d.ElectionType.Interruptible = ed.interruptible
 		ed.d.Census = vapi.CensusTypeDescription{Type: vapi.CensusTypeWeighted}
 
-		if err := t.elections[i].setupElection(ed.d); err != nil {
+		if err := t.elections[i].setupElection(ed.d, t.elections[0].config.nvotes); err != nil {
 			log.Errorf("failed to setup election %d: %v", i, err)
 		}
 	}

--- a/cmd/end2endtest/main.go
+++ b/cmd/end2endtest/main.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,13 +36,10 @@ type VochainTest interface {
 }
 
 type e2eElection struct {
-	api    *apiclient.HTTPclient
-	config *config
-
-	election      *vapi.Election
-	voterAccounts []*ethereum.SignKeys
-	proofs        map[string]*apiclient.CensusProof
-	sikproofs     map[string]*apiclient.CensusProof
+	api      *apiclient.HTTPclient
+	config   *config
+	election *vapi.Election
+	voters   *sync.Map // key:acc.Public, value: acctProof struct {account, proof, proofSik}
 }
 
 type operation struct {


### PR DESCRIPTION
We want to make `generateProof` more simple, so in this approach is used a sync.map `t.voters`, a map indexed by `key.PublicKey` that contains acctProof struct

```
type acctProof struct {
	account  *ethereum.SignKeys
	proof    *apiclient.CensusProof
	proofSIK *apiclient.CensusProof
}
```

Relevant changes: 
* use sync.map (key:acc.Public, value: acctProof struct)
* remove voterAccounts, proofs, sikproofs from e2eElection
* remove generateSIKProofs to use the general approach generateProofs
* add publishCheckCensus to separate the feature of publish and check census
* setupElection now has an extra parameter to specify the number of accounts wanted for the census. It allows to remove code and simplify the logic for censusize end2endtest