### PR TITLE
end2end: update sendVotes to avoid infinite for loop

### DIFF
--- a/cmd/end2endtest/ballot.go
+++ b/cmd/end2endtest/ballot.go
@@ -85,7 +85,10 @@ func (t *E2EBallotElection) Run() error {
 			VoterAccount: acct,
 		})
 	}
-	t.sendVotes(votes)
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
 
 	log.Infow("votes submitted successfully",
 		"n", len(t.voterAccounts), "time", time.Since(startTime),

--- a/cmd/end2endtest/censusize.go
+++ b/cmd/end2endtest/censusize.go
@@ -71,7 +71,10 @@ func (t *E2EMaxCensusSizeElection) Run() error {
 			VoterAccount: acct,
 		})
 	}
-	t.sendVotes(votes)
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
 
 	log.Infow("votes submitted successfully",
 		"n", len(t.voterAccounts[1:]), "time", time.Since(startTime),

--- a/cmd/end2endtest/csp.go
+++ b/cmd/end2endtest/csp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -75,7 +76,10 @@ func (t *E2ECSPElection) Run() error {
 			VoterAccount: acct,
 		})
 	}
-	t.sendVotes(votes)
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
 
 	log.Infow("votes submitted successfully",
 		"n", c.nvotes, "time", time.Since(startTime),

--- a/cmd/end2endtest/dynamicensus.go
+++ b/cmd/end2endtest/dynamicensus.go
@@ -134,7 +134,11 @@ func (t *E2EDynamicensusElection) Run() error {
 				VoterAccount: acct,
 			})
 		}
-		t.elections[0].sendVotes(votes)
+		errs := t.elections[0].sendVotes(votes)
+		if len(errs) > 0 {
+			errCh <- fmt.Errorf("error from electionID: %s, %+v", electionID, errs)
+			return
+		}
 
 		log.Infow("votes submitted successfully",
 			"n", len(t.elections[0].voterAccounts[1:]), "time", time.Since(startTime),
@@ -252,7 +256,11 @@ func (t *E2EDynamicensusElection) Run() error {
 				VoterAccount: acct,
 			})
 		}
-		t.elections[1].sendVotes(votes)
+		errs := t.elections[1].sendVotes(votes)
+		if len(errs) > 0 {
+			errCh <- fmt.Errorf("error from electionID: %s, %+v", electionID, errs)
+			return
+		}
 
 		log.Infow("votes submitted successfully",
 			"n", len(t.elections[1].voterAccounts[1:]), "time", time.Since(startTime),

--- a/cmd/end2endtest/encrypted.go
+++ b/cmd/end2endtest/encrypted.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -72,7 +73,10 @@ func (t *E2EEncryptedElection) Run() error {
 			Keys:         keys,
 		})
 	}
-	t.sendVotes(votes)
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
 
 	log.Infow("votes submitted successfully",
 		"n", len(t.voterAccounts), "time", time.Since(startTime),

--- a/cmd/end2endtest/overwrite.go
+++ b/cmd/end2endtest/overwrite.go
@@ -67,7 +67,10 @@ func (t *E2EOverwriteElection) Run() error {
 			VoterAccount: acct,
 		})
 	}
-	t.sendVotes(votes)
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
 
 	log.Infow("votes submitted successfully",
 		"n", c.nvotes, "time", time.Since(startTime),

--- a/cmd/end2endtest/plaintext.go
+++ b/cmd/end2endtest/plaintext.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -64,7 +65,10 @@ func (t *E2EPlaintextElection) Run() error {
 			VoterAccount: acct,
 		})
 	}
-	t.sendVotes(votes)
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
 
 	log.Infow("votes submitted successfully",
 		"n", c.nvotes, "time", time.Since(startTime),

--- a/cmd/end2endtest/zkweighted.go
+++ b/cmd/end2endtest/zkweighted.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"math/big"
 	"os"
 	"time"
@@ -65,7 +66,10 @@ func (t *E2EAnonElection) Run() error {
 			VoteWeight:   big.NewInt(defaultWeight / 2),
 		})
 	}
-	t.sendVotes(votes)
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
 
 	log.Infow("votes submitted successfully",
 		"n", len(t.voterAccounts), "time", time.Since(startTime),


### PR DESCRIPTION
Currently in the approach for send a batch of votes `sendVotes` is possible to experiment a infinite for loop, due in some cases the error is handled with a log using `log.Warn(err)` or it is just ignored and continue, in order to prevent the infinite loop a couple of variables was added to count each of those errors and if the count reach the max count allowed, that error is added to the slice of error returned by the method. 

Also, currently the errs returned by the `sendVotes` is not been checked in each test, it was also included in this change. 

And in the other hand `overwriteVote` was simplified to not use `sendVotes` as intermediary method, instead just use `api.Vote` and check the error once.