### PR TITLE
end2end: extent ballot test

### DIFF
--- a/cmd/end2endtest/ballot.go
+++ b/cmd/end2endtest/ballot.go
@@ -2,112 +2,367 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"time"
 
+	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
+const (
+	rankedVote    = "ranked"
+	quadraticVote = "quadratic"
+	rangeVote     = "range"
+	approvalVote  = "approval"
+)
+
 func init() {
-	ops["ballotelection"] = operation{
-		test:        &E2EBallotElection{},
-		description: "ballot election with unique values, maxCount, maxValue, maxTotalCost to test different ballotProtocol configurations",
-		example:     os.Args[0] + " --operation=ballotelection --votes=1000",
+	ops["ballotRanked"] = operation{
+		test:        &E2EBallotRanked{},
+		description: "ballot election to test ranked voting",
+		example:     os.Args[0] + " --operation=ballotRanked --votes=1000",
+	}
+	ops["ballotQuadratic"] = operation{
+		test:        &E2EBallotQuadratic{},
+		description: "ballot election to test quadratic voting",
+		example:     os.Args[0] + " --operation=ballotQuadratic --votes=1000",
+	}
+	ops["ballotRange"] = operation{
+		test:        &E2EBallotRange{},
+		description: "ballot election to test range voting",
+		example:     os.Args[0] + " --operation=ballotRange --votes=1000",
+	}
+	ops["ballotApproval"] = operation{
+		test:        &E2EBallotApproval{},
+		description: "ballot election to test approval voting",
+		example:     os.Args[0] + " --operation=ballotApproval --votes=1000",
 	}
 }
 
-var _ VochainTest = (*E2EBallotElection)(nil)
+var _ VochainTest = (*E2EBallotRanked)(nil)
+var _ VochainTest = (*E2EBallotQuadratic)(nil)
+var _ VochainTest = (*E2EBallotRange)(nil)
+var _ VochainTest = (*E2EBallotApproval)(nil)
 
-type E2EBallotElection struct {
-	e2eElection
-}
+type E2EBallotRanked struct{ e2eElection }
+type E2EBallotQuadratic struct{ e2eElection }
+type E2EBallotRange struct{ e2eElection }
+type E2EBallotApproval struct{ e2eElection }
 
-func (t *E2EBallotElection) Setup(api *apiclient.HTTPclient, c *config) error {
+func (t *E2EBallotRanked) Setup(api *apiclient.HTTPclient, c *config) error {
 	t.api = api
 	t.config = c
 
-	p := &models.Process{
-		StartBlock: 0,
-		BlockCount: 100,
-		Status:     models.ProcessStatus_READY,
-		EnvelopeType: &models.EnvelopeType{
-			EncryptedVotes: false,
-			UniqueValues:   true},
-		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED,
-		VoteOptions: &models.ProcessVoteOptions{
-			MaxCount:     2,
-			MaxValue:     6,
-			MaxTotalCost: 10,
-			CostExponent: 1,
-		},
-		Mode: &models.ProcessMode{
-			AutoStart:     true,
-			Interruptible: true,
-		},
-		MaxCensusSize: uint64(t.config.nvotes),
+	//setup for ranked voting
+	p := newTestProcess()
+	p.VoteOptions = &models.ProcessVoteOptions{
+		MaxCount:     4,
+		MaxValue:     3,
+		MaxTotalCost: 6,
+		CostExponent: 1,
 	}
 
 	if err := t.setupElectionRaw(p); err != nil {
-		return err
+		return fmt.Errorf("error in setupElectionRaw for ranked voting: %s", err)
 	}
 
 	log.Debugf("election details: %+v", *t.election)
 	return nil
 }
 
-func (*E2EBallotElection) Teardown() error {
+func (*E2EBallotRanked) Teardown() error {
 	// nothing to do here
 	return nil
 }
 
-func (t *E2EBallotElection) Run() error {
-	bdata := ballotData{
-		maxValue:     t.election.TallyMode.MaxValue,
-		maxCount:     t.election.TallyMode.MaxCount,
-		maxTotalCost: t.election.TallyMode.MaxTotalCost,
-		costExponent: t.election.TallyMode.CostExponent,
+func (t *E2EBallotRanked) Run() error {
+	nvotes := t.config.nvotes
+
+	choices, expectedResults := ballotVotes(
+		t.election.TallyMode, nvotes,
+		rankedVote, t.election.VoteMode.UniqueValues)
+
+	if err := sendAndValidateVotes(t.e2eElection, choices, expectedResults); err != nil {
+		return err
 	}
 
-	choices, expectedResults := ballotVotes(bdata, len(t.voterAccounts))
+	return nil
+}
 
-	// Send the votes (parallelized)
+func (t *E2EBallotQuadratic) Setup(api *apiclient.HTTPclient, c *config) error {
+	t.api = api
+	t.config = c
+
+	// setup for quadratic voting
+	p := newTestProcess()
+	// update uniqueValues to false
+	p.EnvelopeType.UniqueValues = false
+	p.VoteOptions = &models.ProcessVoteOptions{
+		MaxCount:     4,
+		MaxValue:     3,
+		MaxTotalCost: 12,
+		CostExponent: 2,
+	}
+
+	if err := t.setupElectionRaw(p); err != nil {
+		return fmt.Errorf("error in setupElectionRaw for quadratic voting: %s", err)
+	}
+
+	log.Debugf("election details: %+v", *t.election)
+	return nil
+}
+
+func (*E2EBallotQuadratic) Teardown() error {
+	// nothing to do here
+	return nil
+}
+
+func (t *E2EBallotQuadratic) Run() error {
+	nvotes := t.config.nvotes
+
+	choices, expectedResults := ballotVotes(
+		t.election.TallyMode, nvotes,
+		quadraticVote, t.election.VoteMode.UniqueValues)
+
+	if err := sendAndValidateVotes(t.e2eElection, choices, expectedResults); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *E2EBallotRange) Setup(api *apiclient.HTTPclient, c *config) error {
+	t.api = api
+	t.config = c
+
+	// setup for range voting
+	p := newTestProcess()
+	p.VoteOptions = &models.ProcessVoteOptions{
+		MaxCount:     4,
+		MaxValue:     3,
+		MaxTotalCost: 10,
+		CostExponent: 1,
+	}
+
+	if err := t.setupElectionRaw(p); err != nil {
+		return fmt.Errorf("error in setupElectionRaw for range voting: %s", err)
+	}
+
+	log.Debugf("election details: %+v", *t.election)
+	return nil
+}
+
+func (*E2EBallotRange) Teardown() error {
+	// nothing to do here
+	return nil
+}
+
+func (t *E2EBallotRange) Run() error {
+	nvotes := t.config.nvotes
+
+	choices, expectedResults := ballotVotes(
+		t.election.TallyMode, nvotes,
+		rangeVote, t.election.VoteMode.UniqueValues)
+
+	if err := sendAndValidateVotes(t.e2eElection, choices, expectedResults); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *E2EBallotApproval) Setup(api *apiclient.HTTPclient, c *config) error {
+	t.api = api
+	t.config = c
+
+	//setup for approval voting
+	p := newTestProcess()
+	// update uniqueValues to false
+	p.EnvelopeType.UniqueValues = false
+	p.VoteOptions = &models.ProcessVoteOptions{
+		MaxCount:     4,
+		MaxValue:     1,
+		MaxTotalCost: 4,
+		CostExponent: 1,
+	}
+
+	if err := t.setupElectionRaw(p); err != nil {
+		return fmt.Errorf("error in setupElectionRaw for approval voting: %s", err)
+	}
+
+	log.Debugf("election details: %+v", *t.election)
+	return nil
+}
+
+func (*E2EBallotApproval) Teardown() error {
+	// nothing to do here
+	return nil
+}
+
+func (t *E2EBallotApproval) Run() error {
+	nvotes := t.config.nvotes
+
+	choices, expectedResults := ballotVotes(
+		t.election.TallyMode, nvotes,
+		approvalVote, t.election.VoteMode.UniqueValues)
+
+	if err := sendAndValidateVotes(t.e2eElection, choices, expectedResults); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func sendAndValidateVotes(e e2eElection, choices [][]int, expectedResults [][]*types.BigInt) error {
+	nvotes := e.config.nvotes
 	startTime := time.Now()
 
-	log.Infow("enqueuing votes", "n", len(t.voterAccounts), "election", t.election.ElectionID)
+	log.Infow("enqueuing votes", "n", len(e.voterAccounts), "election", e.election.ElectionID)
 	votes := []*apiclient.VoteData{}
-	for i, acct := range t.voterAccounts {
+	for i, acct := range e.voterAccounts {
 		votes = append(votes, &apiclient.VoteData{
-			ElectionID:   t.election.ElectionID,
-			ProofMkTree:  t.proofs[acct.Address().Hex()],
+			ElectionID:   e.election.ElectionID,
+			ProofMkTree:  e.proofs[acct.Address().Hex()],
 			Choices:      choices[i],
 			VoterAccount: acct,
 		})
 	}
-	errs := t.sendVotes(votes)
+	errs := e.sendVotes(votes)
 	if len(errs) > 0 {
 		return fmt.Errorf("error in sendVotes %+v", errs)
 	}
 
 	log.Infow("votes submitted successfully",
-		"n", len(t.voterAccounts), "time", time.Since(startTime),
-		"vps", int(float64(len(t.voterAccounts))/time.Since(startTime).Seconds()))
+		"n", len(e.voterAccounts), "time", time.Since(startTime),
+		"vps", int(float64(len(e.voterAccounts))/time.Since(startTime).Seconds()))
 
-	if err := t.verifyVoteCount(t.config.nvotes); err != nil {
-		return err
+	if err := e.verifyVoteCount(nvotes); err != nil {
+		return fmt.Errorf("error in verifyVoteCount: %s", err)
 	}
 
-	elres, err := t.endElectionAndFetchResults()
+	elres, err := e.endElectionAndFetchResults()
 	if err != nil {
-		return err
+		return fmt.Errorf("error in electionAndFetchResults: %s", err)
 	}
+
 	if !matchResults(elres.Results, expectedResults) {
-		return fmt.Errorf("election result must match, expected Results: %v but got Results: %v", expectedResults, elres.Results)
+		return fmt.Errorf("election result must match, expected Results: %s but got Results: %v", expectedResults, elres.Results)
 	}
 
-	log.Infof("election %s status is RESULTS", t.election.ElectionID.String())
+	log.Infof("election %s status is RESULTS", e.election.ElectionID.String())
 	log.Infof("election results: %v", elres.Results)
-
 	return nil
+}
+
+// ballotVotes from a default list of 10 vote values that exceed the max value, max total cost and is not unique will
+func ballotVotes(vop vapi.TallyMode, nvotes int, ballotType string, expectUniqueV bool) ([][]int, [][]*types.BigInt) {
+	votes := make([][]int, 0, nvotes)
+	var resultsFields [][]*types.BigInt
+	var v [][]int
+
+	switch ballotType {
+	// fill initial 10 votes to be sent by the ballot test
+	case rankedVote:
+		v = [][]int{
+			{0, 5, 0, 2}, {3, 1, 0, 2}, {3, 2, 0, 1}, {1, 0, 3, 2},
+			{2, 3, 1, 1}, {4, 1, 1, 0}, {0, 0, 2, 1}, {0, 2, 1, 3},
+			{1, 1, 1, 4}, {0, 3, 2, 1},
+		}
+		// default results on field 1,2,3,4 for 10 votes
+		resultsFields = append(resultsFields, votesToBigInt(20, 10, 0, 20),
+			votesToBigInt(10, 10, 20, 10), votesToBigInt(20, 10, 10, 10),
+			votesToBigInt(0, 20, 20, 10))
+
+	case quadraticVote:
+		v = [][]int{
+			{2, 4, 2, 0}, {3, 3, 2, 2}, {2, 3, 0, 1}, {0, 2, 3, 3},
+			{1, 2, 1, 2}, {5, 0, 1, 0}, {0, 2, 2, 2}, {2, 1, 1, 2},
+			{1, 3, 0, 1}, {1, 3, 1, 1},
+		}
+		resultsFields = append(resultsFields, votesToBigInt(10, 30, 10, 0),
+			votesToBigInt(0, 10, 20, 20), votesToBigInt(10, 30, 10, 0),
+			votesToBigInt(0, 20, 30, 0))
+
+	case rangeVote:
+		v = [][]int{
+			{5, 0, 4, 2}, {3, 1, 2, 4}, {6, 0, 1, 3}, {0, 3, 2, 1},
+			{2, 1, 3, 0}, {3, 2, 1, 3}, {1, 3, 2, 0}, {2, 1, 1, 2},
+			{1, 2, 0, 3}, {4, 3, 1, 1},
+		}
+		resultsFields = append(resultsFields, votesToBigInt(10, 20, 10, 0),
+			votesToBigInt(0, 10, 10, 20), votesToBigInt(10, 0, 20, 10),
+			votesToBigInt(20, 10, 0, 10))
+
+	case approvalVote:
+		v = [][]int{
+			{1, 0, 0, 0}, {2, 1, 0, 1}, {0, 1, 2, 3}, {0, 0, 0, 1},
+			{0, 0, 1, 1}, {2, 2, 1, 0}, {1, 0, 1, 1}, {0, 0, 0, 0},
+			{1, 1, 0, 3}, {1, 1, 1, 1},
+		}
+		resultsFields = append(resultsFields, votesToBigInt(30, 30, 0, 0),
+			votesToBigInt(50, 10, 0, 0), votesToBigInt(30, 30, 0, 0),
+			votesToBigInt(20, 40, 0, 0))
+	}
+
+	// less than 10 votes
+	if nvotes < 10 {
+		for i := 0; i < int(vop.MaxCount); i++ {
+			// initialize default results with zero values on field 1,2,3,4 for less than 10 votes
+			resultsFields[i] = votesToBigInt(make([]uint64, vop.MaxCount)...)
+		}
+	} else {
+		// greater o equal than 10 votes
+		for i := 0; i < nvotes/10; i++ {
+			votes = append(votes, v...)
+		}
+		// nvotes split 10, for example for 44 nvotes, nvoteDid10 will be 4
+		// and that number will be multiplied by each default result to obtain the results for 40 votes
+		nvotesDiv10 := new(types.BigInt).SetUint64(uint64(nvotes / 10))
+
+		for _, field := range resultsFields {
+			field[0] = new(types.BigInt).Mul(field[0], nvotesDiv10)
+			field[1] = new(types.BigInt).Mul(field[1], nvotesDiv10)
+			field[2] = new(types.BigInt).Mul(field[2], nvotesDiv10)
+			field[3] = new(types.BigInt).Mul(field[3], nvotesDiv10)
+		}
+	}
+
+	remainVotes := nvotes % 10
+	if remainVotes != 0 {
+		votes = append(votes, v[:remainVotes]...)
+
+		for _, vote := range v[:remainVotes] {
+			isValidTotalCost := math.Pow(float64(vote[0]), float64(vop.CostExponent))+
+				math.Pow(float64(vote[1]), float64(vop.CostExponent))+
+				math.Pow(float64(vote[2]), float64(vop.CostExponent))+
+				math.Pow(float64(vote[3]), float64(vop.CostExponent)) <= float64(vop.MaxTotalCost)
+			isValidValues := vote[0] <= int(vop.MaxValue) &&
+				vote[1] <= int(vop.MaxValue) &&
+				vote[2] <= int(vop.MaxValue) &&
+				vote[3] <= int(vop.MaxValue)
+
+			repeatValues := vote[0] == vote[1] || vote[2] == vote[1] ||
+				vote[2] == vote[0] || vote[0] == vote[3] ||
+				vote[1] == vote[3] || vote[2] == vote[3]
+
+			if expectUniqueV && repeatValues {
+				continue
+			}
+
+			if isValidTotalCost && isValidValues {
+				resultsFields[0][vote[0]].Add(resultsFields[0][vote[0]], new(types.BigInt).SetUint64(10))
+				resultsFields[1][vote[1]].Add(resultsFields[1][vote[1]], new(types.BigInt).SetUint64(10))
+				resultsFields[2][vote[2]].Add(resultsFields[2][vote[2]], new(types.BigInt).SetUint64(10))
+				resultsFields[3][vote[3]].Add(resultsFields[3][vote[3]], new(types.BigInt).SetUint64(10))
+			}
+		}
+	}
+
+	log.Debug("vote values generated", votes)
+	log.Debug("results expected", resultsFields)
+	return votes, resultsFields
 }

--- a/cmd/end2endtest/csp.go
+++ b/cmd/end2endtest/csp.go
@@ -28,24 +28,10 @@ func (t *E2ECSPElection) Setup(api *apiclient.HTTPclient, c *config) error {
 	t.api = api
 	t.config = c
 
-	p := &models.Process{
-		StartBlock: 0,
-		BlockCount: 100,
-		Status:     models.ProcessStatus_READY,
-		EnvelopeType: &models.EnvelopeType{
-			EncryptedVotes: false,
-			UniqueValues:   true},
-		CensusOrigin: models.CensusOrigin_OFF_CHAIN_CA,
-		VoteOptions: &models.ProcessVoteOptions{
-			MaxCount: 1,
-			MaxValue: 1,
-		},
-		Mode: &models.ProcessMode{
-			AutoStart:     true,
-			Interruptible: true,
-		},
-		MaxCensusSize: uint64(t.config.nvotes),
-	}
+	//setup for ranked voting
+	p := newTestProcess()
+	// update to use csp origin
+	p.CensusOrigin = models.CensusOrigin_OFF_CHAIN_CA
 
 	if err := t.setupElectionRaw(p); err != nil {
 		return err

--- a/cmd/end2endtest/helpers.go
+++ b/cmd/end2endtest/helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"os"
 	"strings"
@@ -29,13 +28,6 @@ const (
 	retriesSend   = retries / 2
 )
 
-type ballotData struct {
-	maxValue     uint32
-	maxTotalCost uint32
-	costExponent uint32
-	maxCount     uint32
-}
-
 func newTestElectionDescription() *vapi.ElectionDescription {
 	return &vapi.ElectionDescription{
 		Title:       map[string]string{"default": fmt.Sprintf("Test election %s", util.RandomHex(8))},
@@ -57,6 +49,26 @@ func newTestElectionDescription() *vapi.ElectionDescription {
 					},
 				},
 			},
+		},
+	}
+}
+
+func newTestProcess() *models.Process {
+	return &models.Process{
+		StartBlock: 0,
+		BlockCount: 100,
+		Status:     models.ProcessStatus_READY,
+		EnvelopeType: &models.EnvelopeType{
+			EncryptedVotes: false,
+			UniqueValues:   true},
+		CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED,
+		VoteOptions: &models.ProcessVoteOptions{
+			MaxCount: 1,
+			MaxValue: 1,
+		},
+		Mode: &models.ProcessMode{
+			AutoStart:     true,
+			Interruptible: true,
 		},
 	}
 }
@@ -404,6 +416,10 @@ func (t *e2eElection) setupElectionRaw(prc *models.Process) error {
 		return err
 	}
 
+	if prc.MaxCensusSize == 0 {
+		prc.MaxCensusSize = uint64(t.config.nvotes)
+	}
+
 	csp := &ethereum.SignKeys{}
 
 	switch prc.CensusOrigin {
@@ -489,74 +505,6 @@ func (t *e2eElection) overwriteVote(choices []int, indexAcct int, waitType strin
 		}
 	}
 	return nil
-}
-
-// ballotVotes from a default list of 10 vote values that exceed the max value, max total cost and is not unique will
-func ballotVotes(b ballotData, nvotes int) ([][]int, [][]*types.BigInt) {
-	votes := make([][]int, 0, nvotes)
-	var resultsField1, resultsField2 []*types.BigInt
-
-	// initial 10 votes to be sent by the ballot test
-	var v = [][]int{
-		{0, 0}, {0, 7}, {5, 7}, {2, 0}, {2, 3},
-		{1, 6}, {0, 8}, {6, 5}, {2, 7}, {6, 4},
-	}
-
-	// less than 10 votes
-	if nvotes < 10 {
-		// default results with zero values on field 1 for less than 10 votes
-		resultsField1 = votesToBigInt(make([]uint64, b.maxValue+1)...)
-		// default results with zero values on field 2 for less than 10 votes
-		resultsField2 = votesToBigInt(make([]uint64, b.maxValue+1)...)
-	} else {
-		// greater o equal than 10 votes
-		for i := 0; i < nvotes/10; i++ {
-			votes = append(votes, v...)
-		}
-		// default results on field 1 for 10 votes
-		resultsField1 = votesToBigInt(0, 10, 20, 0, 0, 0, 10)
-		// default results on field 2 for 10 votes
-		resultsField2 = votesToBigInt(10, 0, 0, 10, 10, 0, 10)
-
-		// nvotes split 10, for example for 44 nvotes, nvoteDid10 will be 4
-		// and that number will be multiplied by each default result to obtain the results for 40 votes
-		nvotesDiv10 := new(types.BigInt).SetUint64(uint64(nvotes / 10))
-
-		for i := 0; i <= int(b.maxValue); i++ {
-			newvalField1 := new(types.BigInt).Mul(resultsField1[i], nvotesDiv10)
-			newvalField2 := new(types.BigInt).Mul(resultsField2[i], nvotesDiv10)
-
-			resultsField1[i] = newvalField1
-			resultsField2[i] = newvalField2
-		}
-	}
-
-	// remainVotes check if exists remain votes to add and count, note that if nvotes < 10 raminVote will be nvotes
-	remainVotes := nvotes % 10
-	if remainVotes != 0 {
-		votes = append(votes, v[:remainVotes]...)
-		// update expected results
-		for i := 0; i < remainVotes; i++ {
-			isValidTotalCost := math.Pow(float64(v[i][0]), float64(b.costExponent))+
-				math.Pow(float64(v[i][1]), float64(b.costExponent)) <= float64(b.maxTotalCost)
-			isValidValues := v[i][0] <= int(b.maxValue) && v[i][1] <= int(b.maxValue)
-			isUniqueValues := v[i][0] != v[i][1]
-
-			if isValidTotalCost && isValidValues && isUniqueValues {
-				newvalField1 := new(types.BigInt).Add(resultsField1[v[i][0]], new(types.BigInt).SetUint64(10))
-				newvalField2 := new(types.BigInt).Add(resultsField2[v[i][1]], new(types.BigInt).SetUint64(10))
-
-				resultsField1[v[i][0]] = newvalField1
-				resultsField2[v[i][1]] = newvalField2
-			}
-		}
-	}
-
-	expectedResults := [][]*types.BigInt{resultsField1, resultsField2}
-
-	log.Debug("vote values generated", votes)
-	log.Debug("results expected", expectedResults)
-	return votes, expectedResults
 }
 
 // sendVotes sends a batch of votes concurrently
@@ -655,9 +603,9 @@ func faucetPackage(faucet, faucetAuthToken, myAddress string) (*models.FaucetPac
 
 func matchResults(results, expectedResults [][]*types.BigInt) bool {
 	// iterate over each question to check if the results match with the expected results
-	for i := 0; i < len(results); i++ {
-		for q := range results[i] {
-			if !(expectedResults[i][q].String() == results[i][q].String()) {
+	for i, result := range results {
+		for q, r := range result {
+			if !(expectedResults[i][q].String() == r.String()) {
 				return false
 			}
 		}

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -141,6 +141,13 @@ e2etest_dynamicensuselection() {
   e2etest dynamicensuselection
 }
 
+e2etest_ballotelection() {
+  e2etest ballotRanked
+  e2etest ballotQuadratic
+  e2etest ballotRange
+  e2etest ballotApproval
+}
+
 ### end tests definition
 
 # useful for debugging bash flow


### PR DESCRIPTION
Update ballot test to allow test different voting types: `ranked, quadratic, range and approval`
update helpers for ballotVotes and add newTestProcess to use as standard `models.Process` struct on tests and avoid repeat code. 

Also was added `newE2EElections` to allow to setup elections with different `accountPrivKeys`, in order to avoid nonce update when manage more than one election

Note: I think the code associated with Run each voting case could be refactor to not repeat code, but I think we could open another PR to work that improvement.

- #863  