### PR TITLE
missing SIK related endpoints on CI (vocone)

### DIFF
--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -164,6 +164,7 @@ func (vc *Vocone) EnableAPI(host string, port int, URLpath string) (*api.API, er
 		api.WalletHandler,
 		api.AccountHandler,
 		api.CensusHandler,
+		api.SIKHandler,
 	)
 }
 


### PR DESCRIPTION
Fixing missing SIK related endpoints on `vocone` package, used on entrypoint `cmd/voconed` which is also used on the CI.

This bug produces https://github.com/vocdoni/vocdoni-sdk/actions/runs/5831821998/job/15816668273