### PR TITLE
e2etest fixes

### DIFF
--- a/apiclient/election.go
+++ b/apiclient/election.go
@@ -176,7 +176,7 @@ func (c *HTTPclient) NewElection(description *api.ElectionDescription) (types.He
 		MaxValue:          uint32(maxChoiceValue),
 		MaxVoteOverwrites: uint32(description.VoteType.MaxVoteOverwrites),
 		MaxTotalCost:      uint32(len(description.Questions) * maxChoiceValue),
-		CostExponent:      10000,
+		CostExponent:      1,
 	}
 
 	// Census Origin

--- a/cmd/end2endtest/censusize.go
+++ b/cmd/end2endtest/censusize.go
@@ -30,7 +30,7 @@ func (t *E2EMaxCensusSizeElection) Setup(api *apiclient.HTTPclient, c *config) e
 	t.api = api
 	t.config = c
 
-	ed := newTestElectionDescription()
+	ed := newTestElectionDescription(2)
 	ed.ElectionType = vapi.ElectionType{
 		Autostart:     true,
 		Interruptible: true,
@@ -81,7 +81,7 @@ func (t *E2EMaxCensusSizeElection) Run() error {
 		"vps", int(float64(len(t.voterAccounts[1:]))/time.Since(startTime).Seconds()))
 
 	// the missing vote should fail due maxCensusSize constrain
-	time.Sleep(time.Second * 4)
+	_ = t.api.WaitUntilNextBlock()
 	log.Infof("sending the missing vote associated with the account %v", t.voterAccounts[0].Address())
 
 	v := apiclient.VoteData{

--- a/cmd/end2endtest/dynamicensus.go
+++ b/cmd/end2endtest/dynamicensus.go
@@ -36,8 +36,8 @@ func (t *E2EDynamicensusElection) Setup(api *apiclient.HTTPclient, c *config) er
 		d             *vapi.ElectionDescription
 		dynamicCensus bool
 	}{
-		{d: newTestElectionDescription(), dynamicCensus: true},
-		{d: newTestElectionDescription(), dynamicCensus: false},
+		{d: newTestElectionDescription(2), dynamicCensus: true},
+		{d: newTestElectionDescription(2), dynamicCensus: false},
 	}
 
 	for i, ed := range eDescriptions {

--- a/cmd/end2endtest/encrypted.go
+++ b/cmd/end2endtest/encrypted.go
@@ -28,7 +28,7 @@ func (t *E2EEncryptedElection) Setup(api *apiclient.HTTPclient, c *config) error
 	t.api = api
 	t.config = c
 
-	ed := newTestElectionDescription()
+	ed := newTestElectionDescription(2)
 	ed.ElectionType = vapi.ElectionType{
 		Autostart:         true,
 		Interruptible:     true,

--- a/cmd/end2endtest/lifecycle.go
+++ b/cmd/end2endtest/lifecycle.go
@@ -36,8 +36,8 @@ func (t *E2ELifecycleElection) Setup(api *apiclient.HTTPclient, c *config) error
 		d             *vapi.ElectionDescription
 		interruptible bool
 	}{
-		{d: newTestElectionDescription(), interruptible: false},
-		{d: newTestElectionDescription(), interruptible: true},
+		{d: newTestElectionDescription(2), interruptible: false},
+		{d: newTestElectionDescription(2), interruptible: true},
 	}
 
 	for i, ed := range electionDescriptions {

--- a/cmd/end2endtest/overwrite.go
+++ b/cmd/end2endtest/overwrite.go
@@ -30,7 +30,7 @@ func (t *E2EOverwriteElection) Setup(api *apiclient.HTTPclient, c *config) error
 	t.api = api
 	t.config = c
 
-	ed := newTestElectionDescription()
+	ed := newTestElectionDescription(7)
 	ed.ElectionType = vapi.ElectionType{
 		Autostart:     true,
 		Interruptible: true,
@@ -78,19 +78,17 @@ func (t *E2EOverwriteElection) Run() error {
 
 	// overwrite the previous vote (choice 0) associated with account of index 0, using enough time to do it in the nextBlock
 	// try to make 3 overwrites (number of choices passed to the method). The last overwrite should fail due the maxVoteOverwrite constrain
-	err := t.overwriteVote([]int{0, 1, 0}, 0, nextBlock)
+	err := t.overwriteVote([]int{1, 2, 3}, 0, nextBlock)
 	if err != nil {
 		return err
 	}
 	log.Infof("the account %v send an overwrite vote", t.voterAccounts[0].Address())
-	time.Sleep(time.Second * 5)
 
 	// now the overwrite vote is done in the sameBlock using account of index 1
-	if err = t.overwriteVote([]int{1, 1, 0}, 1, sameBlock); err != nil {
+	if err = t.overwriteVote([]int{4, 5, 6}, 1, sameBlock); err != nil {
 		return err
 	}
 	log.Infof("the account %v send an overwrite vote", t.voterAccounts[1].Address())
-	time.Sleep(time.Second * 5)
 
 	if err := t.verifyVoteCount(t.config.nvotes); err != nil {
 		return err
@@ -102,7 +100,7 @@ func (t *E2EOverwriteElection) Run() error {
 	}
 
 	// should count only the first overwrite
-	expectedResults := [][]*types.BigInt{votesToBigInt(uint64(c.nvotes-2)*10, 20, 0)}
+	expectedResults := [][]*types.BigInt{votesToBigInt(uint64(c.nvotes-2)*10, 0, 10, 0, 0, 10, 0, 0)}
 
 	// only the first overwrite should be valid in the results and must math with the expected results
 	if !matchResults(elres.Results, expectedResults) {

--- a/cmd/end2endtest/plaintext.go
+++ b/cmd/end2endtest/plaintext.go
@@ -28,7 +28,7 @@ func (t *E2EPlaintextElection) Setup(api *apiclient.HTTPclient, c *config) error
 	t.api = api
 	t.config = c
 
-	ed := newTestElectionDescription()
+	ed := newTestElectionDescription(2)
 	ed.ElectionType = vapi.ElectionType{
 		Autostart:     true,
 		Interruptible: true,

--- a/cmd/end2endtest/zkweighted.go
+++ b/cmd/end2endtest/zkweighted.go
@@ -29,7 +29,7 @@ func (t *E2EAnonElection) Setup(api *apiclient.HTTPclient, c *config) error {
 	t.api = api
 	t.config = c
 
-	ed := newTestElectionDescription()
+	ed := newTestElectionDescription(2)
 	ed.ElectionType = vapi.ElectionType{
 		Autostart:     true,
 		Interruptible: true,


### PR DESCRIPTION
* apiclient: fix default CostExponent in NewElection
* remove unnecessary use of time.Sleep()
* elections can now be created with more than 2 choices 
* overwrite now votes different options, so now it's clear from results
 which vote was taken into account in case something unexpected happens
* avoid a panic in matchResults