### PR TITLE
state: fix locking issues during Commit

### DIFF
--- a/cmd/end2endtest/race.go
+++ b/cmd/end2endtest/race.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	vapi "go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/apiclient"
+	"go.vocdoni.io/dvote/log"
+)
+
+func init() {
+	ops["raceDuringCommit"] = operation{
+		test:        &E2ERaceDuringCommit{},
+		description: "Creates an election, votes, ends it, and while waiting for the results, spams the API to check for unexpected errors during block commit",
+		example:     os.Args[0] + " --operation=raceDuringCommit",
+	}
+}
+
+var _ VochainTest = (*E2ERaceDuringCommit)(nil)
+
+type E2ERaceDuringCommit struct {
+	e2eElection
+}
+
+func (t *E2ERaceDuringCommit) Setup(api *apiclient.HTTPclient, c *config) error {
+	t.api = api
+	t.config = c
+
+	ed := newTestElectionDescription(2)
+	ed.ElectionType = vapi.ElectionType{
+		Autostart:     true,
+		Interruptible: true,
+	}
+	ed.VoteType = vapi.VoteType{MaxVoteOverwrites: 1}
+	ed.Census = vapi.CensusTypeDescription{Type: vapi.CensusTypeWeighted}
+
+	if err := t.setupElection(ed); err != nil {
+		return err
+	}
+
+	log.Debugf("election details: %+v", *t.election)
+	return nil
+}
+
+func (*E2ERaceDuringCommit) Teardown() error {
+	// nothing to do here
+	return nil
+}
+
+func (t *E2ERaceDuringCommit) Run() error {
+	c := t.config
+
+	// Send the votes (parallelized)
+	startTime := time.Now()
+
+	log.Infof("enqueuing %d votes", len(t.voterAccounts))
+	votes := []*apiclient.VoteData{}
+	for i, acct := range t.voterAccounts {
+		votes = append(votes, &apiclient.VoteData{
+			ElectionID:   t.election.ElectionID,
+			ProofMkTree:  t.proofs[acct.Address().Hex()],
+			Choices:      []int{i % 2},
+			VoterAccount: acct,
+		})
+	}
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
+
+	log.Infow("votes submitted successfully",
+		"n", c.nvotes, "time", time.Since(startTime),
+		"vps", int(float64(c.nvotes)/time.Since(startTime).Seconds()))
+
+	if err := t.verifyVoteCount(t.config.nvotes); err != nil {
+		return err
+	}
+
+	// Set the account back to the organization account
+	api := t.api.Clone(t.config.accountPrivKeys[0])
+
+	// End the election by setting the status to ENDED
+	log.Infof("ending election...")
+	if _, err := api.SetElectionStatus(t.election.ElectionID, "ENDED"); err != nil {
+		return fmt.Errorf("cannot set election status to ENDED %w", err)
+	}
+
+	// Wait for the election to be in RESULTS state
+	ctx, cancel := context.WithTimeout(context.Background(), t.config.timeout*3)
+	defer cancel()
+
+	for {
+		election, err := t.api.ElectionResults(t.election.ElectionID)
+		if err != nil && !strings.Contains(err.Error(), "5024") { // "election results are not yet available" (TODO: proper code matching)
+			return fmt.Errorf("found an unexpected error %w", err)
+		}
+		if err == nil && election != nil {
+			log.Infow("election published results", "election",
+				t.election.ElectionID.String(), "duration", time.Since(startTime).String())
+			return nil
+		}
+		select {
+		case <-time.After(5 * time.Millisecond): // very short interval to spam the API and hit the window where the block commit happens
+			continue
+		case <-ctx.Done():
+			return fmt.Errorf("election %s never published results after %s: %w",
+				t.election.ElectionID.String(), time.Since(startTime).String(), ctx.Err())
+		}
+	}
+}

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -48,6 +48,7 @@ log() { echo $(date --rfc-3339=s) "$@" ; }
 ### newtest() { whatever ; }
 
 tests_to_run=(
+	"e2etest_raceDuringCommit"
 	"e2etest_plaintextelection_empty"
 	"e2etest_plaintextelection"
 	"e2etest_encryptedelection"
@@ -91,6 +92,10 @@ e2etest() {
 		  --parallel=$CONCURRENT_CONNECTIONS \
 		  --timeout=10m \
 		  $args
+}
+
+e2etest_raceDuringCommit() {
+  e2etest raceDuringCommit
 }
 
 e2etest_plaintextelection() {
@@ -176,7 +181,7 @@ results="/tmp/.vocdoni-test$RANDOM"
 mkdir -p $results
 
 for test in ${tests_to_run[@]}; do
-	if [ $test == "tokentransactions" ] || [ $CONCURRENT -eq 0 ] ; then
+	if [ $test == "e2etest_raceDuringCommit" ] || [ $CONCURRENT -eq 0 ] ; then
 		log "### Running test $test ###"
 		( set -o pipefail ; $test | tee $results/$test.stdout ; echo $? > $results/$test.retval )
 	else

--- a/vochain/state/state.go
+++ b/vochain/state/state.go
@@ -404,6 +404,7 @@ func (v *State) Save() ([]byte, error) {
 	// Note that we need to commit the tx after calling listeners, because
 	// the listeners may need to get the previous (not committed) state.
 	v.tx.Lock()
+	defer v.tx.Unlock()
 	err := func() error {
 		var err error
 		if err := v.tx.Commit(height); err != nil {
@@ -414,7 +415,6 @@ func (v *State) Save() ([]byte, error) {
 		}
 		return nil
 	}()
-	v.tx.Unlock()
 	if err != nil {
 		return nil, err
 	}

--- a/vochain/state/trees.go
+++ b/vochain/state/trees.go
@@ -46,6 +46,8 @@ type treeTxWithMutex struct {
 // MainTreeView is a thread-safe function to obtain a pointer to the last
 // opened mainTree as a TreeView.
 func (v *State) MainTreeView() *statedb.TreeView {
+	v.tx.RLock()
+	defer v.tx.RUnlock()
 	return v.mainTreeViewValue.Load()
 }
 


### PR DESCRIPTION
state: fix locking issues during Commit

* State.MainTreeView needs to respect v.tx.RLock()
* State.Save now defers v.tx.Unlock() until the end

fix #1100 'while down, could not get value for key'
that was returned on any query to the state
during Commit of a block

* e2etest: add raceDuringCommit to reproduce 'while down, could not get value for key'
