### PR TITLE
fix/golangci-lint-issues

### DIFF
--- a/api/censuses.go
+++ b/api/censuses.go
@@ -273,7 +273,7 @@ func (a *API) censusAddHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext
 // censusTypeHandler
 //
 //	@Summary		Get type of census
-//	@Description	Get the type of a census
+//	@Description	Get the census type
 //	@Tags			Censuses
 //	@Accept			json
 //	@Produce		json

--- a/api/elections.go
+++ b/api/elections.go
@@ -147,7 +147,7 @@ func (a *API) electionFullListHandler(_ *apirest.APIdata, ctx *httprouter.HTTPCo
 		}
 		list = append(list, a.electionSummary(e))
 	}
-	// wrap list in a struct to consistently return list in a object, return empty
+	// wrap list in a struct to consistently return list in an object, return empty
 	// object if the list does not contains any result
 	data, err := json.Marshal(struct {
 		Elections []ElectionSummary `json:"elections"`

--- a/api/faucet/faucet.go
+++ b/api/faucet/faucet.go
@@ -17,7 +17,7 @@ const (
 	FaucetHandler = "faucet"
 )
 
-// FaucetAPI is an httprouter/apirest handler for the faucet.
+// FaucetAPI is a httprouter/apirest handler for the faucet.
 // It generates a signed package that can be used to request tokens from the faucet.
 type FaucetAPI struct {
 	signingKey *ethereum.SignKeys

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -132,7 +132,7 @@ func (a *API) walletSignAndSendTx(stx *models.SignedTx, wallet *ethereum.SignKey
 // walletAddHandler
 //
 //	@Summary		Add account
-//	@Description	Add a new account to the local store. It return a token used to manage this account on the future.
+//	@Description	Add a new account to the local store. It returns a token used to manage this account on the future.
 //	@Tags			Wallet
 //	@Accept			json
 //	@Produce		json

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -158,11 +158,11 @@ func main() {
 
 }
 
-func accountIsSet(c *vocdoniCLI) bool {
+func accountIsSet(c *VocdoniCLI) bool {
 	return c.currentAccount >= 0
 }
 
-func accountHandler(c *vocdoniCLI) error {
+func accountHandler(c *VocdoniCLI) error {
 	accountAddNewStr := "-> import an account (from hexadecimal private key)"
 	accountGenerateStr := "-> generate a new account"
 	p := ui.Select{
@@ -193,7 +193,7 @@ func accountHandler(c *vocdoniCLI) error {
 	return nil
 }
 
-func accountSet(c *vocdoniCLI) error {
+func accountSet(c *VocdoniCLI) error {
 	p := ui.Prompt{
 		Label: "Account private key",
 	}
@@ -212,7 +212,7 @@ func accountSet(c *vocdoniCLI) error {
 	return c.setAPIaccount(key, memo)
 }
 
-func accountGen(c *vocdoniCLI) error {
+func accountGen(c *VocdoniCLI) error {
 	p := ui.Prompt{
 		Label: "Account memo note",
 	}
@@ -225,7 +225,7 @@ func accountGen(c *vocdoniCLI) error {
 	return c.setAPIaccount(key, memo)
 }
 
-func accountInfo(c *vocdoniCLI) error {
+func accountInfo(c *VocdoniCLI) error {
 	acc, err := c.api.Account("")
 	if err != nil {
 		return err
@@ -243,7 +243,7 @@ func accountInfo(c *vocdoniCLI) error {
 	if acc.Metadata != nil {
 		accMetadata, err := json.MarshalIndent(acc.Metadata, "", "  ")
 		if err != nil {
-			log.Debug("account metadta cannot be unmarshal")
+			log.Debug("account metadata cannot be unmarshal")
 		} else {
 			fmt.Printf("%s:\n%s\n", keysPrint.Sprintf(" ➥ metadata"), valuesPrint.Sprintf("%s", accMetadata))
 		}
@@ -252,7 +252,7 @@ func accountInfo(c *vocdoniCLI) error {
 	return nil
 }
 
-func networkInfo(cli *vocdoniCLI) error {
+func networkInfo(cli *VocdoniCLI) error {
 	info, err := cli.api.ChainInfo()
 	if err != nil {
 		return err
@@ -265,7 +265,7 @@ func networkInfo(cli *vocdoniCLI) error {
 	return nil
 }
 
-func bootStrapAccount(cli *vocdoniCLI) error {
+func bootStrapAccount(cli *VocdoniCLI) error {
 	var faucetPkg *models.FaucetPackage
 	p := ui.Prompt{
 		Label:   "Do you have a faucet package? [y,n]",
@@ -322,7 +322,7 @@ func bootStrapAccount(cli *vocdoniCLI) error {
 	return nil
 }
 
-func transfer(cli *vocdoniCLI) error {
+func transfer(cli *VocdoniCLI) error {
 	s := ui.Select{
 		Label: "Select a destination account",
 		Items: append(cli.listAccounts(), "to external account"),
@@ -397,10 +397,10 @@ func transfer(cli *vocdoniCLI) error {
 	return nil
 }
 
-func hostHandler(cli *vocdoniCLI) error {
+func hostHandler(cli *VocdoniCLI) error {
 	validateFunc := func(url string) error {
 		log.Debugf("performing ping test to %s", url)
-		_, err := http.NewRequest("GET", url+"/ping", nil)
+		_, err := http.NewRequest("GET", url+"/ping", http.NoBody)
 		return err
 	}
 	p := ui.Prompt{
@@ -431,7 +431,7 @@ func hostHandler(cli *vocdoniCLI) error {
 	return cli.setAuthToken(token)
 }
 
-func accountSetMetadata(cli *vocdoniCLI) error {
+func accountSetMetadata(cli *VocdoniCLI) error {
 	currentAccount, err := cli.api.Account("")
 	if err != nil {
 		return err
@@ -515,7 +515,7 @@ func accountSetMetadata(cli *vocdoniCLI) error {
 
 }
 
-func electionHandler(cli *vocdoniCLI) error {
+func electionHandler(cli *VocdoniCLI) error {
 	infoPrint.Printf("preparing the election template...\n")
 	description := api.ElectionDescription{
 		Title:        map[string]string{"default": "election title"},

--- a/cmd/cli/vocdonicli.go
+++ b/cmd/cli/vocdonicli.go
@@ -54,7 +54,7 @@ type Account struct {
 	PublicKey types.HexBytes `json:"pubKey"`
 }
 
-type vocdoniCLI struct {
+type VocdoniCLI struct {
 	filepath string
 	config   *Config
 	api      *apiclient.HTTPclient
@@ -63,7 +63,7 @@ type vocdoniCLI struct {
 	currentAccount int
 }
 
-func NewVocdoniCLI(configFile, host string) (*vocdoniCLI, error) {
+func NewVocdoniCLI(configFile, host string) (*VocdoniCLI, error) {
 	cfg := Config{}
 	if err := cfg.Load(configFile); err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func NewVocdoniCLI(configFile, host string) (*vocdoniCLI, error) {
 			return nil, err
 		}
 	}
-	return &vocdoniCLI{
+	return &VocdoniCLI{
 		filepath:       configFile,
 		config:         &cfg,
 		api:            api,
@@ -110,7 +110,7 @@ func NewVocdoniCLI(configFile, host string) (*vocdoniCLI, error) {
 	}, nil
 }
 
-func (v *vocdoniCLI) setHost(host string) error {
+func (v *VocdoniCLI) setHost(host string) error {
 	u, err := url.Parse(host)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func (v *vocdoniCLI) setHost(host string) error {
 	return v.save()
 }
 
-func (v *vocdoniCLI) setAuthToken(token string) error {
+func (v *VocdoniCLI) setAuthToken(token string) error {
 	t, err := uuid.Parse(token)
 	if err != nil {
 		return err
@@ -137,7 +137,7 @@ func (v *vocdoniCLI) setAuthToken(token string) error {
 	return v.save()
 }
 
-func (v *vocdoniCLI) useAccount(index int) error {
+func (v *VocdoniCLI) useAccount(index int) error {
 	if index >= len(v.config.Accounts) {
 		return fmt.Errorf("account %d does not exist", index)
 	}
@@ -149,21 +149,21 @@ func (v *vocdoniCLI) useAccount(index int) error {
 	return v.api.SetAccount(v.config.Accounts[index].PrivKey.String())
 }
 
-func (v *vocdoniCLI) getAccount(index int) (*Account, error) {
+func (v *VocdoniCLI) getAccount(index int) (*Account, error) {
 	if index >= len(v.config.Accounts) {
 		return nil, fmt.Errorf("account %d does not exist", index)
 	}
 	return &v.config.Accounts[index], nil
 }
 
-func (v *vocdoniCLI) getCurrentAccount() *Account {
+func (v *VocdoniCLI) getCurrentAccount() *Account {
 	if v.currentAccount < 0 {
 		return nil
 	}
 	return &v.config.Accounts[v.currentAccount]
 }
 
-func (v *vocdoniCLI) setAPIaccount(key, memo string) error {
+func (v *VocdoniCLI) setAPIaccount(key, memo string) error {
 	if err := v.api.SetAccount(key); err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func (v *vocdoniCLI) setAPIaccount(key, memo string) error {
 }
 
 // listAccounts list the memo notes of all stored accounts
-func (v *vocdoniCLI) listAccounts() []string {
+func (v *VocdoniCLI) listAccounts() []string {
 	accounts := []string{}
 	for _, a := range v.config.Accounts {
 		accounts = append(accounts, a.Memo)
@@ -206,12 +206,12 @@ func (v *vocdoniCLI) listAccounts() []string {
 	return accounts
 }
 
-func (v *vocdoniCLI) transactionMined(txHash types.HexBytes) bool {
+func (v *VocdoniCLI) transactionMined(txHash types.HexBytes) bool {
 	_, err := v.api.TransactionReference(txHash)
 	return err == nil
 }
 
-func (v *vocdoniCLI) waitForTransaction(txHash types.HexBytes) bool {
+func (v *VocdoniCLI) waitForTransaction(txHash types.HexBytes) bool {
 	startTime := time.Now()
 	for time.Now().Before(startTime.Add(transactionConfirmationThreshold)) {
 		if v.transactionMined(txHash) {
@@ -222,6 +222,6 @@ func (v *vocdoniCLI) waitForTransaction(txHash types.HexBytes) bool {
 	return false
 }
 
-func (v *vocdoniCLI) save() error {
+func (v *VocdoniCLI) save() error {
 	return v.config.Save(v.filepath)
 }

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -438,7 +438,7 @@ func main() {
 		// set IsSeedNode to true if seed mode configured
 		globalCfg.Vochain.IsSeedNode = types.ModeSeed == globalCfg.Mode
 		// do we need indexer?
-		globalCfg.Vochain.Indexer.Enabled = (globalCfg.Mode == types.ModeGateway)
+		globalCfg.Vochain.Indexer.Enabled = globalCfg.Mode == types.ModeGateway
 		// offchainDataDownloader is only needed for gateways
 		globalCfg.Vochain.OffChainDataDownloader = globalCfg.Vochain.OffChainDataDownloader &&
 			globalCfg.Mode == types.ModeGateway

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ import (
 type Config struct {
 	// Vochain config options
 	Vochain *VochainCfg
-	// Ipfs ipfs config options
+	// Ipfs config options
 	Ipfs *IPFSCfg
 	// Metrics config options
 	Metrics *MetricsCfg

--- a/data/downloader/downloader.go
+++ b/data/downloader/downloader.go
@@ -21,7 +21,7 @@ const (
 	// ImportRetrieveTimeout the maximum duration the import queue will wait
 	// for retrieving a remote file.
 	ImportRetrieveTimeout = 5 * time.Minute
-	// ImportQueueTimeout is the maximum duration the import queue will wait
+	// ImportPinTimeout is the maximum duration the import queue will wait
 	// for pinning a remote file.
 	ImportPinTimeout = 3 * time.Minute
 	// MaxFileSize is the maximum size of a file that can be imported.

--- a/data/ipfs/init.go
+++ b/data/ipfs/init.go
@@ -13,7 +13,7 @@ import (
 	ihelper "github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
 	ipfscid "github.com/ipfs/go-cid"
 	"github.com/ipfs/kubo/commands"
-	config "github.com/ipfs/kubo/config"
+	"github.com/ipfs/kubo/config"
 	ipfscore "github.com/ipfs/kubo/core"
 	ipfsapi "github.com/ipfs/kubo/core/coreapi"
 	"github.com/ipfs/kubo/plugin/loader"
@@ -236,7 +236,9 @@ func checkWritable(dir string) error {
 			}
 			return fmt.Errorf("unexpected error while checking writeablility of repo root: %s", err)
 		}
-		fi.Close()
+		if err := fi.Close(); err != nil {
+			return err
+		}
 		return os.Remove(testfile)
 	}
 

--- a/httprouter/httprouter.go
+++ b/httprouter/httprouter.go
@@ -158,7 +158,6 @@ func (r *HTTProuter) Init(host string, port int) error {
 	}
 	r.address = ln.Addr()
 	return nil
-
 }
 
 // EnablePrometheusMetrics enables go-chi prometheus metrics under specified ID.

--- a/log/log.go
+++ b/log/log.go
@@ -49,7 +49,7 @@ var logTestTime, _ = time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
 
 type testHook struct{}
 
-// To ensure that the log output in the test is deterministic.
+// Run ensure that the log output in the test is deterministic.
 func (*testHook) Run(e *zerolog.Event, _ zerolog.Level, _ string) {
 	e.Stringer("time", logTestTime)
 }

--- a/statedb/statedb.go
+++ b/statedb/statedb.go
@@ -360,7 +360,7 @@ func (*readOnlyWriteTx) Set(_ []byte, _ []byte) error {
 	return ErrReadOnly
 }
 
-// Set implements db.WriteTx.Delete but returns error always.
+// Delete implements db.WriteTx.Delete but returns error always.
 func (*readOnlyWriteTx) Delete(_ []byte) error {
 	return ErrReadOnly
 }
@@ -373,7 +373,7 @@ func (*readOnlyWriteTx) Apply(_ db.WriteTx) error {
 // Commit implements db.WriteTx.Commit but returns nil always.
 func (*readOnlyWriteTx) Commit() error { return nil }
 
-// Commit implements db.WriteTx.Discard as a no-op.
+// Discard implements db.WriteTx.Discard as a no-op.
 func (*readOnlyWriteTx) Discard() {}
 
 // TreeView returns the mainTree opened at root as a TreeView for read-only.

--- a/subpub/subpub.go
+++ b/subpub/subpub.go
@@ -27,7 +27,7 @@ const (
 	// We use go-bare for export/import the trie. In order to support
 	// big census (up to 8 Million entries) we need to increase the maximums.
 	bareMaxArrayLength    uint64 = 1024 * 1014 * 8         // 8 Million entries
-	bareMaxUnmarshalBytes uint64 = bareMaxArrayLength * 32 // Assuming 32 bytes per entry
+	bareMaxUnmarshalBytes        = bareMaxArrayLength * 32 // Assuming 32 bytes per entry
 )
 
 // SubPub is a simplified PubSub protocol using libp2p.
@@ -90,7 +90,7 @@ func NewSubPub(groupKey [32]byte, node *core.IpfsNode) *SubPub {
 // Start connects the SubPub networking stack
 // and begins passing incoming messages to the receiver chan
 func (s *SubPub) Start(ctx context.Context, receiver chan *Message) {
-	if len(s.Topic) == 0 {
+	if s.Topic == "" {
 		log.Fatal("no group key provided")
 	}
 	ipfslog.SetLogLevel("*", "ERROR")

--- a/types/consts.go
+++ b/types/consts.go
@@ -30,7 +30,7 @@ const (
 	// EthereumAddressSize is the size of an ethereum address
 	EthereumAddressSize = 20
 
-	// EntityIDsizeV2 legacy: in the past we used hash(addr)
+	// EntityIDsize V2 legacy: in the past we used hash(addr)
 	// this is a temporal work around to support both
 	EntityIDsize = 20
 	// KeyIndexSeparator is the default char used to split keys
@@ -41,52 +41,46 @@ const (
 
 	// ENS Domains
 
-	// ENTITY RESOLVER
-	// EntityResolverDomain is the default entity resolver ENS domain
+	// EntityResolverDomain default entity resolver ENS domain
 	EntityResolverDomain = "entities.voc.eth"
 	// EntityResolverStageDomain is the default entity resolver ENS domain
 	EntityResolverStageDomain = "entities.stg.voc.eth"
 	// EntityResolverDevelopmentDomain is the default entity resolver ENS domain
 	EntityResolverDevelopmentDomain = "entities.dev.voc.eth"
 
-	// PROCESSES
-	// ProcessesDomain
+	// ProcessesDomain default process domain
 	ProcessesDomain = "processes.voc.eth"
-	// ProcessesStageDomain
+	// ProcessesStageDomain stage process domain
 	ProcessesStageDomain = "processes.stg.voc.eth"
-	// ProcessesDevelopmentDomain
+	// ProcessesDevelopmentDomain dev process domain
 	ProcessesDevelopmentDomain = "processes.dev.voc.eth"
 
-	// NAMESPACES
-	// NamespacesDomain
+	// NamespacesDomain default namespace domain
 	NamespacesDomain = "namespaces.voc.eth"
-	// NamespacesStageDomain
+	// NamespacesStageDomain stage namespace domain
 	NamespacesStageDomain = "namespaces.stg.voc.eth"
-	// NamespacesDevelopmentDomain
+	// NamespacesDevelopmentDomain dev namespace domain
 	NamespacesDevelopmentDomain = "namespaces.dev.voc.eth"
 
-	// ERC20 PROOFS
-	// ERC20ProofsDomain
+	// ERC20ProofsDomain default domain for erc20 proofs
 	ERC20ProofsDomain = "erc20.proofs.voc.eth"
-	// ERC20ProofsStageDomain
+	// ERC20ProofsStageDomain domain for erc20 proofs stage
 	ERC20ProofsStageDomain = "erc20.proofs.stg.voc.eth"
-	// ERC20ProofsDevelopmentDomain
+	// ERC20ProofsDevelopmentDomain domain for erc20 proofs dev
 	ERC20ProofsDevelopmentDomain = "erc20.proofs.dev.voc.eth"
 
-	// GENESIS
-	// GenesisDomain
+	// GenesisDomain default genesis domain
 	GenesisDomain = "genesis.voc.eth"
-	// GenesisStageDomain
+	// GenesisStageDomain stage genesis domain
 	GenesisStageDomain = "genesis.stg.voc.eth"
-	// GenesisDevelopmentDomain
+	// GenesisDevelopmentDomain dev genesis domain
 	GenesisDevelopmentDomain = "genesis.dev.voc.eth"
 
-	// RESULTS
-	// ResultsDomain
+	// ResultsDomain default results domain
 	ResultsDomain = "results.voc.eth"
-	// ResultsStageDomain
+	// ResultsStageDomain stage results domain
 	ResultsStageDomain = "results.stg.voc.eth"
-	// ResultsDevelopmentDomain
+	// ResultsDevelopmentDomain dev results domain
 	ResultsDevelopmentDomain = "results.dev.voc.eth"
 
 	// EntityMetaKey is the key of an ENS text record for the entity metadata

--- a/util/net.go
+++ b/util/net.go
@@ -22,6 +22,8 @@ func PublicIP(ipversion uint) (net.IP, error) {
 	config := externalip.DefaultConsensusConfig().WithTimeout(publicIPTimeout)
 
 	consensus := externalip.DefaultConsensus(config, nil)
-	consensus.UseIPProtocol(ipversion)
+	if err := consensus.UseIPProtocol(ipversion); err != nil {
+		return nil, err
+	}
 	return consensus.ExternalIP()
 }

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -160,7 +160,7 @@ func (app *BaseApplication) InitChain(_ context.Context,
 	req *abcitypes.RequestInitChain) (*abcitypes.ResponseInitChain, error) {
 	// setting the app initial state with validators, height = 0 and empty apphash
 	// unmarshal app state from genesis
-	var genesisAppState genesis.GenesisAppState
+	var genesisAppState genesis.AppState
 	err := json.Unmarshal(req.AppStateBytes, &genesisAppState)
 	if err != nil {
 		return nil, fmt.Errorf("cannot unmarshal app state bytes: %w", err)
@@ -583,7 +583,7 @@ func (app *BaseApplication) CircuitConfigurationTag() string {
 	return app.circuitConfigTag
 }
 
-// IsSynchronizing informes if the blockchain is synchronizing or not.
+// IsSynchronizing informs if the blockchain is synchronizing or not.
 func (app *BaseApplication) isSynchronizingTendermint() bool {
 	if app.Node == nil {
 		return true
@@ -591,7 +591,7 @@ func (app *BaseApplication) isSynchronizingTendermint() bool {
 	return app.Node.ConsensusReactor().WaitSync()
 }
 
-// IsSynchronizing informes if the blockchain is synchronizing or not.
+// IsSynchronizing informs if the blockchain is synchronizing or not.
 // The value is updated every new block.
 func (app *BaseApplication) IsSynchronizing() bool {
 	return app.isSynchronizing.Load()

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -174,10 +174,10 @@ func NewTemplateGenesisFile(dir string, validators int) (*tmtypes.GenesisDoc, er
 	}
 
 	// Build genesis app state and create genesis file
-	appState := genesis.GenesisAppState{
+	appState := genesis.AppState{
 		Validators: appStateValidators,
 		Treasurer:  types.HexBytes(treasurer.Address().Bytes()),
-		Accounts: []genesis.GenesisAccount{
+		Accounts: []genesis.Account{
 			{
 				Address: faucet.Address().Bytes(),
 				Balance: 100000,

--- a/vochain/genesis/genesis.go
+++ b/vochain/genesis/genesis.go
@@ -7,8 +7,7 @@ import (
 )
 
 // Genesis is a map containing the default Genesis details
-var Genesis = map[string]VochainGenesis{
-
+var Genesis = map[string]Vochain{
 	// Development network
 	"dev": {
 		AutoUpdateGenesis: true,
@@ -39,7 +38,7 @@ var Genesis = map[string]VochainGenesis{
 	},
 }
 
-var devGenesis = GenesisDoc{
+var devGenesis = Doc{
 	GenesisTime: time.Date(2023, time.September, 21, 1, 0, 0, 0, time.UTC),
 	ChainID:     "vocdoni-dev-20",
 	ConsensusParams: &ConsensusParams{
@@ -58,7 +57,7 @@ var devGenesis = GenesisDoc{
 			AppVersion: 0,
 		},
 	},
-	AppState: GenesisAppState{
+	AppState: AppState{
 		MaxElectionSize: 100000,
 		NetworkCapacity: 20000,
 		Validators: []AppStateValidators{
@@ -91,7 +90,7 @@ var devGenesis = GenesisDoc{
 				KeyIndex: 4,
 			},
 		},
-		Accounts: []GenesisAccount{
+		Accounts: []Account{
 			{ // faucet
 				Address: types.HexStringToHexBytes("0xC7C6E17059801b6962cc144a374eCc3ba1b8A9e0"),
 				Balance: 100000000,
@@ -116,7 +115,7 @@ var devGenesis = GenesisDoc{
 	},
 }
 
-var stageGenesis = GenesisDoc{
+var stageGenesis = Doc{
 	GenesisTime: time.Date(2023, time.September, 21, 1, 0, 0, 0, time.UTC),
 	ChainID:     "vocdoni-stage-8",
 	ConsensusParams: &ConsensusParams{
@@ -135,7 +134,7 @@ var stageGenesis = GenesisDoc{
 			AppVersion: 0,
 		},
 	},
-	AppState: GenesisAppState{
+	AppState: AppState{
 		MaxElectionSize: 50000,
 		NetworkCapacity: 2000,
 		Validators: []AppStateValidators{
@@ -210,7 +209,7 @@ var stageGenesis = GenesisDoc{
 				KeyIndex: 4,
 			},
 		},
-		Accounts: []GenesisAccount{
+		Accounts: []Account{
 			{ // faucet
 				Address: types.HexStringToHexBytes("0xC7C6E17059801b6962cc144a374eCc3ba1b8A9e0"),
 				Balance: 1000000000,
@@ -235,7 +234,7 @@ var stageGenesis = GenesisDoc{
 	},
 }
 
-var apexGenesis = GenesisDoc{
+var apexGenesis = Doc{
 	GenesisTime: time.Date(2023, time.May, 24, 9, 0, 0, 0, time.UTC),
 	ChainID:     "vocdoni-apex-v1",
 	ConsensusParams: &ConsensusParams{
@@ -254,7 +253,7 @@ var apexGenesis = GenesisDoc{
 			AppVersion: 0,
 		},
 	},
-	AppState: GenesisAppState{
+	AppState: AppState{
 		MaxElectionSize: 1000000,
 		NetworkCapacity: 5000,
 		Validators: []AppStateValidators{
@@ -311,7 +310,7 @@ var apexGenesis = GenesisDoc{
 				Address:  types.HexStringToHexBytes("4945fd40d29870a931561b26a30a529081ded677"),
 				PubKey:   types.HexStringToHexBytes("038276c348971ef9d8b11abaf0cdce50e6cb89bd0f87df14301ef02d46db09db6d"),
 				Power:    10,
-				Name:     "vocdoni-validtaor7",
+				Name:     "vocdoni-validator7",
 				KeyIndex: 0,
 			},
 			{ // 8
@@ -322,7 +321,7 @@ var apexGenesis = GenesisDoc{
 				KeyIndex: 4,
 			},
 		},
-		Accounts: []GenesisAccount{
+		Accounts: []Account{
 			{ // faucet
 				Address: types.HexStringToHexBytes("863a75f41025f0c8878d3a100c8c16576fe8fe4f"),
 				Balance: 10000000,

--- a/vochain/genesis/types.go
+++ b/vochain/genesis/types.go
@@ -11,12 +11,12 @@ import (
 	"go.vocdoni.io/dvote/types"
 )
 
-// VochainGenesis is a struct containing the genesis details.
-type VochainGenesis struct {
+// Vochain is a struct containing the genesis details.
+type Vochain struct {
 	AutoUpdateGenesis bool
 	SeedNodes         []string
 	CircuitsConfigTag string
-	Genesis           *GenesisDoc
+	Genesis           *Doc
 }
 
 // The genesis app state types are copied from
@@ -24,18 +24,18 @@ type VochainGenesis struct {
 // lightweight and not have it import heavy indirect dependencies like grpc or
 // crypto/*.
 
-// GenesisDoc defines the initial conditions for a Vocdoni blockchain.
+// Doc defines the initial conditions for a Vocdoni blockchain.
 // It is mostly a wrapper around the Tendermint GenesisDoc.
-type GenesisDoc struct {
+type Doc struct {
 	GenesisTime     time.Time        `json:"genesis_time"`
 	ChainID         string           `json:"chain_id"`
 	ConsensusParams *ConsensusParams `json:"consensus_params,omitempty"`
 	AppHash         types.HexBytes   `json:"app_hash"`
-	AppState        GenesisAppState  `json:"app_state,omitempty"`
+	AppState        AppState         `json:"app_state,omitempty"`
 }
 
-// TendermintDoc returns the Tendermint GenesisDoc from the Vocdoni GenesisDoc.
-func (g *GenesisDoc) TendermintDoc() tmtypes.GenesisDoc {
+// TendermintDoc returns the Tendermint GenesisDoc from the Vocdoni genesis.Doc.
+func (g *Doc) TendermintDoc() tmtypes.GenesisDoc {
 	appState, err := json.Marshal(g.AppState)
 	if err != nil {
 		// must never happen
@@ -56,8 +56,8 @@ func (g *GenesisDoc) TendermintDoc() tmtypes.GenesisDoc {
 	}
 }
 
-// Marshal returns the JSON encoding of the GenesisDoc.
-func (g *GenesisDoc) Marshal() []byte {
+// Marshal returns the JSON encoding of the genesis.Doc.
+func (g *Doc) Marshal() []byte {
 	data, err := json.Marshal(g)
 	if err != nil {
 		panic(err)
@@ -65,8 +65,8 @@ func (g *GenesisDoc) Marshal() []byte {
 	return data
 }
 
-// Hash returns the hash of the GenesisDoc.
-func (g *GenesisDoc) Hash() []byte {
+// Hash returns the hash of the genesis.Doc.
+func (g *Doc) Hash() []byte {
 	data, err := json.Marshal(g)
 	if err != nil {
 		panic(err)
@@ -90,32 +90,35 @@ type BlockParams struct {
 	MaxGas   StringifiedInt64 `json:"max_gas"`
 }
 
+// EvidenceParams define limits on max evidence age and max duration
 type EvidenceParams struct {
 	MaxAgeNumBlocks StringifiedInt64 `json:"max_age_num_blocks"`
 	// only accept new evidence more recent than this
 	MaxAgeDuration StringifiedInt64 `json:"max_age_duration"`
 }
 
+// ValidatorParams define the validator key
 type ValidatorParams struct {
 	PubKeyTypes []string `json:"pub_key_types"`
 }
 
+// VersionParams define the version app information
 type VersionParams struct {
 	AppVersion StringifiedInt64 `json:"app_version"`
 }
 
 // ________________________ GENESIS APP STATE ________________________
 
-// GenesisAccount represents an account in the genesis app state
-type GenesisAccount struct {
+// Account represents an account in the genesis app state
+type Account struct {
 	Address types.HexBytes `json:"address"`
 	Balance uint64         `json:"balance"`
 }
 
-// GenesisAppState is the main application state in the genesis file.
-type GenesisAppState struct {
+// AppState is the main application state in the genesis file.
+type AppState struct {
 	Validators      []AppStateValidators `json:"validators"`
-	Accounts        []GenesisAccount     `json:"accounts"`
+	Accounts        []Account            `json:"accounts"`
 	Treasurer       types.HexBytes       `json:"treasurer"`
 	TxCost          TransactionCosts     `json:"tx_cost"`
 	MaxElectionSize uint64               `json:"max_election_size"`

--- a/vochain/indexer/vote.go
+++ b/vochain/indexer/vote.go
@@ -96,7 +96,7 @@ func (idx *Indexer) GetEnvelopes(processId []byte, max, from int,
 
 }
 
-// CountVotes returns the total number of envelopes.
+// CountTotalVotes returns the total number of envelopes.
 func (idx *Indexer) CountTotalVotes() (uint64, error) {
 	height, err := idx.readOnlyQuery.CountVotes(context.TODO())
 	return uint64(height), err

--- a/vochain/ist/ist.go
+++ b/vochain/ist/ist.go
@@ -192,7 +192,7 @@ func (c *Controller) Commit(height uint32) error {
 	for id, action := range actions {
 		switch action.ID {
 		case ActionCommitResults:
-			// if the election is setted up with tempSIKs as true, purge the election
+			// if the election is set up with tempSIKs as true, purge the election
 			// related SIKs
 			process, err := c.state.Process(action.ElectionID, false)
 			if err != nil {

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -106,7 +106,7 @@ func NewKeyKeeper(dbPath string, v *vochain.BaseApplication,
 }
 
 // RevealUnpublished is a rescue function for revealing keys that should be already revealed.
-// It should be callend once the Vochain is synchronized in order to have the correct height.
+// It should be called once the Vochain is synchronized in order to have the correct height.
 func (k *KeyKeeper) RevealUnpublished() {
 	// wait for vochain sync?
 	height, err := k.vochain.State.LastHeight()

--- a/vochain/offchaindatahandler/offchaindatahandler.go
+++ b/vochain/offchaindatahandler/offchaindatahandler.go
@@ -136,7 +136,7 @@ func (d *OffChainDataHandler) OnCensusUpdate(pid, censusRoot []byte, censusURI s
 }
 
 // OnProcessesStart is triggered when a process starts. Does nothing.
-func (d *OffChainDataHandler) OnProcessesStart(_ [][]byte) {
+func (*OffChainDataHandler) OnProcessesStart(_ [][]byte) {
 }
 
 // OnSetAccount is triggered when a new account is created or modified. If metadata info is present, it is enqueued.

--- a/vochain/transaction/vote_tx.go
+++ b/vochain/transaction/vote_tx.go
@@ -76,7 +76,7 @@ func (t *TransactionHandler) VoteTxCheck(vtx *vochaintx.Tx, forCommit bool) (*vs
 	//
 	// We use CacheGetCopy because we will modify the vote to set
 	// the Height.  If we don't work with a copy we are racing with
-	// concurrent reads to the votes in the cache which happen in
+	// concurrent reads to the votes in the cache which happen
 	// in State.CachePurge run via a goroutine in
 	// started in BaseApplication.BeginBlock.
 	// Warning: vote cache might change during the execution of this function.

--- a/vochain/vochaininfo/vochaininfo.go
+++ b/vochain/vochaininfo/vochaininfo.go
@@ -101,7 +101,7 @@ func (vi *VochainInfo) EstimateBlockHeight(target time.Time) (uint64, error) {
 	// Multiply by 1000 because t is represented in seconds, not ms.
 	// Dividing t first can floor the integer, leading to divide-by-zero
 	currentHeight := uint64(vi.Height())
-	blockDiff := (uint64(absDiff*1000) / t)
+	blockDiff := uint64(absDiff*1000) / t
 	if inPast {
 		if blockDiff > currentHeight {
 			return 0, fmt.Errorf("target time %v is before origin", target)
@@ -244,11 +244,11 @@ func (vi *VochainInfo) Start(sleepSecs int64) {
 				n60++
 				n360++
 				n1440++
-				h1 += (height - pheight)
-				h10 += (height - pheight)
-				h60 += (height - pheight)
-				h360 += (height - pheight)
-				h1440 += (height - pheight)
+				h1 += height - pheight
+				h10 += height - pheight
+				h60 += height - pheight
+				h360 += height - pheight
+				h1440 += height - pheight
 
 				if sleepSecs*n1 >= 60 && h1 > 0 {
 					a1 = int32((n1 * sleepSecs * 1000) / h1)

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -155,7 +155,7 @@ func (vc *Vocone) Start() {
 	go vochainPrintInfo(10, vc.Stats)
 	if vc.App.Height() == 0 {
 		log.Infof("initializing new blockchain")
-		genesisAppData, err := json.Marshal(&genesis.GenesisAppState{
+		genesisAppData, err := json.Marshal(&genesis.AppState{
 			MaxElectionSize: 1000000,
 			NetworkCapacity: uint64(vc.txsPerBlock),
 			TxCost:          defaultTxCosts(),


### PR DESCRIPTION
- remove extra newline not needed, fix method comments, fix typos, remove redundant type conversion
- `vochain/genesis`: update types name to remove package name, it will be redundant calling genesis.GenesisAppState,
- `cmd/cli`: fix exported function with the unexported return type
- `util/net`: fix unhandled error
- deepsoruce issues