### PR TITLE
fix error message when no keys for election

### DIFF
--- a/apiclient/vote.go
+++ b/apiclient/vote.go
@@ -236,7 +236,7 @@ func (c *HTTPclient) voteEnvelopeWithKeys(choices []int, keysEnc []api.Key, elec
 			}
 		}
 		if len(keys) == 0 {
-			return nil, fmt.Errorf("no keys for election %s", election.ElectionID)
+			return nil, fmt.Errorf("no keys for election %x", election.ElectionID)
 		}
 	}
 


### PR DESCRIPTION
The error was being displayed in the wrong format

![Screenshot from 2023-09-19 21-49-53](https://github.com/vocdoni/vocdoni-node/assets/48325352/aed98af8-1cb6-450c-a747-5cbcbed74c29)

