### PR TITLE
en2endtest: extend annonelection

### DIFF
--- a/apiclient/account.go
+++ b/apiclient/account.go
@@ -322,7 +322,7 @@ func (c *HTTPclient) DelSIK() (types.HexBytes, error) {
 }
 
 // RegisterSIKForVote function performs the free RegisterSIKTx to the vochain
-// helping to non registered accounts to vote in a on going election, but only
+// helping to non registered accounts to vote in an ongoing election, but only
 // if the account is in the election census. The function returns the hash of
 // the sent transaction, and requires the election ID. The census proof and the
 // secret are optional. If no proof is provided, it will be generated.

--- a/cmd/end2endtest/zkweighted.go
+++ b/cmd/end2endtest/zkweighted.go
@@ -17,13 +17,18 @@ func init() {
 		description: "Performs a complete test of anonymous election, from creating a census to voting and validating votes",
 		example:     os.Args[0] + " --operation=anonelection --votes=1000",
 	}
+	ops["anonelectionTempSIKs"] = operation{
+		test:        &E2EAnonElectionTempSIKs{},
+		description: "Performs a complete test of anonymous election with TempSIKs flag to vote with half of the accounts that are not registered, and the remaining half with registered accounts",
+		example:     os.Args[0] + " --operation=anonelectionTempSIKS --votes=1000",
+	}
 }
 
 var _ VochainTest = (*E2EAnonElection)(nil)
+var _ VochainTest = (*E2EAnonElectionTempSIKs)(nil)
 
-type E2EAnonElection struct {
-	e2eElection
-}
+type E2EAnonElection struct{ e2eElection }
+type E2EAnonElectionTempSIKs struct{ e2eElection }
 
 func (t *E2EAnonElection) Setup(api *apiclient.HTTPclient, c *config) error {
 	t.api = api
@@ -51,6 +56,78 @@ func (*E2EAnonElection) Teardown() error {
 }
 
 func (t *E2EAnonElection) Run() error {
+	var vcount int
+
+	startTime := time.Now()
+	votes := []*apiclient.VoteData{}
+
+	log.Infow("enqueuing votes", "n", t.config.nvotes, "election", t.election.ElectionID)
+	t.voters.Range(func(key, value any) bool {
+		if acctp, ok := value.(acctProof); ok {
+			votes = append(votes, &apiclient.VoteData{
+				ElectionID:   t.election.ElectionID,
+				ProofMkTree:  acctp.proof,
+				ProofSIKTree: acctp.proofSIK,
+				Choices:      []int{vcount % 2},
+				VoterAccount: acctp.account,
+				VoteWeight:   big.NewInt(defaultWeight / 2),
+			})
+			vcount += 1
+		}
+		return true
+	})
+
+	errs := t.sendVotes(votes)
+	if len(errs) > 0 {
+		return fmt.Errorf("error in sendVotes %+v", errs)
+	}
+
+	log.Infow("votes submitted successfully",
+		"n", t.config.nvotes, "time", time.Since(startTime),
+		"vps", int(float64(t.config.nvotes)/time.Since(startTime).Seconds()))
+
+	if err := t.verifyVoteCount(t.config.nvotes); err != nil {
+		return err
+	}
+
+	elres, err := t.endElectionAndFetchResults()
+	if err != nil {
+		return err
+	}
+
+	log.Infof("election %s status is RESULTS", t.election.ElectionID.String())
+	log.Infof("election results: %v", elres.Results)
+
+	return nil
+}
+
+func (t *E2EAnonElectionTempSIKs) Setup(api *apiclient.HTTPclient, c *config) error {
+	t.api = api
+	t.config = c
+
+	ed := newTestElectionDescription(2)
+	ed.ElectionType = vapi.ElectionType{
+		Autostart:     true,
+		Interruptible: true,
+		Anonymous:     true,
+	}
+	ed.VoteType = vapi.VoteType{MaxVoteOverwrites: 1}
+	ed.Census = vapi.CensusTypeDescription{Type: vapi.CensusTypeZKWeighted}
+	ed.TempSIKs = true
+
+	if err := t.setupElection(ed, t.config.nvotes); err != nil {
+		return err
+	}
+	log.Debugf("election details: %+v", *t.election)
+	return nil
+}
+
+func (*E2EAnonElectionTempSIKs) Teardown() error {
+	// nothing to do here
+	return nil
+}
+
+func (t *E2EAnonElectionTempSIKs) Run() error {
 	var vcount int
 
 	startTime := time.Now()

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -112,6 +112,7 @@ e2etest_encryptedelection() {
 
 e2etest_anonelection() {
 	e2etest anonelection
+	e2etest anonelectionTempSIKs
 }
 
 e2etest_hysteresis() {


### PR DESCRIPTION
Adding a test with `TempSIKs` flag set to true to vote with half of the accounts that are not registered using `RegisterSIKForVote`, and the remaining half voting with registered annon accounts.
#1083 
