### PR TITLE
vocone: refactor Vocone struct as an extension of service.VocdoniService

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -387,7 +387,6 @@ func main() {
 	}
 
 	var err error
-	var vochainKeykeeper *keykeeper.KeyKeeper
 	srv := service.VocdoniService{Config: globalCfg.Vochain}
 
 	if globalCfg.Mode == types.ModeGateway {
@@ -503,7 +502,7 @@ func main() {
 		} else {
 			// start keykeeper service (if key index specified)
 			if validator.KeyIndex > 0 {
-				vochainKeykeeper, err = keykeeper.NewKeyKeeper(
+				srv.KeyKeeper, err = keykeeper.NewKeyKeeper(
 					path.Join(globalCfg.Vochain.DataDir, "keykeeper"),
 					srv.App,
 					&signer,
@@ -511,7 +510,7 @@ func main() {
 				if err != nil {
 					log.Fatal(err)
 				}
-				go vochainKeykeeper.RevealUnpublished()
+				go srv.KeyKeeper.RevealUnpublished()
 			} else {
 				log.Warnw("validator keyIndex disabled")
 			}

--- a/service/service.go
+++ b/service/service.go
@@ -10,6 +10,7 @@ import (
 	"go.vocdoni.io/dvote/metrics"
 	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/dvote/vochain/indexer"
+	"go.vocdoni.io/dvote/vochain/keykeeper"
 	"go.vocdoni.io/dvote/vochain/offchaindatahandler"
 	"go.vocdoni.io/dvote/vochain/vochaininfo"
 )
@@ -27,4 +28,5 @@ type VocdoniService struct {
 	Stats          *vochaininfo.VochainInfo
 	Storage        data.Storage
 	Signer         *ethereum.SignKeys
+	KeyKeeper      *keykeeper.KeyKeeper
 }

--- a/vochain/offchaindatahandler/offchaindatahandler.go
+++ b/vochain/offchaindatahandler/offchaindatahandler.go
@@ -76,7 +76,7 @@ func (d *OffChainDataHandler) Commit(_ uint32) error {
 			// AddToQueue() writes to a channel that might be full, so we don't want to block the main thread.
 			go d.enqueueOffchainCensus(item.censusRoot, item.uri)
 		case itemTypeElectionMetadata, itemTypeAccountMetadata:
-			log.Infow("importing data", "type", "election metadata", "uri", item.uri)
+			log.Infow("importing metadata", "type", item.itemType, "uri", item.uri)
 			go d.enqueueMetadata(item.uri)
 		default:
 			log.Errorf("unknown item %d", item.itemType)

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -59,7 +59,7 @@ type Vocone struct {
 }
 
 // NewVocone returns a ready Vocone instance.
-func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool) (*Vocone, error) {
+func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool, connectKey string, connectPeers []string) (*Vocone, error) {
 	var err error
 
 	vc := &Vocone{}
@@ -106,7 +106,9 @@ func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool) 
 	// Create the IPFS storage layer
 	if !disableIPFS {
 		vc.Storage, err = vc.IPFS(&config.IPFSCfg{
-			ConfigPath: filepath.Join(dataDir, "ipfs"),
+			ConfigPath:   filepath.Join(dataDir, "ipfs"),
+			ConnectKey:   connectKey,
+			ConnectPeers: connectPeers,
 		})
 		if err != nil {
 			return nil, err

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -31,7 +31,7 @@ func TestVocone(t *testing.T) {
 	err = account.Generate()
 	qt.Assert(t, err, qt.IsNil)
 
-	vc, err := NewVocone(dir, &keymng, true)
+	vc, err := NewVocone(dir, &keymng, false)
 	qt.Assert(t, err, qt.IsNil)
 
 	vc.SetBlockTimeTarget(time.Millisecond * 500)

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -31,7 +31,7 @@ func TestVocone(t *testing.T) {
 	err = account.Generate()
 	qt.Assert(t, err, qt.IsNil)
 
-	vc, err := NewVocone(dir, &keymng, false)
+	vc, err := NewVocone(dir, &keymng, false, "", nil)
 	qt.Assert(t, err, qt.IsNil)
 
 	vc.SetBlockTimeTarget(time.Millisecond * 500)


### PR DESCRIPTION
this way, the whole init phase is much similar to what `node` does, avoiding bugs
and making it easier to maintain in the future when features are added
    
this refactor was originated by a bug introduced when OffchainDataDownloader feature
was merged on `node` but not fully properly in `voconed`,
so `voconed` was not doing vs.DataDownloader.Start() that `node` does during init
    
the best solution was to make voconed call the same init function that node calls
srv.OffChainDataHandler()

