### PR TITLE
add integration test for /elections/price endpoint

### DIFF
--- a/test/testcommon/api.go
+++ b/test/testcommon/api.go
@@ -57,7 +57,7 @@ func (d *APIserver) Start(t testing.TB, apis ...string) {
 	d.VochainAPP = vochain.TestBaseApplication(t)
 
 	// create and add balance for the pre-created Account
-	err = d.VochainAPP.State.CreateAccount(d.Account.Address(), "", nil, 100000)
+	err = d.VochainAPP.State.CreateAccount(d.Account.Address(), "", nil, 1000000)
 	qt.Assert(t, err, qt.IsNil)
 	d.VochainAPP.CommitState()
 


### PR DESCRIPTION
without fix #1138, this new test reproduces the bug in cost estimation:
```
go test ./test/ -run TestAPIElectionCost -count=1 -v
=== RUN   TestAPIElectionCost
    api.go:52: address: http://127.0.0.1:40415/
    vochain.go:139: starting vochain indexer
    apiclient.go:34: querying http://127.0.0.1:40415/accounts
    apiclient.go:34: querying http://127.0.0.1:40415/chain/info
    apiclient.go:34: querying http://127.0.0.1:40415/chain/transactions/count
    apiclient.go:34: querying http://127.0.0.1:40415/censuses/weighted
    apiclient.go:34: querying http://127.0.0.1:40415/censuses/50c4eaf182c18d3922bbd402e70bd26f2738e6c3608b93aa3876dd753bc9a3cf/publish
    apiclient.go:34: querying http://127.0.0.1:40415/elections/price
    apiclient.go:34: querying http://127.0.0.1:40415/accounts/0x8f6664A47be5bCc6E1A2b3698FB936aaCF044DF5
    apiclient.go:34: querying http://127.0.0.1:40415/elections
    apiclient.go:34: querying http://127.0.0.1:40415/chain/info
    apiclient.go:34: querying http://127.0.0.1:40415/chain/transactions/count
    apiclient.go:34: querying http://127.0.0.1:40415/accounts/0x8f6664A47be5bCc6E1A2b3698FB936aaCF044DF5
    api_test.go:353: 
        error:
          values are not equal
        comment:
          endpoint /elections/price predicted cost 6, but actual election creation costed 11
        got:
          uint64(4989)
        want:
          uint64(4994)
        stack:
          /home/user/src/vocdoni/vocdoni-node/test/api_test.go:353
            qt.Assert(t, balance,
                qt.Equals, initialBalance-predictedPrice,
                qt.Commentf("endpoint /elections/price predicted cost %d, "+
                    "but actual election creation costed %d", predictedPrice, initialBalance-balance))
          /home/user/src/vocdoni/vocdoni-node/test/api_test.go:260
            runAPIElectionCostWithParams(t,
                electionprice.ElectionParameters{
                    MaxCensusSize:    100,
                    ElectionDuration: 2000,
                    EncryptedVotes:   false,
                    AnonymousVotes:   false,
                    MaxVoteOverwrite: 1,
                },
                10000, 5000,
                5, 1000,
                6)
        
--- FAIL: TestAPIElectionCost (0.24s)
FAIL
FAIL	go.vocdoni.io/dvote/test	0.292s
FAIL
```