### PR TITLE
use the flag --no-install-recommends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=builder /go/pkg/mod/github.com/wasmerio/wasmer-go@v1.0.4/wasmer/pack
                     /go/pkg/mod/github.com/wasmerio/wasmer-go@v1.0.4/wasmer/packaged/lib/linux-amd64/libwasmer.so
 # Support for go-rapidsnark prover (https://github.com/iden3/go-rapidsnark/tree/main/prover)
 RUN apt-get update && \
-	apt-get install -y libc6-dev libomp-dev openmpi-common libgomp1 curl && \
+	apt-get install --no-install-recommends -y libc6-dev libomp-dev openmpi-common libgomp1 curl && \
 	apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
use --no-install-recommends for installation time decrease and could help with the container space.