### PR TITLE
stage fork hotfix

### DIFF
--- a/vochain/app.go
+++ b/vochain/app.go
@@ -165,8 +165,6 @@ func (app *BaseApplication) InitChain(_ context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("cannot unmarshal app state bytes: %w", err)
 	}
-	// set ChainID for app & state
-	app.SetChainID(req.ChainId)
 	// create accounts
 	for _, acc := range genesisAppState.Accounts {
 		addr := ethcommon.BytesToAddress(acc.Address)

--- a/vochain/transaction/election_tx.go
+++ b/vochain/transaction/election_tx.go
@@ -286,5 +286,8 @@ func (t *TransactionHandler) txElectionCostFromProcessPreFork20231016(process *m
 func (t *TransactionHandler) isBeforeFork20231016() bool {
 	// when vocdoni-stage-8 was ~200000 blocks old, we found a bug in txElectionCostFromProcess
 	// that needed a soft-fork. we agreed on fixing it (changing the behavior) at block 212000
-	return t.state.ChainID() == "vocdoni-stage-8" && t.state.CurrentHeight() < Fork20231016Block
+	//
+	// this should also check for t.state.ChainID() == "vocdoni-stage-8"
+	// but that doesn't work due to https://github.com/vocdoni/vocdoni-node/issues/1149
+	return t.state.CurrentHeight() < Fork20231016Block
 }


### PR DESCRIPTION
- Revert "vochain: InitChain now calls app.SetChainID"
- Fork20231016: remove check ChainID == vocdoni-stage-8, just check CurrentHeight
