### PR TITLE
remove unused structs in indexer db models

### DIFF
--- a/vochain/indexer/db/models.go
+++ b/vochain/indexer/db/models.go
@@ -8,42 +8,12 @@ import (
 	"time"
 
 	"go.vocdoni.io/dvote/types"
-	"go.vocdoni.io/dvote/vochain/state"
 )
 
 type Block struct {
 	Height   int64
 	Time     time.Time
 	DataHash []byte
-}
-
-type Process struct {
-	ID                 types.ProcessID
-	EntityID           types.EntityID
-	StartBlock         int64
-	EndBlock           int64
-	BlockCount         int64
-	HaveResults        bool
-	FinalResults       bool
-	ResultsVotes       string
-	ResultsWeight      string
-	ResultsBlockHeight int64
-	CensusRoot         types.CensusRoot
-	MaxCensusSize      int64
-	CensusUri          string
-	Metadata           string
-	CensusOrigin       int64
-	Status             int64
-	Namespace          int64
-	Envelope           string
-	Mode               string
-	VoteOpts           string
-	PrivateKeys        string
-	PublicKeys         string
-	QuestionIndex      int64
-	CreationTime       time.Time
-	SourceBlockHeight  int64
-	SourceNetworkID    int64
 }
 
 type TokenFee struct {
@@ -71,16 +41,4 @@ type Transaction struct {
 	BlockHeight int64
 	BlockIndex  int64
 	Type        string
-}
-
-type Vote struct {
-	Nullifier            types.Nullifier
-	ProcessID            types.ProcessID
-	BlockHeight          int64
-	BlockIndex           int64
-	Weight               string
-	VoterID              state.VoterID
-	OverwriteCount       int64
-	EncryptionKeyIndexes string
-	Package              string
 }

--- a/vochain/indexer/sqlc.yaml
+++ b/vochain/indexer/sqlc.yaml
@@ -8,6 +8,7 @@ sql:
       package: "indexerdb"
       out: "db"
       emit_prepared_queries: true
+      omit_unused_structs: true
       overrides:
       # Defaults to int32 for integers, which is a bit small.
       - db_type: "int"


### PR DESCRIPTION
We can use the sqlc tag `omit_unused_structs: true` to avoid create models that are not being used in any part of the code 