### PR TITLE
testsuite: don't leak orphan networks in ci server

### DIFF
--- a/dockerfiles/testsuite/docker-compose.yml
+++ b/dockerfiles/testsuite/docker-compose.yml
@@ -117,8 +117,8 @@ services:
       - gocoverage-miner3:/app/run/gocoverage/miner3
       - gocoverage-gateway0:/app/run/gocoverage/gateway0
       - gocoverage-test:/app/run/gocoverage/test
-    profiles:
-      - tools # this container is only intended to be `docker compose run`, no need to start on `docker compose up`
+    networks:
+      - blockchain
 
   prometheus:
     image: prom/prometheus:v2.26.0
@@ -144,7 +144,7 @@ services:
     networks:
       - blockchain
     ports:
-      - 3000:3000
+      - "[::1]:3000:3000"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning/:/etc/grafana/provisioning/


### PR DESCRIPTION
until now, on every run a network testsuite_${{ github.run_id }}_default
was created, and not properly cleaned up (left behind in server)
after about 30 runs, CI on that server fails with
  Error response from daemon: could not find an available,
  non-overlapping IPv4 address pool among the defaults to assign to the network
until a `docker network prune` is run

while at it, don't expose grafana outside localhost
