### PR TITLE
F/censusdb race

### DIFF
--- a/api/censusdb/censusdb.go
+++ b/api/censusdb/censusdb.go
@@ -109,9 +109,6 @@ func (c *CensusDB) New(censusID []byte, censusType models.Census_Type,
 		return nil, err
 	}
 	ref.tree = tree
-	if uri != "" {
-		ref.tree.Publish()
-	}
 	return ref, nil
 }
 
@@ -149,9 +146,6 @@ func (c *CensusDB) Load(censusID []byte, authToken *uuid.UUID) (*CensusRef, erro
 		})
 	if err != nil {
 		return nil, err
-	}
-	if ref.URI != "" {
-		ref.tree.Publish()
 	}
 	root, err := ref.Tree().Root()
 	if err != nil {

--- a/api/censusdb/censusdb_test.go
+++ b/api/censusdb/censusdb_test.go
@@ -61,6 +61,7 @@ func TestCensusDBLoad(t *testing.T) {
 
 	// Attempting to load a non-existent census should return an error
 	_, err := censusDB.Load(censusID, &authToken)
+	censusDB.UnLoad()
 	qt.Assert(t, err, qt.IsNotNil)
 
 	// Create a new census for loading
@@ -69,6 +70,7 @@ func TestCensusDBLoad(t *testing.T) {
 
 	// Load the census with the correct auth token
 	censusRef, err := censusDB.Load(censusID, &authToken)
+	censusDB.UnLoad()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, censusRef, qt.IsNotNil)
 }
@@ -131,8 +133,10 @@ func TestImportCensusDB(t *testing.T) {
 
 	// Ensure the data is in the database
 	_, err = censusDB.Load(censusID1, &token1)
+	censusDB.UnLoad()
 	qt.Assert(t, err, qt.IsNil)
 	_, err = censusDB.Load(censusID2, &token2)
+	censusDB.UnLoad()
 	qt.Assert(t, err, qt.IsNil)
 
 	// Dump the census data to a byte buffer
@@ -156,7 +160,7 @@ func TestImportCensusDB(t *testing.T) {
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, v, qt.DeepEquals, value)
 	}
-
+	newDB.UnLoad()
 	newCensusRef, err = newDB.Load(censusID2, &token2)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -165,4 +169,5 @@ func TestImportCensusDB(t *testing.T) {
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, v, qt.DeepEquals, value)
 	}
+	newDB.UnLoad()
 }

--- a/api/censuses.go
+++ b/api/censuses.go
@@ -710,7 +710,6 @@ func (a *API) censusPublishHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCon
 	if err := newRef.Tree().ImportDump(dump); err != nil {
 		return err
 	}
-	newRef.Tree().Publish()
 
 	var data []byte
 	if data, err = json.Marshal(&Census{

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -114,6 +114,11 @@ func (c *HTTPclient) SetAuthToken(token *uuid.UUID) {
 	c.token = token
 }
 
+// BearerToken returns the current bearer authentication token.
+func (c *HTTPclient) BearerToken() *uuid.UUID {
+	return c.token
+}
+
 // SetHostAddr configures the host address of the API server.
 func (c *HTTPclient) SetHostAddr(addr *url.URL) error {
 	c.addr = addr

--- a/censustree/censustree.go
+++ b/censustree/censustree.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
-	"sync/atomic"
 
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/prefixeddb"
@@ -24,7 +23,6 @@ var censusWeightKey = []byte("censusWeight")
 // updates it.
 type Tree struct {
 	tree        *tree.Tree
-	public      atomic.Bool
 	censusType  models.Census_Type
 	hashFunc    func(...[]byte) ([]byte, error)
 	hashLen     int
@@ -145,16 +143,6 @@ func (t *Tree) FromRoot(root []byte) (*Tree, error) {
 
 	return &Tree{tree: treeFromRoot, censusType: t.Type()}, nil
 }
-
-// Publish makes a merkle tree available for queries.  Application layer should
-// call Publish() before considering the Tree available.
-func (t *Tree) Publish() { t.public.Store(true) }
-
-// Unpublish makes a merkle tree not available for queries.
-func (t *Tree) Unpublish() { t.public.Store(false) }
-
-// IsPublic returns true if the tree is available.
-func (t *Tree) IsPublic() bool { return t.public.Load() }
 
 // Root wraps tree.Tree.Root.
 func (t *Tree) Root() ([]byte, error) {

--- a/censustree/censustree_test.go
+++ b/censustree/censustree_test.go
@@ -16,28 +16,6 @@ import (
 // The proper tests are in tree package, here there are tests that check the
 // added code in the CensusTree wrapper.
 
-func TestPublish(t *testing.T) {
-	db := metadb.NewTest(t)
-	censusTree, err := New(Options{Name: "test", ParentDB: db, MaxLevels: DefaultMaxLevels,
-		CensusType: models.Census_ARBO_BLAKE2B})
-	qt.Assert(t, err, qt.IsNil)
-	rnd := testutil.NewRandom(0)
-	key, value := rnd.RandomBytes(DefaultMaxKeyLen), rnd.RandomBytes(32)
-	qt.Assert(t, censusTree.Add(key, value), qt.IsNil)
-
-	qt.Assert(t, censusTree.IsPublic(), qt.IsFalse)
-
-	censusTree.Publish()
-	qt.Assert(t, censusTree.IsPublic(), qt.IsTrue)
-
-	recValue, _, err := censusTree.GenProof(key)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, value, qt.DeepEquals, recValue)
-
-	censusTree.Unpublish()
-	qt.Assert(t, censusTree.IsPublic(), qt.IsFalse)
-}
-
 func TestImportWeighted(t *testing.T) {
 	db := metadb.NewTest(t)
 	censusTree, err := New(Options{Name: "test", ParentDB: db, MaxLevels: DefaultMaxLevels,
@@ -117,8 +95,6 @@ func TestWeightedProof(t *testing.T) {
 
 	err = censusTree.Add(userKey, userWeight)
 	qt.Assert(t, err, qt.IsNil)
-
-	censusTree.Publish()
 
 	// generate and test the proof
 	value, siblings, err := censusTree.GenProof(userKey)

--- a/data/data.go
+++ b/data/data.go
@@ -4,6 +4,7 @@ package data
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"go.vocdoni.io/dvote/data/ipfs"
 	"go.vocdoni.io/dvote/types"
@@ -13,6 +14,7 @@ import (
 type Storage interface {
 	Init(d *types.DataStore) error
 	Publish(ctx context.Context, data []byte) (string, error)
+	PublishReader(ctx context.Context, data io.Reader) (string, error)
 	Retrieve(ctx context.Context, id string, maxSize int64) ([]byte, error)
 	Pin(ctx context.Context, path string) error
 	Unpin(ctx context.Context, path string) error

--- a/data/datamocktest.go
+++ b/data/datamocktest.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"io"
 	"maps"
 	"os"
 	"sync"
@@ -25,6 +26,14 @@ func (d *DataMockTest) Init(_ *types.DataStore) error {
 	d.prefix = "ipfs://"
 	d.rnd = testutil.NewRandom(0)
 	return nil
+}
+
+func (d *DataMockTest) PublishReader(_ context.Context, r io.Reader) (string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return d.Publish(context.Background(), data)
 }
 
 func (d *DataMockTest) Publish(_ context.Context, o []byte) (string, error) {

--- a/test/testcommon/testvoteproof/voteproof.go
+++ b/test/testcommon/testvoteproof/voteproof.go
@@ -67,7 +67,6 @@ func CreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys, []b
 		hashedKeys = append(hashedKeys, c)
 	}
 
-	tr.Publish()
 	var proofs [][]byte
 	for i := range keys {
 		_, proof, err := tr.GenProof(hashedKeys[i])

--- a/vochain/genesis/genesis.go
+++ b/vochain/genesis/genesis.go
@@ -40,7 +40,7 @@ var Genesis = map[string]Vochain{
 
 var devGenesis = Doc{
 	GenesisTime: time.Date(2023, time.October, 17, 1, 0, 0, 0, time.UTC),
-	ChainID:     "vocdoni-dev-25",
+	ChainID:     "vocdoni-dev-26",
 	ConsensusParams: &ConsensusParams{
 		Block: BlockParams{
 			MaxBytes: 2097152,

--- a/vochain/genesis/genesis.go
+++ b/vochain/genesis/genesis.go
@@ -39,8 +39,8 @@ var Genesis = map[string]Vochain{
 }
 
 var devGenesis = Doc{
-	GenesisTime: time.Date(2023, time.October, 17, 1, 0, 0, 0, time.UTC),
-	ChainID:     "vocdoni-dev-26",
+	GenesisTime: time.Date(2023, time.October, 31, 1, 0, 0, 0, time.UTC),
+	ChainID:     "vocdoni/DEV/28",
 	ConsensusParams: &ConsensusParams{
 		Block: BlockParams{
 			MaxBytes: 2097152,

--- a/vochain/vote_test.go
+++ b/vochain/vote_test.go
@@ -37,8 +37,6 @@ func testCreateKeysAndBuildWeightedZkCensus(t *testing.T, size int, weight *big.
 		qt.Check(t, err, qt.IsNil)
 	}
 
-	tr.Publish()
-
 	root, err := tr.Root()
 	qt.Check(t, err, qt.IsNil)
 	var proofs [][]byte
@@ -74,7 +72,6 @@ func testCreateKeysAndBuildCensus(t *testing.T, size int) ([]*ethereum.SignKeys,
 		hashedKeys = append(hashedKeys, c)
 	}
 
-	tr.Publish()
 	var proofs [][]byte
 	for i := range keys {
 		_, proof, err := tr.GenProof(hashedKeys[i])


### PR DESCRIPTION
see commit message

@lucasmenendez if you are using censusdb, once you upgrade to the code containing this PR, you should call censusdb.Unload() after every Load() to release the lock.