### PR TITLE
vochain: ensure transaction order is deterministic when Nonce and Addr are equal

### DIFF
--- a/vochain/cometbft.go
+++ b/vochain/cometbft.go
@@ -372,6 +372,9 @@ func (app *BaseApplication) PrepareProposal(ctx context.Context,
 		}
 		if validTxInfos[i].Addr != nil && validTxInfos[j].Addr != nil {
 			if bytes.Equal(validTxInfos[i].Addr.Bytes(), validTxInfos[j].Addr.Bytes()) {
+				if validTxInfos[i].Nonce == validTxInfos[j].Nonce {
+					return bytes.Compare(validTxInfos[i].Data, validTxInfos[j].Data) == -1
+				}
 				return validTxInfos[i].Nonce < validTxInfos[j].Nonce
 			}
 			return bytes.Compare(validTxInfos[i].Addr.Bytes(), validTxInfos[j].Addr.Bytes()) == -1


### PR DESCRIPTION
while digging into https://github.com/vocdoni/vocdoni-node/issues/1154 i realised two txs can have the same Nonce and Addr (two Votes from the same voter, that are vote overwrites) and in that case the order is not deterministic, but the resulting state (election result) will be different, depending on which tx is accepted and which one is discarded (as invalid, due to MaxVoteOverwrite)