### PR TITLE
e2etest: never try to overwrite votes on the same block

### DIFF
--- a/cmd/end2endtest/helpers.go
+++ b/cmd/end2endtest/helpers.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	nextBlock     = "nextBlock"
-	sameBlock     = "sameBlock"
 	defaultWeight = 10
 	retriesSend   = retries / 2
 )
@@ -468,8 +466,9 @@ func (t *e2eElection) checkElectionPrice(ed *vapi.ElectionDescription) error {
 	return nil
 }
 
-// overwriteVote allow to try to overwrite a previous vote given the index of the account, it can use the sameBlock or the nextBlock
-func (t *e2eElection) overwriteVote(choices []int, v *apiclient.VoteData, waitType string) error {
+// overwriteVote allow to try to overwrite a previous vote given the index of the account,
+// always waiting for a block between overwrites (otherwise results are impredictable)
+func (t *e2eElection) overwriteVote(choices []int, v *apiclient.VoteData) error {
 	for i := 0; i < len(choices); i++ {
 		// assign the choices wanted for each overwrite vote
 		v.Choices = []int{choices[i]}
@@ -481,9 +480,7 @@ func (t *e2eElection) overwriteVote(choices []int, v *apiclient.VoteData, waitTy
 			}
 			log.Debug("error expected: ", err.Error())
 		}
-		if waitType == nextBlock {
-			_ = t.api.WaitUntilNextBlock()
-		}
+		_ = t.api.WaitUntilNextBlock()
 	}
 	return nil
 }

--- a/cmd/end2endtest/overwrite.go
+++ b/cmd/end2endtest/overwrite.go
@@ -82,14 +82,8 @@ func (t *E2EOverwriteElection) Run() error {
 
 	// overwrite the previous vote (choice 0) associated with account of index 0, using enough time to do it in the nextBlock
 	// try to make 3 overwrites (number of choices passed to the method). The last overwrite should fail due the maxVoteOverwrite constrain
-	err := t.overwriteVote([]int{1, 2, 3}, votes[0], nextBlock)
+	err := t.overwriteVote([]int{1, 2, 3}, votes[0])
 	if err != nil {
-		return err
-	}
-	log.Infof("the account %v send an overwrite vote", votes[0].VoterAccount.Address())
-
-	// now the overwrite vote is done in the sameBlock using account of index 1
-	if err = t.overwriteVote([]int{4, 5, 6}, votes[1], sameBlock); err != nil {
 		return err
 	}
 	log.Infof("the account %v send an overwrite vote", votes[0].VoterAccount.Address())
@@ -104,7 +98,7 @@ func (t *E2EOverwriteElection) Run() error {
 	}
 
 	// should count only the first overwrite
-	expectedResults := [][]*types.BigInt{votesToBigInt(uint64(c.nvotes-2)*10, 0, 10, 0, 0, 10, 0, 0)}
+	expectedResults := [][]*types.BigInt{votesToBigInt(uint64(c.nvotes-1)*10, 0, 10, 0, 0, 0, 0, 0)}
 
 	// only the first overwrite should be valid in the results and must math with the expected results
 	if !matchResults(elres.Results, expectedResults) {


### PR DESCRIPTION
The results are impredictable since the tx reordering feature was introduced
