### PR TITLE
indexer: extend to improve archive support

### DIFF
--- a/api/api_types.go
+++ b/api/api_types.go
@@ -34,6 +34,8 @@ type ElectionSummary struct {
 	FinalResults   bool              `json:"finalResults"`
 	Results        [][]*types.BigInt `json:"result,omitempty"`
 	ManuallyEnded  bool              `json:"manuallyEnded"`
+	FromArchive    bool              `json:"fromArchive"`
+	ChainID        string            `json:"chainId"`
 }
 
 // ElectionResults is the struct used to wrap the results of an election

--- a/service/indexer.go
+++ b/service/indexer.go
@@ -24,7 +24,7 @@ func (vs *VocdoniService) VochainIndexer() error {
 
 	if vs.Config.Indexer.ArchiveURL != "" {
 		log.Infow("starting archive retrieval", "path", vs.Config.Indexer.ArchiveURL)
-		go vs.Indexer.StartArchiveRetrival(vs.Storage, vs.Config.Indexer.ArchiveURL)
+		go vs.Indexer.StartArchiveRetrieval(vs.Storage, vs.Config.Indexer.ArchiveURL)
 	}
 
 	return nil

--- a/types/consts.go
+++ b/types/consts.go
@@ -1,9 +1,5 @@
 package types
 
-import (
-	"time"
-)
-
 func Bool(b bool) *bool { return &b }
 
 // These exported variables should be treated as constants, to be used in API
@@ -14,152 +10,39 @@ var (
 )
 
 const (
-	// All
-
 	// The mode defines the behaviour of the vocdoninode
 
-	// ModeMiner starts vocdoninode as a miner
+	// ModeMiner starts vocdoninode as a miner.
 	ModeMiner = "miner"
-	// ModeSeed starts vocdoninode as a seed node
+	// ModeSeed starts vocdoninode as a seed node.
 	ModeSeed = "seed"
-	// ModeGateway starts the vocdoninode as a gateway
+	// ModeGateway starts the vocdoninode as a gateway.
 	ModeGateway = "gateway"
-	// ModeCensus starts the vocdoninode as a census only service
+	// ModeCensus starts the vocdoninode as a census only service.
 	ModeCensus = "census"
 
-	// ProcessIDsize is the size of a process id
+	// ProcessIDsize is the size of a process id.
 	ProcessIDsize = 32
-	// EthereumAddressSize is the size of an ethereum address
+
+	// EthereumAddressSize is the size of an ethereum address.
 	EthereumAddressSize = 20
 
-	// EntityIDsize V2 legacy: in the past we used hash(addr)
-	// this is a temporal work around to support both
-	EntityIDsize = 20
-	// KeyIndexSeparator is the default char used to split keys
-	KeyIndexSeparator = ":"
-	// EthereumConfirmationsThreshold is the minimum amout of blocks
-	// that should pass before considering a tx final
-	EthereumConfirmationsThreshold = 6
+	// EntityIDsize is the size of an entity id (ethereum address).
+	EntityIDsize = EthereumAddressSize
 
-	// ENS Domains
-
-	// EntityResolverDomain default entity resolver ENS domain
-	EntityResolverDomain = "entities.voc.eth"
-	// EntityResolverStageDomain is the default entity resolver ENS domain
-	EntityResolverStageDomain = "entities.stg.voc.eth"
-	// EntityResolverDevelopmentDomain is the default entity resolver ENS domain
-	EntityResolverDevelopmentDomain = "entities.dev.voc.eth"
-
-	// ProcessesDomain default process domain
-	ProcessesDomain = "processes.voc.eth"
-	// ProcessesStageDomain stage process domain
-	ProcessesStageDomain = "processes.stg.voc.eth"
-	// ProcessesDevelopmentDomain dev process domain
-	ProcessesDevelopmentDomain = "processes.dev.voc.eth"
-
-	// NamespacesDomain default namespace domain
-	NamespacesDomain = "namespaces.voc.eth"
-	// NamespacesStageDomain stage namespace domain
-	NamespacesStageDomain = "namespaces.stg.voc.eth"
-	// NamespacesDevelopmentDomain dev namespace domain
-	NamespacesDevelopmentDomain = "namespaces.dev.voc.eth"
-
-	// ERC20ProofsDomain default domain for erc20 proofs
-	ERC20ProofsDomain = "erc20.proofs.voc.eth"
-	// ERC20ProofsStageDomain domain for erc20 proofs stage
-	ERC20ProofsStageDomain = "erc20.proofs.stg.voc.eth"
-	// ERC20ProofsDevelopmentDomain domain for erc20 proofs dev
-	ERC20ProofsDevelopmentDomain = "erc20.proofs.dev.voc.eth"
-
-	// GenesisDomain default genesis domain
-	GenesisDomain = "genesis.voc.eth"
-	// GenesisStageDomain stage genesis domain
-	GenesisStageDomain = "genesis.stg.voc.eth"
-	// GenesisDevelopmentDomain dev genesis domain
-	GenesisDevelopmentDomain = "genesis.dev.voc.eth"
-
-	// ResultsDomain default results domain
-	ResultsDomain = "results.voc.eth"
-	// ResultsStageDomain stage results domain
-	ResultsStageDomain = "results.stg.voc.eth"
-	// ResultsDevelopmentDomain dev results domain
-	ResultsDevelopmentDomain = "results.dev.voc.eth"
-
-	// EntityMetaKey is the key of an ENS text record for the entity metadata
-	EntityMetaKey = "vnd.vocdoni.meta"
-
-	// EthereumReadTimeout is the max amount of time for reading anything on
-	// the Ethereum network to wait until canceling it's context
-	EthereumReadTimeout = 1 * time.Minute
-	// EthereumWriteTimeout is the max amount of time for writing anything on
-	// the Ethereum network to wait until canceling it's context
-	EthereumWriteTimeout = 1 * time.Minute
-	// EthereumDialMaxRetry is the max number of attempts an ethereum client will
-	// make in order to dial to an endpoint before considering the endpoint unreachable
-	EthereumDialMaxRetry = 10
-
-	// Indexer
-
-	// IndexerLiveProcessPrefix is used for sotring temporary results on live
-	IndexerLiveProcessPrefix = byte(0x21)
-	// IndexerEntityPrefix is the prefix for the storage entity keys
-	IndexerEntityPrefix = byte(0x22)
-	// IndexerResultsPrefix is the prefix of the storage results summary keys
-	IndexerResultsPrefix = byte(0x24)
-	// IndexerProcessEndingPrefix is the prefix for keep track of the processes ending
-	// on a specific block
-	IndexerProcessEndingPrefix = byte(0x25)
-
-	// ArchiveURL is the default URL where the archive is retrieved from
+	// ArchiveURL is the default URL where the archive is retrieved from.
 	ArchiveURL = "/ipns/k2k4r8mdn544n7f8nprwqeo27jr1v1unsu74th57s1j8mumjck7y7cbz"
 
-	// Vochain
+	// DefaultBlockTimeSeconds is the default block time in seconds.
+	DefaultBlockTimeSeconds = 12
 
-	// PetitionSign contains the string that needs to match with the received vote type
-	// for petition-sign
-	PetitionSign = "petition-sign"
-	// PollVote contains the string that needs to match with the received vote type for poll-vote
-	PollVote = "poll-vote"
-	// EncryptedPoll contains the string that needs to match with the received vote type
-	// for encrypted-poll
-	EncryptedPoll = "encrypted-poll"
-	// SnarkVote contains the string that needs to match with the received vote type for snark-vote
-	SnarkVote = "snark-vote"
-
-	// KeyKeeper
-
-	// KeyKeeperMaxKeyIndex is the maxim number of allowed encryption keys
+	// KeyKeeperMaxKeyIndex is the maxim number of allowed encryption keys.
 	KeyKeeperMaxKeyIndex = 16
 
-	// List of transition names
-
-	TxVote              = "vote"
-	TxNewProcess        = "newProcess"
-	TxCancelProcess     = "cancelProcess" // legacy
-	TxSetProcess        = "setProcess"
-	TxAddValidator      = "addValidator"
-	TxRemoveValidator   = "removeValidator"
-	TxAddProcessKeys    = "addProcessKeys"
-	TxRevealProcessKeys = "revealProcessKeys"
-
-	// ProcessesContractMaxProcessMode represents the max value that a uint8 can have
-	// with the current smart contract bitmask describing the supported process mode
-	ProcessesContractMaxProcessMode = 31
 	// ProcessesContractMaxEnvelopeType represents the max value that a uint8 can have
-	// with the current smart contract bitmask describing the supported envelope types
+	// with the current smart contract bitmask describing the supported envelope types.
 	ProcessesContractMaxEnvelopeType = 31
 
-	// TODO: @jordipainan this values are tricky
-
-	// ProcessesContractMinBlockCount represents the minimum number of vochain blocks
-	// that a process should last
-	ProcessesContractMinBlockCount = 2
-
-	// ProcessesParamsSignatureSize represents the size of a signature on ethereum
-	ProcessesParamsSignatureSize = 32
-
-	VochainWsReadLimit = 20 << 20 // tendermint requires 20 MiB minimum
-	Web3WsReadLimit    = 5 << 20  // go-ethereum accepts maximum 5 MiB
-
+	// MaxURLLength is the maximum length of a URL string used in the protocol.
 	MaxURLLength = 2083
 )

--- a/vochain/indexer/archive_test.go
+++ b/vochain/indexer/archive_test.go
@@ -27,9 +27,13 @@ func TestImportArchive(t *testing.T) {
 	qt.Assert(t, process1.Results().Votes[0][0].MathBigInt().Int64(), qt.Equals, int64(342))
 	qt.Assert(t, process1.Results().Votes[0][1].MathBigInt().Int64(), qt.Equals, int64(365))
 	qt.Assert(t, process1.Results().Votes[0][2].MathBigInt().Int64(), qt.Equals, int64(21))
-	// TODO: qt.Assert(t, process1.Results().Weight.MathBigInt().Int64(), qt.Equals, int64(342+365+21))
+	qt.Assert(t, process1.StartDate, qt.DeepEquals, *archiveProcess1.StartDate)
+	// check that endDate is set after startDate
+	qt.Assert(t, process1.EndDate.After(process1.StartDate), qt.Equals, true)
 }
 
+// This is an old archive process format, we check backwards compatibility.
+// At some point we should update this format to the new one.
 var testArchiveProcess1 = `
 {
   "chainId": "vocdoni-stage-8",

--- a/vochain/indexer/db/models.go
+++ b/vochain/indexer/db/models.go
@@ -27,8 +27,11 @@ type Process struct {
 	EntityID           types.EntityID
 	StartBlock         int64
 	EndBlock           int64
+	StartDate          time.Time
+	EndDate            time.Time
 	BlockCount         int64
 	VoteCount          int64
+	ChainID            string
 	HaveResults        bool
 	FinalResults       bool
 	ResultsVotes       string
@@ -50,6 +53,7 @@ type Process struct {
 	CreationTime       time.Time
 	SourceBlockHeight  int64
 	SourceNetworkID    int64
+	FromArchive        bool
 }
 
 type TokenFee struct {

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -541,8 +541,7 @@ func (idx *Indexer) OnRevealKeys(pid []byte, _ string, _ int32) {
 }
 
 // OnProcessResults verifies the results for a process and appends it to blockUpdateProcs
-func (idx *Indexer) OnProcessResults(pid []byte, _ *models.ProcessResult,
-	_ int32) {
+func (idx *Indexer) OnProcessResults(pid []byte, _ *models.ProcessResult, _ int32) {
 	idx.blockMu.Lock()
 	defer idx.blockMu.Unlock()
 	idx.blockUpdateProcs[string(pid)] = true

--- a/vochain/indexer/indexertypes/types.go
+++ b/vochain/indexer/indexertypes/types.go
@@ -21,6 +21,8 @@ type Process struct {
 	EntityID          types.HexBytes             `json:"entityId"`
 	StartBlock        uint32                     `json:"startBlock"`
 	EndBlock          uint32                     `json:"endBlock"`
+	StartDate         time.Time                  `json:"startDate,omitempty"`
+	EndDate           time.Time                  `json:"endDate,omitempty"`
 	BlockCount        uint32                     `json:"blockCount"`
 	VoteCount         uint64                     `json:"voteCount"`
 	CensusRoot        types.HexBytes             `json:"censusRoot"`
@@ -39,6 +41,8 @@ type Process struct {
 	SourceBlockHeight uint64                     `json:"sourceBlockHeight"`
 	SourceNetworkId   string                     `json:"sourceNetworkId"` // string form of the enum to be user friendly
 	MaxCensusSize     uint64                     `json:"maxCensusSize"`
+	FromArchive       bool                       `json:"fromArchive,omitempty"`
+	ChainID           string                     `json:"chainId,omitempty"`
 
 	PrivateKeys json.RawMessage `json:"-"` // json array
 	PublicKeys  json.RawMessage `json:"-"` // json array
@@ -65,6 +69,8 @@ func ProcessFromDB(dbproc *indexerdb.Process) *Process {
 		EntityID:          nonEmptyBytes(dbproc.EntityID),
 		StartBlock:        uint32(dbproc.StartBlock),
 		EndBlock:          uint32(dbproc.EndBlock),
+		StartDate:         dbproc.StartDate,
+		EndDate:           dbproc.EndDate,
 		BlockCount:        uint32(dbproc.BlockCount),
 		HaveResults:       dbproc.HaveResults,
 		FinalResults:      dbproc.FinalResults,
@@ -80,6 +86,8 @@ func ProcessFromDB(dbproc *indexerdb.Process) *Process {
 		CreationTime:      dbproc.CreationTime,
 		SourceBlockHeight: uint64(dbproc.SourceBlockHeight),
 		Metadata:          dbproc.Metadata,
+		ChainID:           dbproc.ChainID,
+		FromArchive:       dbproc.FromArchive,
 
 		PrivateKeys:        json.RawMessage(dbproc.PrivateKeys),
 		PublicKeys:         json.RawMessage(dbproc.PublicKeys),

--- a/vochain/indexer/migrations/0001_create_table_processes.sql
+++ b/vochain/indexer/migrations/0001_create_table_processes.sql
@@ -4,8 +4,11 @@ CREATE TABLE processes (
   entity_id    BLOB NOT NULL,
   start_block  INTEGER NOT NULL,
   end_block    INTEGER NOT NULL,
+  start_date   DATETIME NOT NULL,
+  end_date     DATETIME NOT NULL,
   block_count  INTEGER NOT NULL,
   vote_count   INTEGER NOT NULL,
+  chain_id     TEXT NOT NULL,
 
   have_results            BOOLEAN NOT NULL,
   final_results           BOOLEAN NOT NULL,
@@ -31,7 +34,8 @@ CREATE TABLE processes (
   question_index      INTEGER NOT NULL,
   creation_time       DATETIME NOT NULL,
   source_block_height INTEGER NOT NULL,
-  source_network_id   INTEGER NOT NULL
+  source_network_id   INTEGER NOT NULL,
+  from_archive        BOOLEAN NOT NULL
 );
 
 CREATE INDEX index_processes_entity_id

--- a/vochain/indexer/queries/processes.sql
+++ b/vochain/indexer/queries/processes.sql
@@ -1,21 +1,23 @@
 -- name: CreateProcess :execresult
 INSERT INTO processes (
-	id, entity_id, start_block, end_block, block_count,
-	vote_count, have_results, final_results, census_root,
+	id, entity_id, start_block, end_block, start_date, end_date, 
+	block_count, vote_count, have_results, final_results, census_root,
 	max_census_size, census_uri, metadata,
 	census_origin, status, namespace,
 	envelope, mode, vote_opts,
 	private_keys, public_keys,
 	question_index, creation_time,
 	source_block_height, source_network_id,
+	from_archive, chain_id,
 
 	results_votes, results_weight, results_block_height
 ) VALUES (
+	?, ?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
-	?, ?, ?, ?,
 	?, ?, ?,
 	?, ?, ?,
 	?, ?, ?,
+	?, ?,
 	?, ?,
 	?, ?,
 	?, ?,
@@ -50,7 +52,8 @@ SET census_root         = sqlc.arg(census_root),
 	private_keys        = sqlc.arg(private_keys),
 	public_keys         = sqlc.arg(public_keys),
 	metadata            = sqlc.arg(metadata),
-	status              = sqlc.arg(status)
+	status              = sqlc.arg(status),
+	start_date 	        = sqlc.arg(start_date)
 WHERE id = sqlc.arg(id);
 
 -- name: GetProcessStatus :one
@@ -70,12 +73,14 @@ UPDATE processes
 SET have_results = TRUE, final_results = TRUE,
 	results_votes = sqlc.arg(votes),
 	results_weight = sqlc.arg(weight),
-	results_block_height = sqlc.arg(block_height)
+	results_block_height = sqlc.arg(block_height),
+	end_date = sqlc.arg(end_date)
 WHERE id = sqlc.arg(id);
 
 -- name: SetProcessResultsCancelled :execresult
 UPDATE processes
-SET have_results = FALSE, final_results = TRUE
+SET have_results = FALSE, final_results = TRUE, 
+    end_date = sqlc.arg(end_date)
 WHERE id = sqlc.arg(id);
 
 -- name: SetProcessVoteCount :execresult
@@ -112,5 +117,6 @@ WHERE id = sqlc.arg(id);
 
 -- name: UpdateProcessEndBlock :execresult
 UPDATE processes
-SET end_block  = sqlc.arg(end_block)
+SET end_block  = sqlc.arg(end_block),
+	end_date = sqlc.arg(end_date)
 WHERE id = sqlc.arg(id);

--- a/vochain/vochaininfo/vochaininfo.go
+++ b/vochain/vochaininfo/vochaininfo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/VictoriaMetrics/metrics"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/dvote/vochain/state"
 )
@@ -68,14 +69,17 @@ func (vi *VochainInfo) updateCounters() {
 	mempoolSize.Set(uint64(vi.vnode.MempoolSize()))
 }
 
-// Height returns the current number of blocks of the blockchain
+// Height returns the current number of blocks of the blockchain.
 func (vi *VochainInfo) Height() uint64 {
 	return height.Get()
 }
 
 // BlockTimes returns the average block time in milliseconds for 1, 10, 60, 360 and 1440 minutes.
-// Value 0 means there is not yet an average
+// Value 0 means there is not yet an average.
 func (vi *VochainInfo) BlockTimes() *[5]uint64 {
+	if vi.vnode.IsSynchronizing() {
+		return &[5]uint64{types.DefaultBlockTimeSeconds, 0, 0, 0, 0}
+	}
 	vi.lock.RLock()
 	defer vi.lock.RUnlock()
 	return &[5]uint64{vi.avg1, vi.avg10, vi.avg60, vi.avg360, vi.avg1440}


### PR DESCRIPTION
- add startTime and endTime to indexer, this way we do not need the block time estimation.

- add the chainID into the indexer database, so we can identify the origin chain

- add fromArchive flag to inform the user about the process being added by the archive