### PR TITLE
fix: not allow to send tokens with "to" and "from" address equals

### DIFF
--- a/vochain/account_test.go
+++ b/vochain/account_test.go
@@ -594,6 +594,33 @@ func TestSendTokensTx(t *testing.T) {
 	qt.Assert(t, fromAcc.Balance, qt.Equals, uint64(890))
 }
 
+func TestSendTokensTxToTheSameAccount(t *testing.T) {
+	app := TestBaseApplication(t)
+
+	signer := ethereum.SignKeys{}
+	err := signer.Generate()
+	qt.Assert(t, err, qt.IsNil)
+
+	app.State.SetAccount(state.BurnAddress, &state.Account{})
+
+	err = app.State.SetTxBaseCost(models.TxType_SEND_TOKENS, 10)
+	qt.Assert(t, err, qt.IsNil)
+
+	err = app.State.CreateAccount(signer.Address(), "ipfs://", [][]byte{}, 0)
+	qt.Assert(t, err, qt.IsNil)
+
+	err = app.State.MintBalance(&vochaintx.TokenTransfer{
+		ToAddress: signer.Address(),
+		Amount:    1000,
+	})
+	qt.Assert(t, err, qt.IsNil)
+	testCommitState(t, app)
+
+	err = testSendTokensTx(t, &signer, app, signer.Address(), 89, 0)
+	qt.Assert(t, err, qt.IsNotNil)
+
+}
+
 func testSendTokensTx(t *testing.T,
 	signer *ethereum.SignKeys,
 	app *BaseApplication,

--- a/vochain/genesis/genesis.go
+++ b/vochain/genesis/genesis.go
@@ -41,8 +41,8 @@ var Genesis = map[string]Vochain{
 }
 
 var devGenesis = Doc{
-	GenesisTime: time.Date(2023, time.October, 31, 1, 0, 0, 0, time.UTC),
-	ChainID:     "vocdoni/DEV/28",
+	GenesisTime: time.Date(2023, time.November, 8, 1, 0, 0, 0, time.UTC),
+	ChainID:     "vocdoni/DEV/29",
 	ConsensusParams: &ConsensusParams{
 		Block: BlockParams{
 			MaxBytes: 2097152,

--- a/vochain/transaction/tokens_tx.go
+++ b/vochain/transaction/tokens_tx.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -30,6 +31,7 @@ func (t *TransactionHandler) SendTokensTxCheck(vtx *vochaintx.Tx) error {
 	if len(tx.To) == 0 {
 		return fmt.Errorf("invalid to address")
 	}
+
 	pubKey, err := ethereum.PubKeyFromSignature(vtx.SignedBody, vtx.Signature)
 	if err != nil {
 		return fmt.Errorf("cannot extract public key from vtx.Signature: %w", err)
@@ -46,6 +48,10 @@ func (t *TransactionHandler) SendTokensTxCheck(vtx *vochaintx.Tx) error {
 		)
 	}
 	txToAddress := common.BytesToAddress(tx.To)
+	if bytes.Equal(txFromAddress.Bytes(), txToAddress.Bytes()) {
+		return fmt.Errorf("to and from address are equal")
+	}
+
 	toTxAccount, err := t.state.GetAccount(txToAddress, false)
 	if err != nil {
 		return fmt.Errorf("cannot get to account: %w", err)


### PR DESCRIPTION
If we transfer from an account to the exact same account the cost is charged but the balance increase, for example, if an account have a balance of `1000` and send 89 tokens to the own same account with a cost of 10, the final balance will be 1079. This fix will prevent send token when address "from" and "to" are the same, in order to avoid the problem that.

Also the genesis dev was updated