### PR TITLE
fix: add json tag with lowercase

### DIFF
--- a/vochain/indexer/indexertypes/types.go
+++ b/vochain/indexer/indexertypes/types.go
@@ -237,6 +237,6 @@ type Account struct {
 
 // TokenTransfersAccount contains the tokes transfers received and sent information in an account
 type TokenTransfersAccount struct {
-	Received []*TokenTransferMeta
-	Sent     []*TokenTransferMeta
+	Received []*TokenTransferMeta `json:"received"`
+	Sent     []*TokenTransferMeta `json:"sent"`
 }


### PR DESCRIPTION
Now the response is: 

```
{
   "transfers":{
      "received":[
         {
            "amount":10,
            "from":"d67350e531daa11c539b1f96de1487e9bc554082",
            "height":4,
            "txHash":"yfA0N4bjMxaFkWKaxhLc1Lm6qJW41AiHszaaXPmLBfA=",
            "timestamp":"2023-11-09T11:04:10.280248641-04:00",
            "to":"34e14abfe5052c4d81982cfaa43fdae3ec637901"
         },
         {
            "amount":80,
            "from":"c52d065a811cbc85aa232f010b42d883c1aa71f0",
            "height":1,
            "txHash":"IN87trSzT9AzKzCrA6Zl0WOZjsY/9BIrnYzQiIPgPJE=",
            "timestamp":"2023-11-09T11:04:10.252218421-04:00",
            "to":"34e14abfe5052c4d81982cfaa43fdae3ec637901"
         }
      ],
      "sent":[
         {
            "amount":25,
            "from":"34e14abfe5052c4d81982cfaa43fdae3ec637901",
            "height":3,
            "txHash":"Pd70tJAFtx6Q6tah4eFIVnGFGjEjoGDFd5xbcJZzFXs=",
            "timestamp":"2023-11-09T11:04:10.27257822-04:00",
            "to":"d67350e531daa11c539b1f96de1487e9bc554082"
         }
      ]
   }
}
```