### PR TITLE
end2endtest: check siks are deleted when use TempSIKs

### DIFF
--- a/cmd/end2endtest/helpers.go
+++ b/cmd/end2endtest/helpers.go
@@ -373,6 +373,17 @@ func (t *e2eElection) setupElection(ed *vapi.ElectionDescription, nvAccts int) e
 					log.Errorf("gave up waiting for tx %x to be mined: %s", hash, err)
 					errorChan <- err
 				}
+
+				// check if the current account has a valid SIK
+				validSik, err := accountApi.ValidSIK()
+				if err != nil {
+					errorChan <- fmt.Errorf("unexpected error in account %s, when validate SIK, %s", acc.Address(), err)
+				}
+				if !validSik {
+					errorChan <- fmt.Errorf("unexpected invalid SIK for account %x", acc.Address())
+				}
+				log.Infof("valid SIK for the account %x", acc.Address())
+
 			}(i, acc)
 		}
 


### PR DESCRIPTION
For the `anonelectionTempSIKsValidate` test, at the end of the election the half of the accounts should not have a valid SIK, due they are using temporal SIK, and the other half of accounts should have it.

#1179