### PR TITLE
vochain: improve blocktime estimation

### DIFF
--- a/api/chain.go
+++ b/api/chain.go
@@ -302,7 +302,7 @@ func (a *API) chainInfoHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) 
 
 	data, err := json.Marshal(&ChainInfo{
 		ID:                      a.vocapp.ChainID(),
-		BlockTime:               *a.vocinfo.BlockTimes(),
+		BlockTime:               a.vocinfo.BlockTimes(),
 		ElectionCount:           a.indexer.CountTotalProcesses(),
 		OrganizationCount:       a.indexer.CountTotalEntities(),
 		Height:                  a.vocapp.Height(),

--- a/service/vochain.go
+++ b/service/vochain.go
@@ -140,9 +140,9 @@ func (vs *VocdoniService) Start() error {
 			time.Sleep(time.Second * 1)
 			if i%10 == 0 {
 				log.Monitor("vochain fastsync", map[string]any{
-					"height":   vs.Stats.Height(),
-					"blocks/s": float64(vs.Stats.Height()-lastHeight) / time.Since(timeCounter).Seconds(),
-					"peers":    vs.Stats.NPeers(),
+					"height":     vs.Stats.Height(),
+					"blocks/sec": fmt.Sprintf("%.2f", float64(vs.Stats.Height()-lastHeight)/time.Since(timeCounter).Seconds()),
+					"peers":      vs.Stats.NPeers(),
 				})
 				timeCounter = time.Now()
 				lastHeight = vs.Stats.Height()
@@ -166,25 +166,18 @@ func (vs *VocdoniService) Start() error {
 
 // VochainPrintInfo initializes the Vochain statistics recollection.
 func VochainPrintInfo(interval time.Duration, vi *vochaininfo.VochainInfo) {
-	var a *[5]uint64
 	var h uint64
 	var p, v uint64
 	var m, vc, vxm uint64
 	var b strings.Builder
 	for {
 		b.Reset()
-		a = vi.BlockTimes()
-		if a[0] > 0 {
-			fmt.Fprintf(&b, "1m:%.2f", float32(a[0])/1000)
-		}
+		a := vi.BlockTimes()
 		if a[1] > 0 {
 			fmt.Fprintf(&b, " 10m:%.2f", float32(a[1])/1000)
 		}
 		if a[2] > 0 {
 			fmt.Fprintf(&b, " 1h:%.2f", float32(a[2])/1000)
-		}
-		if a[3] > 0 {
-			fmt.Fprintf(&b, " 6h:%.2f", float32(a[3])/1000)
 		}
 		if a[4] > 0 {
 			fmt.Fprintf(&b, " 24h:%.2f", float32(a[4])/1000)
@@ -195,14 +188,15 @@ func VochainPrintInfo(interval time.Duration, vi *vochaininfo.VochainInfo) {
 		vc = vi.VoteCacheSize()
 		log.Monitor("vochain status",
 			map[string]any{
-				"height":    h,
-				"mempool":   m,
-				"peers":     vi.NPeers(),
-				"elections": p,
-				"votes":     v,
-				"voteCache": vc,
-				"votes/min": vxm,
-				"blockTime": b.String(),
+				"height":       h,
+				"mempool":      m,
+				"peers":        vi.NPeers(),
+				"elections":    p,
+				"votes":        v,
+				"voteCache":    vc,
+				"votes/min":    vxm,
+				"blockPeriod":  b.String(),
+				"blocksMinute": fmt.Sprintf("%.2f", vi.BlocksLastMinute()),
 			})
 
 		time.Sleep(interval)

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -195,7 +195,7 @@ func (app *BaseApplication) ExecuteBlock(txs [][]byte, height uint32, blockTime 
 func (app *BaseApplication) CommitState() ([]byte, error) {
 	// Commit the state and get the hash
 	if app.State.TxCounter() > 0 {
-		log.Infow("commit block", "height", app.Height(), "txs", app.State.TxCounter())
+		log.Debugw("commit block", "height", app.Height(), "txs", app.State.TxCounter())
 	}
 	hash, err := app.State.Save()
 	if err != nil {

--- a/vochain/cometbft.go
+++ b/vochain/cometbft.go
@@ -459,6 +459,15 @@ func (app *BaseApplication) ProcessProposal(_ context.Context,
 	}
 
 	startTime := time.Now()
+
+	// TODO: check if we can enable this check without breaking consensus
+	//
+	// Check if the time difference is within the allowed threshold
+	//	timeDiff := startTime.Sub(req.Time)
+	//	if timeDiff > allowedConsensusTimeDiff {
+	//		return nil, fmt.Errorf("the time difference for the proposal exceeds the threshold")
+	//	}
+
 	resp, err := app.ExecuteBlock(req.Txs, uint32(req.GetHeight()), req.GetTime())
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute block on process proposal: %w", err)

--- a/vochain/vochaininfo/metrics.go
+++ b/vochain/vochaininfo/metrics.go
@@ -3,11 +3,13 @@ package vochaininfo
 import "github.com/VictoriaMetrics/metrics"
 
 var (
-	height          = metrics.NewCounter("vochain_height")       // Height of the vochain (last block)
-	voteCount       = metrics.NewCounter("vochain_vote_tree")    // Total vote count
-	processTreeSize = metrics.NewCounter("vochain_process_tree") // Size of the process tree
-	accountTreeSize = metrics.NewCounter("vochain_account_tree") // Size of the account tree
-	sikTreeSize     = metrics.NewCounter("vochain_sik_tree")     // Size of the SIK tree
-	mempoolSize     = metrics.NewCounter("vochain_mempool")      // Number of Txs in the mempool
-	voteCacheSize   = metrics.NewCounter("vochain_vote_cache")   // Size of the current vote cache
+	height               = metrics.NewCounter("vochain_height")              // Height of the vochain (last block)
+	voteCount            = metrics.NewCounter("vochain_vote_tree")           // Total vote count
+	processTreeSize      = metrics.NewCounter("vochain_process_tree")        // Size of the process tree
+	accountTreeSize      = metrics.NewCounter("vochain_account_tree")        // Size of the account tree
+	sikTreeSize          = metrics.NewCounter("vochain_sik_tree")            // Size of the SIK tree
+	mempoolSize          = metrics.NewCounter("vochain_mempool")             // Number of Txs in the mempool
+	voteCacheSize        = metrics.NewCounter("vochain_vote_cache")          // Size of the current vote cache
+	blockPeriodMinute    = metrics.NewCounter("vochain_block_period_minute") // Block period for the last minute
+	blocksSyncLastMinute = metrics.NewCounter("vochain_blocks_sync_minute")  // Blocks synced the last minute
 )

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -448,14 +448,13 @@ func (vc *Vocone) getTxWithHash(height uint32, txIndex int32) (*models.SignedTx,
 
 // VochainPrintInfo initializes the Vochain statistics recollection
 func vochainPrintInfo(interval time.Duration, vi *vochaininfo.VochainInfo) {
-	var a *[5]uint64
 	var h uint64
 	var p, v uint64
 	var m, vc, vxm uint64
 	var b strings.Builder
 	for {
 		b.Reset()
-		a = vi.BlockTimes()
+		a := vi.BlockTimes()
 		if a[0] > 0 {
 			fmt.Fprintf(&b, "1m:%.2f", float32(a[0])/1000)
 		}
@@ -476,13 +475,14 @@ func vochainPrintInfo(interval time.Duration, vi *vochaininfo.VochainInfo) {
 		p, v, vxm = vi.TreeSizes()
 		vc = vi.VoteCacheSize()
 		log.Monitor("[vochain info]", map[string]any{
-			"height":    h,
-			"mempool":   m,
-			"processes": p,
-			"votes":     v,
-			"vxm":       vxm,
-			"voteCache": vc,
-			"blockTime": b.String(),
+			"height":       h,
+			"mempool":      m,
+			"processes":    p,
+			"votes":        v,
+			"vxm":          vxm,
+			"voteCache":    vc,
+			"blockPeriod":  b.String(),
+			"blocksMinute": fmt.Sprintf("%.2f", vi.BlocksLastMinute()),
 		})
 		time.Sleep(interval)
 	}


### PR DESCRIPTION
Use blocktimes from the block headers. This provides a more accurate way to estimate election times.