### PR TITLE
vochain fork: bump vocdoni/STAGE/9 ForkBlock

### DIFF
--- a/config/forks.go
+++ b/config/forks.go
@@ -11,7 +11,7 @@ var Forks = map[string]*ForksCfg{
 		VoceremonyForkBlock: 217200, // estimated 2023-12-05T11:33:31.426638381Z
 	},
 	"vocdoni/STAGE/9": {
-		VoceremonyForkBlock: 247000, // estimated 2023-12-11T08:47:56.552083308Z
+		VoceremonyForkBlock: 249500, // estimated 2023-12-11T10:38:31.862340282Z
 	},
 	"vocdoni/LTS/1.2": {
 		VoceremonyForkBlock: 393000, // estimated 2023-12-11T11:51:47.046130989Z


### PR DESCRIPTION
`stage` branch was not updated last week, and planned fork time is past. bump it. LTS is still on time todayii