### PR TITLE
fork lts today at 12:50pm UTC+1

### DIFF
--- a/api/api_types.go
+++ b/api/api_types.go
@@ -200,20 +200,20 @@ type GenericTransactionWithInfo struct {
 }
 
 type ChainInfo struct {
-	ID                      string    `json:"chainId" example:"azeno"`
-	BlockTime               [5]uint64 `json:"blockTime" example:"12000,11580,11000,11100,11100"`
-	ElectionCount           uint64    `json:"electionCount" example:"120"`
-	OrganizationCount       uint64    `json:"organizationCount" example:"20"`
-	GenesisTime             time.Time `json:"genesisTime"  format:"date-time" example:"2022-11-17T18:00:57.379551614Z"`
-	Height                  uint32    `json:"height" example:"5467"`
-	Syncing                 bool      `json:"syncing" example:"true"`
-	Timestamp               int64     `json:"blockTimestamp" swaggertype:"string" format:"date-time" example:"2022-11-17T18:00:57.379551614Z"`
-	TransactionCount        uint64    `json:"transactionCount" example:"554"`
-	ValidatorCount          uint32    `json:"validatorCount" example:"5"`
-	VoteCount               uint64    `json:"voteCount" example:"432"`
-	CircuitConfigurationTag string    `json:"cicuitConfigurationTag" example:"dev"`
-	MaxCensusSize           uint64    `json:"maxCensusSize" example:"50000"`
-	NetworkCapacity         uint64    `json:"networkCapacity" example:"2000"`
+	ID                string    `json:"chainId" example:"azeno"`
+	BlockTime         [5]uint64 `json:"blockTime" example:"12000,11580,11000,11100,11100"`
+	ElectionCount     uint64    `json:"electionCount" example:"120"`
+	OrganizationCount uint64    `json:"organizationCount" example:"20"`
+	GenesisTime       time.Time `json:"genesisTime"  format:"date-time" example:"2022-11-17T18:00:57.379551614Z"`
+	Height            uint32    `json:"height" example:"5467"`
+	Syncing           bool      `json:"syncing" example:"true"`
+	Timestamp         int64     `json:"blockTimestamp" swaggertype:"string" format:"date-time" example:"2022-11-17T18:00:57.379551614Z"`
+	TransactionCount  uint64    `json:"transactionCount" example:"554"`
+	ValidatorCount    uint32    `json:"validatorCount" example:"5"`
+	VoteCount         uint64    `json:"voteCount" example:"432"`
+	CircuitVersion    string    `json:"circuitVersion" example:"v1.0.0"`
+	MaxCensusSize     uint64    `json:"maxCensusSize" example:"50000"`
+	NetworkCapacity   uint64    `json:"networkCapacity" example:"2000"`
 }
 
 type Account struct {

--- a/api/censuses.go
+++ b/api/censuses.go
@@ -209,14 +209,9 @@ func (a *API) censusCreateHandler(msg *apirest.APIdata, ctx *httprouter.HTTPCont
 		return ErrCensusTypeUnknown
 	}
 
-	// get census max levels from vochain app if available
-	maxLevels := circuit.CircuitsConfigurations[circuit.DefaultCircuitConfigurationTag].Levels
-	if a.vocapp != nil {
-		maxLevels = a.vocapp.TransactionHandler.ZkCircuit.Config.Levels
-	}
-
+	// census max levels is limited by global ZkCircuit Levels
 	censusID := util.RandomBytes(32)
-	_, err = a.censusdb.New(censusID, censusType, "", &token, maxLevels)
+	_, err = a.censusdb.New(censusID, censusType, "", &token, circuit.Global().Config.Levels)
 	if err != nil {
 		return err
 	}

--- a/api/chain.go
+++ b/api/chain.go
@@ -301,20 +301,20 @@ func (a *API) chainInfoHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) 
 	}
 
 	data, err := json.Marshal(&ChainInfo{
-		ID:                      a.vocapp.ChainID(),
-		BlockTime:               a.vocinfo.BlockTimes(),
-		ElectionCount:           a.indexer.CountTotalProcesses(),
-		OrganizationCount:       a.indexer.CountTotalEntities(),
-		Height:                  a.vocapp.Height(),
-		Syncing:                 a.vocapp.IsSynchronizing(),
-		TransactionCount:        transactionCount,
-		ValidatorCount:          uint32(len(validators)),
-		Timestamp:               a.vocapp.Timestamp(),
-		VoteCount:               voteCount,
-		GenesisTime:             a.vocapp.Genesis().GenesisTime,
-		CircuitConfigurationTag: a.vocapp.CircuitConfigurationTag(),
-		MaxCensusSize:           maxCensusSize,
-		NetworkCapacity:         networkCapacity,
+		ID:                a.vocapp.ChainID(),
+		BlockTime:         a.vocinfo.BlockTimes(),
+		ElectionCount:     a.indexer.CountTotalProcesses(),
+		OrganizationCount: a.indexer.CountTotalEntities(),
+		Height:            a.vocapp.Height(),
+		Syncing:           a.vocapp.IsSynchronizing(),
+		TransactionCount:  transactionCount,
+		ValidatorCount:    uint32(len(validators)),
+		Timestamp:         a.vocapp.Timestamp(),
+		VoteCount:         voteCount,
+		GenesisTime:       a.vocapp.Genesis().GenesisTime,
+		CircuitVersion:    circuit.Version(),
+		MaxCensusSize:     maxCensusSize,
+		NetworkCapacity:   networkCapacity,
 	})
 	if err != nil {
 		return err
@@ -329,13 +329,11 @@ func (a *API) chainInfoHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) 
 //	@Tags			Chain
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{object}	circuit.ZkCircuitConfig
+//	@Success		200	{object}	circuit.Config
 //	@Router			/chain/info/circuit [get]
 func (a *API) chainCircuitInfoHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) error {
-	// Get current circuit tag
-	circuitConfig := circuit.GetCircuitConfiguration(a.vocapp.CircuitConfigurationTag())
-	// Encode the circuit configuration to JSON
-	data, err := json.Marshal(circuitConfig)
+	// Encode the current circuit configuration to JSON
+	data, err := json.Marshal(circuit.Global().Config)
 	if err != nil {
 		return err
 	}

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -41,7 +41,7 @@ type HTTPclient struct {
 	addr    *url.URL
 	account *ethereum.SignKeys
 	chainID string
-	circuit *circuit.ZkCircuitConfig
+	circuit *circuit.ZkCircuit
 	retries int
 }
 
@@ -72,8 +72,11 @@ func NewHTTPclient(addr *url.URL, bearerToken *uuid.UUID) (*HTTPclient, error) {
 		return nil, fmt.Errorf("cannot get chain ID from API server")
 	}
 	c.chainID = info.ID
-	// Get the default circuit config
-	c.circuit = circuit.GetCircuitConfiguration(info.CircuitConfigurationTag)
+
+	c.circuit, err = circuit.LoadVersion(info.CircuitVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error loading circuit: %w", err)
+	}
 	return c, nil
 }
 

--- a/apiclient/vote.go
+++ b/apiclient/vote.go
@@ -1,7 +1,6 @@
 package apiclient
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -102,14 +101,9 @@ func (cl *HTTPclient) Vote(v *VoteData) (types.HexBytes, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error encoding inputs: %w", err)
 		}
-		// load the correct circuit from the ApiClient configuration
-		currentCircuit, err := circuit.LoadZkCircuit(context.Background(), c.circuit)
-		if err != nil {
-			return nil, fmt.Errorf("error loading circuit: %w", err)
-		}
 		// instance the prover with the circuit config loaded and generate the
 		// proof for the calculated inputs
-		proof, err := prover.Prove(currentCircuit.ProvingKey, currentCircuit.Wasm, inputs)
+		proof, err := prover.Prove(c.circuit.ProvingKey, c.circuit.Wasm, inputs)
 		if err != nil {
 			return nil, fmt.Errorf("could not generate anonymous proof: %w", err)
 		}
@@ -119,7 +113,7 @@ func (cl *HTTPclient) Vote(v *VoteData) (types.HexBytes, error) {
 			return nil, err
 		}
 		// include vote nullifier and the encoded proof in a VoteEnvelope
-		nullifier, err := proof.Nullifier()
+		nullifier, err := proof.ExtractPubSignal("nullifier")
 		if err != nil {
 			return nil, err
 		}

--- a/benchmark/zk_census_benchmark_test.go
+++ b/benchmark/zk_census_benchmark_test.go
@@ -158,7 +158,7 @@ func genProofZk(b *testing.B, electionID []byte, acc *ethereum.SignKeys, censusD
 		"nullifier", nullifier.String())
 
 	// Get artifacts of the current circuit
-	currentCircuit, err := circuit.LoadZkCircuit(context.Background(), zkCircuitTest)
+	currentCircuit, err := circuit.LoadConfig(context.Background(), zkCircuitTest)
 	qt.Assert(b, err, qt.IsNil)
 	// Calculate the proof for the current apiclient circuit config and the
 	// inputs encoded.

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -79,8 +79,8 @@ func newConfig() (*config.Config, config.Error) {
 		"directory where data is stored")
 	flag.StringVarP(&conf.Vochain.DBType, "dbType", "t", db.TypePebble,
 		fmt.Sprintf("key-value db type [%s,%s,%s]", db.TypePebble, db.TypeLevelDB, db.TypeMongo))
-	flag.StringVarP(&conf.Vochain.Chain, "chain", "c", "dev",
-		fmt.Sprintf("vocdoni blockchain to connect with: %q", genesis.AvailableChains()))
+	flag.StringVarP(&conf.Vochain.Network, "chain", "c", "dev",
+		fmt.Sprintf("vocdoni network to connect with: %q", genesis.AvailableNetworks()))
 	flag.BoolVar(&conf.Dev, "dev", false,
 		"use developer mode (less security)")
 	conf.PprofPort = *flag.Int("pprof", 0,
@@ -181,7 +181,7 @@ func newConfig() (*config.Config, config.Error) {
 	if err = viper.BindPFlag("chain", flag.Lookup("chain")); err != nil {
 		log.Fatalf("failed to bind chain flag to viper: %v", err)
 	}
-	conf.Vochain.Chain = viper.GetString("chain")
+	conf.Vochain.Network = viper.GetString("chain")
 
 	if err = viper.BindPFlag("dev", flag.Lookup("dev")); err != nil {
 		log.Fatalf("failed to bind dev flag to viper: %v", err)
@@ -197,8 +197,8 @@ func newConfig() (*config.Config, config.Error) {
 	}
 	conf.Vochain.DBType = viper.GetString("dbType")
 
-	// use different datadirs for different chains
-	conf.DataDir = filepath.Join(conf.DataDir, conf.Vochain.Chain)
+	// use different datadirs for different networks
+	conf.DataDir = filepath.Join(conf.DataDir, conf.Vochain.Network)
 
 	if err = viper.BindPFlag("archiveURL", flag.Lookup("archiveURL")); err != nil {
 		log.Fatalf("failed to bind archiveURL flag to viper: %v", err)
@@ -478,7 +478,7 @@ func main() {
 		}()
 	}
 	log.Infow("starting vocdoni node", "version", internal.Version, "mode", conf.Mode,
-		"chain", conf.Vochain.Chain, "dbType", conf.Vochain.DBType)
+		"network", conf.Vochain.Network, "dbType", conf.Vochain.DBType)
 	if conf.Dev {
 		log.Warn("developer mode is enabled!")
 	}
@@ -517,8 +517,8 @@ func main() {
 			srv.Config.TendermintMetrics = true
 			srv.Router.ExposePrometheusEndpoint("/metrics")
 
-			metrics.NewCounter(fmt.Sprintf("vocdoni_info{version=%q,mode=%q,chain=%q}",
-				internal.Version, conf.Mode, conf.Vochain.Chain)).Set(1)
+			metrics.NewCounter(fmt.Sprintf("vocdoni_info{version=%q,mode=%q,network=%q}",
+				internal.Version, conf.Mode, conf.Vochain.Network)).Set(1)
 		}
 	}
 

--- a/cmd/vochaininspector/inspector.go
+++ b/cmd/vochaininspector/inspector.go
@@ -170,9 +170,9 @@ func main() {
 	}
 }
 
-func newVochain(chain, dataDir string) *vochain.BaseApplication {
+func newVochain(network, dataDir string) *vochain.BaseApplication {
 	cfg := &config.VochainCfg{
-		Chain:     chain,
+		Network:   network,
 		Dev:       true,
 		LogLevel:  "error",
 		DataDir:   dataDir,
@@ -192,7 +192,7 @@ func newVochain(chain, dataDir string) *vochain.BaseApplication {
 	}
 	log.Infof("external ip address %s", cfg.PublicAddr)
 	// Create the vochain node
-	genesisBytes := genesis.Genesis[chain].Genesis.Marshal()
+	genesisBytes := genesis.Genesis[network].Genesis.Marshal()
 	return vochain.NewVochain(cfg, genesisBytes)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -85,8 +85,8 @@ type IPFSCfg struct {
 
 // VochainCfg includes all possible config params needed by the Vochain
 type VochainCfg struct {
-	// Chain is the network name to connect with
-	Chain string
+	// Network is the network name to connect with
+	Network string
 	// Dev indicates we use the Vochain development mode (low security is accepted)
 	Dev bool
 	// LogLevel logging level for tendermint

--- a/config/forks.go
+++ b/config/forks.go
@@ -11,7 +11,7 @@ var Forks = map[string]*ForksCfg{
 		VoceremonyForkBlock: 217200, // estimated 2023-12-05T11:33:31.426638381Z
 	},
 	"vocdoni/STAGE/9": {
-		VoceremonyForkBlock: 247000, // estimated 2023-12-11T08:47:56.552083308Z
+		VoceremonyForkBlock: 249500, // estimated 2023-12-11T10:38:31.862340282Z
 	},
 	"vocdoni/LTS/1.2": {
 		VoceremonyForkBlock: 393000, // estimated 2023-12-11T11:51:47.046130989Z

--- a/config/forks.go
+++ b/config/forks.go
@@ -1,0 +1,27 @@
+package config
+
+// ForksCfg allows applying softforks at specified heights
+type ForksCfg struct {
+	VoceremonyForkBlock uint32
+}
+
+// Forks is a map of chainIDs
+var Forks = map[string]*ForksCfg{
+	"vocdoni/DEV/29": {
+		VoceremonyForkBlock: 217200, // estimated 2023-12-05T11:33:31.426638381Z
+	},
+	"vocdoni/STAGE/9": {
+		VoceremonyForkBlock: 247000, // estimated 2023-12-11T08:47:56.552083308Z
+	},
+	"vocdoni/LTS/1.2": {
+		VoceremonyForkBlock: 393000, // estimated 2023-12-11T11:51:47.046130989Z
+	},
+}
+
+// ForksForChainID returns the ForksCfg of chainID, if found, or an empty ForksCfg otherwise
+func ForksForChainID(chainID string) *ForksCfg {
+	if cfg, found := Forks[chainID]; found {
+		return cfg
+	}
+	return &ForksCfg{}
+}

--- a/crypto/ethereum/vocdoni_sik.go
+++ b/crypto/ethereum/vocdoni_sik.go
@@ -5,8 +5,8 @@ import (
 	"math/big"
 
 	"github.com/iden3/go-iden3-crypto/poseidon"
-	"go.vocdoni.io/dvote/crypto/zk"
 	"go.vocdoni.io/dvote/tree/arbo"
+	"go.vocdoni.io/dvote/util"
 )
 
 // SIKsignature signs the default vocdoni sik payload. It envolves the
@@ -38,8 +38,8 @@ func (k *SignKeys) AccountSIK(secret []byte) ([]byte, error) {
 	}
 	seed := []*big.Int{
 		arbo.BytesToBigInt(k.Address().Bytes()),
-		zk.BigToFF(new(big.Int).SetBytes(secret)),
-		zk.BigToFF(new(big.Int).SetBytes(sign)),
+		util.BigToFF(new(big.Int).SetBytes(secret)),
+		util.BigToFF(new(big.Int).SetBytes(sign)),
 	}
 	hash, err := poseidon.Hash(seed)
 	if err != nil {
@@ -58,14 +58,14 @@ func (k *SignKeys) AccountSIKnullifier(electionID, secret []byte) ([]byte, error
 	}
 	// get the representation of the signature on the finite field and repeat
 	// the same with the secret if it is provided, if not add a zero
-	seed := []*big.Int{zk.BigToFF(new(big.Int).SetBytes(sign))}
+	seed := []*big.Int{util.BigToFF(new(big.Int).SetBytes(sign))}
 	if secret != nil {
-		seed = append(seed, zk.BigToFF(new(big.Int).SetBytes(secret)))
+		seed = append(seed, util.BigToFF(new(big.Int).SetBytes(secret)))
 	} else {
 		seed = append(seed, big.NewInt(0))
 	}
 	// encode the election id for circom and include it into the nullifier
-	seed = append(seed, zk.BytesToArbo(electionID)...)
+	seed = append(seed, util.BytesToArbo(electionID)...)
 	// calculate the poseidon image --> H(signature + secret + electionId)
 	hash, err := poseidon.Hash(seed)
 	if err != nil {

--- a/crypto/zk/circuit/circuit_test.go
+++ b/crypto/zk/circuit/circuit_test.go
@@ -46,7 +46,7 @@ func TestLoadZkCircuit(t *testing.T) {
 	server := testFileServer(testFiles)
 	defer server.Close()
 
-	config := &ZkCircuitConfig{
+	config := &Config{
 		URI:                     server.URL,
 		CircuitPath:             "/test/",
 		ProvingKeyFilename:      testProvingKey,
@@ -69,7 +69,7 @@ func TestLoadZkCircuit(t *testing.T) {
 	testCircuits := filepath.Join(BaseDir, config.CircuitPath)
 	defer os.RemoveAll(testCircuits)
 
-	circuit, err := LoadZkCircuit(context.Background(), config)
+	circuit, err := LoadConfig(context.Background(), config)
 	c.Assert(err, qt.IsNil)
 	c.Assert(circuit.ProvingKey, qt.DeepEquals, testFiles[testProvingKey])
 	c.Assert(circuit.VerificationKey, qt.DeepEquals, testFiles[testVerificationKey])
@@ -90,7 +90,7 @@ func TestLoadLocal(t *testing.T) {
 	c := qt.New(t)
 
 	circuit := &ZkCircuit{
-		Config: &ZkCircuitConfig{
+		Config: &Config{
 			CircuitPath:             "/test/",
 			ProvingKeyFilename:      testProvingKey,
 			VerificationKeyFilename: testVerificationKey,
@@ -135,7 +135,7 @@ func TestLoadRemote(t *testing.T) {
 	defer server.Close()
 
 	circuit := &ZkCircuit{
-		Config: &ZkCircuitConfig{
+		Config: &Config{
 			URI:                     server.URL,
 			CircuitPath:             "/test/",
 			ProvingKeyFilename:      testProvingKey,
@@ -199,7 +199,7 @@ func TestVerifiedCircuitArtifacts(t *testing.T) {
 		ProvingKey:      testFiles[testProvingKey],
 		VerificationKey: testFiles[testVerificationKey],
 		Wasm:            testFiles[testWasm],
-		Config:          &ZkCircuitConfig{},
+		Config:          &Config{},
 	}
 
 	hashFn := sha256.New()

--- a/crypto/zk/circuit/config.go
+++ b/crypto/zk/circuit/config.go
@@ -10,14 +10,10 @@ import (
 	"go.vocdoni.io/dvote/util"
 )
 
-// DefaultCircuitConfigurationTag constant contains the tag value that points
-// to the default ZkSnark circuit configuration. It ensures that at least one
-// circuit configuration is available so the configuration referred by this tag
-// must be defined.
-const DefaultCircuitConfigurationTag = "dev"
-
-// ZkCircuitConfig defines the configuration of the files to be downloaded
-type ZkCircuitConfig struct {
+// Config defines the configuration of the files to be downloaded
+type Config struct {
+	// Version of the published circuit
+	Version string
 	// URI defines the URI from where to download the files
 	URI string `json:"uri"`
 	// CircuitPath defines the path from where the files are downloaded.
@@ -41,6 +37,8 @@ type ZkCircuitConfig struct {
 	// FilenameWasm defines the name of the file of the circuit wasm compiled
 	// version
 	WasmFilename string `json:"wasmFilename"` // circuit.wasm
+	// PublicSignals indicates the index of each public signal
+	PublicSignals map[string]int
 	// maxCensusSize contains a precomputed max size of a census for the
 	// circuit, which is defined by the expresion:
 	//   maxCensusSize = 2^circuitLevels
@@ -49,7 +47,7 @@ type ZkCircuitConfig struct {
 
 // KeySize returns the maximum number of bytes of a leaf key according to the
 // number of levels of the current circuit (nBytes = nLevels / 8).
-func (conf *ZkCircuitConfig) KeySize() int {
+func (conf *Config) KeySize() int {
 	return conf.Levels / 8
 }
 
@@ -57,7 +55,7 @@ func (conf *ZkCircuitConfig) KeySize() int {
 // for the census supports. The method checks if it is already precalculated
 // or not. If it is not precalculated, it will calculate and initialise it. In
 // any case, the value is returned as big.Int.
-func (conf *ZkCircuitConfig) MaxCensusSize() *big.Int {
+func (conf *Config) MaxCensusSize() *big.Int {
 	if conf.maxCensusSize != nil {
 		return conf.maxCensusSize
 	}
@@ -71,18 +69,30 @@ func (conf *ZkCircuitConfig) MaxCensusSize() *big.Int {
 // SupportsCensusSize returns if the provided censusSize is supported by the
 // current circuit configuration. It ensures that the provided value is lower
 // than 2^config.Levels.
-func (conf *ZkCircuitConfig) SupportsCensusSize(maxCensusSize uint64) bool {
+func (conf *Config) SupportsCensusSize(maxCensusSize uint64) bool {
 	return conf.MaxCensusSize().Cmp(new(big.Int).SetUint64(maxCensusSize)) > 0
 }
+
+// DefaultZkCircuitVersion is the circuit version used by default
+const DefaultZkCircuitVersion = V1_0_0
+
+// PreVoceremonyForkZkCircuitVersion is the circuit version used before VoceremonyForkBlock
+const PreVoceremonyForkZkCircuitVersion = V0_0_1
+
+// Version strings
+const (
+	V0_0_1 = "v0.0.1"
+	V1_0_0 = "v1.0.0"
+)
 
 // CircuitsConfigurations stores the relation between the different vochain nets
 // and the associated circuit configuration. Any circuit configuration must have
 // the remote and local location of the circuits artifacts and their metadata
 // such as artifacts hash or the number of parameters.
-var CircuitsConfigurations = map[string]*ZkCircuitConfig{
-	"dev": {
-		URI: "https://raw.githubusercontent.com/vocdoni/" +
-			"zk-franchise-proof-circuit/master",
+var CircuitsConfigurations = map[string]*Config{
+	V0_0_1: {
+		Version:                 V0_0_1,
+		URI:                     "https://raw.githubusercontent.com/vocdoni/zk-franchise-proof-circuit/master",
 		CircuitPath:             "artifacts/zkCensus/dev/160",
 		Levels:                  160, // ZkCircuit number of levels
 		ProvingKeyHash:          hexToBytes("0xe359b256e5e3c78acaccf8dab5dc4bea99a2f07b2a05e935b5ca658c714dea4a"),
@@ -91,30 +101,53 @@ var CircuitsConfigurations = map[string]*ZkCircuitConfig{
 		VerificationKeyFilename: "verification_key.json",
 		WasmHash:                hexToBytes("0x80a73567f6a4655d4332301efcff4bc5711bb48176d1c71fdb1e48df222ac139"),
 		WasmFilename:            "circuit.wasm",
+		PublicSignals: map[string]int{
+			"electionId[0]": 0,
+			"electionId[1]": 1,
+			"nullifier":     2,
+			"voteHash[0]":   3,
+			"voteHash[1]":   4,
+			"sikRoot":       5,
+			"censusRoot":    6,
+			"voteWeight":    7,
+		},
 	},
-	"prod": {
-		URI: "https://raw.githubusercontent.com/vocdoni/" +
-			"zk-franchise-proof-circuit/master",
-		CircuitPath:             "artifacts/zkCensus/dev/160",
+	V1_0_0: {
+		Version:                 V1_0_0,
+		URI:                     "https://raw.githubusercontent.com/vocdoni/zk-voceremony",
+		CircuitPath:             "ceremony/vocdoni-zkcensus-ceremony/results",
 		Levels:                  160, // ZkCircuit number of levels
-		ProvingKeyHash:          hexToBytes("0xe359b256e5e3c78acaccf8dab5dc4bea99a2f07b2a05e935b5ca658c714dea4a"),
-		ProvingKeyFilename:      "proving_key.zkey",
-		VerificationKeyHash:     hexToBytes("0x235e55571812f8e324e73e37e53829db0c4ac8f68469b9b953876127c97b425f"),
-		VerificationKeyFilename: "verification_key.json",
-		WasmHash:                hexToBytes("0x80a73567f6a4655d4332301efcff4bc5711bb48176d1c71fdb1e48df222ac139"),
-		WasmFilename:            "circuit.wasm",
+		ProvingKeyHash:          hexToBytes("0x94f4062db3e43175ac1136f285551d547a177e37b0616a41900a38ed5ec3d478"),
+		ProvingKeyFilename:      "census_proving_key.zkey",
+		VerificationKeyHash:     hexToBytes("0x2a47ff7e511926290fedfa406886944eeb0a3df9021ca26333c0c124c89aa7b0"),
+		VerificationKeyFilename: "census_verification_key.json",
+		WasmHash:                hexToBytes("0xc98133cf4d84ced677549e0d848739f4e80ddf78af678cbc8b95377247a92773"),
+		WasmFilename:            "census.wasm",
+		// Due to a bug in this circuit definition, voteWeight ended up being a private signal,
+		// and the only public weight-related signal is availableWeight (on index 3).
+		// but we don't yet support voteWeight < availableWeight anyway, so we take just availableWeight == voteWeight
+		PublicSignals: map[string]int{
+			"electionId[0]": 0,
+			"electionId[1]": 1,
+			"nullifier":     2,
+			"voteWeight":    3, // see comment above
+			"voteHash[0]":   4,
+			"voteHash[1]":   5,
+			"sikRoot":       6,
+			"censusRoot":    7,
+		},
 	},
 }
 
 // GetCircuitConfiguration returns the circuit configuration associated with the
 // provided tag or gets the default one.
-func GetCircuitConfiguration(configTag string) *ZkCircuitConfig {
+func GetCircuitConfiguration(version string) *Config {
 	// check if the provided config tag exists and return it if it does
-	if conf, ok := CircuitsConfigurations[configTag]; ok {
+	if conf, ok := CircuitsConfigurations[version]; ok {
 		return conf
 	}
 	// if not, return default configuration
-	return CircuitsConfigurations[DefaultCircuitConfigurationTag]
+	return CircuitsConfigurations[DefaultZkCircuitVersion]
 }
 
 // hexToBytes parses a hex string and returns the byte array from it. Warning,

--- a/crypto/zk/circuit/inputs.go
+++ b/crypto/zk/circuit/inputs.go
@@ -6,8 +6,8 @@ import (
 	"math/big"
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/zk"
 	"go.vocdoni.io/dvote/tree/arbo"
+	"go.vocdoni.io/dvote/util"
 )
 
 // CircuitInputs wraps all the necessary circuit parameters. They must all be
@@ -71,23 +71,23 @@ func GenerateCircuitInput(p CircuitInputsParameters) (*CircuitInputs, error) {
 	}
 	ffPassword := new(big.Int)
 	if p.Password != nil {
-		ffPassword = zk.BigToFF(new(big.Int).SetBytes(p.Password))
+		ffPassword = util.BigToFF(new(big.Int).SetBytes(p.Password))
 	}
 	signature, err := p.Account.SIKsignature()
 	if err != nil {
 		return nil, err
 	}
 	return &CircuitInputs{
-		ElectionId:      zk.BytesToArboStr(p.ElectionId),
+		ElectionId:      util.BytesToArboStr(p.ElectionId),
 		Nullifier:       new(big.Int).SetBytes(nullifier).String(),
 		AvailableWeight: p.AvailableWeight.String(),
-		VoteHash:        zk.BytesToArboStr(p.AvailableWeight.Bytes()),
+		VoteHash:        util.BytesToArboStr(p.AvailableWeight.Bytes()),
 		SIKRoot:         arbo.BytesToBigInt(p.SIKRoot).String(),
 		CensusRoot:      arbo.BytesToBigInt(p.CensusRoot).String(),
 
 		Address:   arbo.BytesToBigInt(p.Account.Address().Bytes()).String(),
 		Password:  ffPassword.String(),
-		Signature: zk.BigToFF(new(big.Int).SetBytes(signature)).String(),
+		Signature: util.BigToFF(new(big.Int).SetBytes(signature)).String(),
 
 		VoteWeight:     p.VoteWeight.String(),
 		CensusSiblings: p.CensusSiblings,

--- a/crypto/zk/circuit/inputs_test.go
+++ b/crypto/zk/circuit/inputs_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/zk"
 	"go.vocdoni.io/dvote/tree/arbo"
+	"go.vocdoni.io/dvote/util"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -33,7 +33,7 @@ func TestGenerateCircuitInput(t *testing.T) {
 	// mock the availableWeight
 	availableWeight := new(big.Int).SetUint64(10)
 	// calc vote hash
-	voteHash := zk.BytesToArboStr(availableWeight.Bytes())
+	voteHash := util.BytesToArboStr(availableWeight.Bytes())
 	// decode the test root
 	hexTestRoot, err := hex.DecodeString(testRoot)
 	c.Assert(err, qt.IsNil)
@@ -51,7 +51,7 @@ func TestGenerateCircuitInput(t *testing.T) {
 
 		Address:   arbo.BytesToBigInt(acc.Address().Bytes()).String(),
 		Password:  "0",
-		Signature: zk.BigToFF(new(big.Int).SetBytes(signature)).String(),
+		Signature: util.BigToFF(new(big.Int).SetBytes(signature)).String(),
 
 		VoteWeight:     availableWeight.String(),
 		CensusSiblings: testSiblings,

--- a/crypto/zk/utils.go
+++ b/crypto/zk/utils.go
@@ -39,11 +39,6 @@ const (
 	publicSigLen = 8
 )
 
-// bn254BaseField contains the Base Field of the twisted Edwards curve, whose
-// base field os the scalar field on the curve BN254. It helps to represent
-// a scalar number into the field.
-var bn254BaseField, _ = new(big.Int).SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
-
 // ProtobufZKProofToProverProof parses the provided protobuf ready proof struct
 // into a prover ready proof struct.
 func ProtobufZKProofToProverProof(p *models.ProofZkSNARK) (*prover.Proof, error) {
@@ -135,36 +130,6 @@ func LittleEndianToNBytes(num *big.Int, n int) *big.Int {
 	numBytes := num.Bytes()
 	m := len(numBytes) - n
 	return new(big.Int).SetBytes(numBytes[m:])
-}
-
-// BigToFF function returns the finite field representation of the big.Int
-// provided. It uses Euclidean Modulus and the BN254 curve scalar field to
-// represent the provided number.
-func BigToFF(iv *big.Int) *big.Int {
-	z := big.NewInt(0)
-	if c := iv.Cmp(bn254BaseField); c == 0 {
-		return z
-	} else if c != 1 && iv.Cmp(z) != -1 {
-		return iv
-	}
-	return z.Mod(iv, bn254BaseField)
-}
-
-// BytesToArbo calculates the sha256 hash (32 bytes) of the slice of bytes
-// provided. Then, splits the hash into a two parts of 16 bytes, swap the
-// endianess of that parts and encodes they into a two big.Int's.
-func BytesToArbo(input []byte) []*big.Int {
-	hash := sha256.Sum256(input)
-	return []*big.Int{
-		new(big.Int).SetBytes(arbo.SwapEndianness(hash[:16])),
-		new(big.Int).SetBytes(arbo.SwapEndianness(hash[16:])),
-	}
-}
-
-// BytesToArboStr function wraps BytesToArbo to return the input as []string.
-func BytesToArboStr(input []byte) []string {
-	arboBytes := BytesToArbo(input)
-	return []string{arboBytes[0].String(), arboBytes[1].String()}
 }
 
 // ProofToCircomSiblings function decodes the provided proof (or packaged

--- a/crypto/zk/utils.go
+++ b/crypto/zk/utils.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"go.vocdoni.io/dvote/censustree"
+	"go.vocdoni.io/dvote/crypto/zk/circuit"
 	"go.vocdoni.io/dvote/crypto/zk/prover"
 	"go.vocdoni.io/dvote/tree/arbo"
 	"go.vocdoni.io/dvote/types"
@@ -18,16 +19,6 @@ import (
 // 		A: [3]bigint,
 // 		B: [3][2]bigint,
 // 		C: [3]bigint,
-// 		PublicSignals: [8]bigint{
-//			0: electionId[0],
-// 			1: electionId[1],
-// 			2: nullifier,
-// 			3: voteHash[0],
-// 			4: voteHash[1],
-// 			5: sikRoot,
-// 			6: censusRoot
-// 			7: voteWeight,
-//		}
 // 	}
 
 // Default length of each proof parameters
@@ -36,7 +27,6 @@ const (
 	proofBLen    = 6 // flatted
 	proofBEncLen = 3 // matrix
 	proofCLen    = 3
-	publicSigLen = 8
 )
 
 // ProtobufZKProofToProverProof parses the provided protobuf ready proof struct
@@ -83,7 +73,7 @@ func ProverProofToProtobufZKProof(p *prover.Proof, electionId, sikRoot,
 
 	// if public signals are provided, check their format
 	proof.PublicInputs = p.PubSignals
-	if p.PubSignals != nil && len(p.PubSignals) != publicSigLen {
+	if p.PubSignals != nil && len(p.PubSignals) != len(circuit.Global().Config.PublicSignals) {
 		return nil, fmt.Errorf("wrong ZkSnark prover public signals format")
 	}
 	// if not, check if the rest of the arguments are provided and try to

--- a/crypto/zk/utils_test.go
+++ b/crypto/zk/utils_test.go
@@ -128,15 +128,3 @@ func TestLittleEndianToNBytes(t *testing.T) {
 	expected, _ = new(big.Int).SetString("873432238408170128747103711248787244651366455432", 10)
 	c.Assert(LittleEndianToNBytes(input, 20).Bytes(), qt.DeepEquals, expected.Bytes())
 }
-
-func TestBytesToArboStr(t *testing.T) {
-	c := qt.New(t)
-
-	input := new(big.Int).SetInt64(1233)
-	encoded := BytesToArboStr(input.Bytes())
-	expected := []string{
-		"145749485520268040037154566173721592631",
-		"243838562910071029186006881148627719363",
-	}
-	c.Assert(encoded, qt.DeepEquals, expected)
-}

--- a/dockerfiles/testsuite/docker-compose.yml
+++ b/dockerfiles/testsuite/docker-compose.yml
@@ -101,6 +101,7 @@ services:
     networks:
       - blockchain
     volumes:
+      - /tmp/.vochain-zkCircuits/:/root/.cache/vocdoni/zkCircuits/
       - gocoverage-test:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.17.0
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a
-	github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319
 	github.com/vocdoni/storage-proofs-eth-go v0.1.6
 	go.mongodb.org/mongo-driver v1.12.1
 	go.vocdoni.io/proto v1.15.4-0.20231023165811-02adcc48142a
@@ -73,6 +72,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Jorropo/jsync v1.0.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,7 +97,6 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/VictoriaMetrics/fastcache v1.5.3/go.mod h1:+jv9Ckb+za/P1ZRg/sulP5Ni1v49daAVERr0H3CuscE=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
 github.com/VictoriaMetrics/fastcache v1.6.0/go.mod h1:0qHz5QP0GMX4pfmMA/zt5RgfNuXJrTP0zS7DqpHGGTw=
 github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=
@@ -204,7 +203,6 @@ github.com/cespare/cp v1.1.1 h1:nCb6ZLdB7NRaqsm91JtQTAme2SKJzXVsdPIPkyJr1MU=
 github.com/cespare/cp v1.1.1/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cespare/xxhash/v2 v2.0.1-0.20190104013014-3767db7a7e18/go.mod h1:HD5P3vAIAh+Y2GAxg0PrPN1P8WkepXGpjbUPDHJqqKM=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -334,7 +332,6 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
 github.com/dop251/goja v0.0.0-20200721192441-a695b0cdd498/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -348,7 +345,6 @@ github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7j
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
-github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/4=
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
@@ -367,8 +363,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum/c-kzg-4844 v0.3.1 h1:sR65+68+WdnMKxseNWxSJuAv2tsUrihTpVBTfM/U5Zg=
 github.com/ethereum/c-kzg-4844 v0.3.1/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
-github.com/ethereum/go-ethereum v1.9.12/go.mod h1:PvsVkQmhZFx92Y+h2ylythYlheEDt/uBgFbl61Js/jo=
-github.com/ethereum/go-ethereum v1.9.13/go.mod h1:qwN9d1GLyDh0N7Ab8bMGd0H9knaji2jOBm2RrMGjXls=
 github.com/ethereum/go-ethereum v1.9.25/go.mod h1:vMkFiYLHI4tgPw4k2j4MHKoovchFE8plZ0M9VMk4/oM=
 github.com/ethereum/go-ethereum v1.10.8/go.mod h1:pJNuIUYfX5+JKzSD/BTdNsvJSZ1TJqmz0dVyXMAbf6M=
 github.com/ethereum/go-ethereum v1.13.4 h1:25HJnaWVg3q1O7Z62LaaI6S9wVq8QCw3K88g8wEzrcM=
@@ -525,7 +519,6 @@ github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2-0.20190517061210-b285ee9cfc6c/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -659,7 +652,6 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
-github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -685,7 +677,6 @@ github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o
 github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3/go.mod h1:MZ2ZmwcBpvOoJ22IJsc7va19ZwoheaBk43rKg12SKag=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goupnp v1.0.2/go.mod h1:0dxJBVBHqTMjIUMkESDTNgOOx/Mw5wYIfyFmdzSamkM=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
@@ -696,7 +687,6 @@ github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSAS
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/iden3/go-iden3-crypto v0.0.5/go.mod h1:XKw1oDwYn2CIxKOtr7m/mL5jMn4mLOxAxtZBRxQBev8=
 github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6GV94cok=
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-rapidsnark/prover v0.0.9 h1:Bifg6VtrvrXiYsfv8ULBQweeT75sw3FjV4bbU3vmNQ0=
@@ -1479,7 +1469,6 @@ github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIK
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spaolacci/murmur3 v1.0.1-0.20190317074736-539464a789e9/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -1534,7 +1523,6 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbeoEm4=
 github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
@@ -1584,8 +1572,6 @@ github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tz
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319 h1:W8N7yfnWsVD3l2Sh0pTtXCDd4+LNh58lE427D1U9SVY=
-github.com/vocdoni/go-snark v0.0.0-20210709152824-f6e4c27d7319/go.mod h1:A4ZJ8jq+ZbNvxrNUmScv2ghL34A6c6vw5Y1Oza2h7lo=
 github.com/vocdoni/storage-proofs-eth-go v0.1.6 h1:mF6VNGudgCjjgjxs5Z2GGMM2tS79+xFBWcr7BnPuhAY=
 github.com/vocdoni/storage-proofs-eth-go v0.1.6/go.mod h1:aoD9pKg8kDFQ5I6b3obGPTwjC+DsaW2h4wt2UQEjQrg=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=
@@ -1746,7 +1732,6 @@ golang.org/x/crypto v0.0.0-20190909091759-094676da4a83/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200602180216-279210d13fed/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -2302,8 +2287,6 @@ gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3M
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
-gopkg.in/olebedev/go-duktape.v3 v3.0.0-20190213234257-ec84240a7772/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
-gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200316214253-d7b0ff38cac9/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=

--- a/service/indexer.go
+++ b/service/indexer.go
@@ -11,9 +11,10 @@ import (
 func (vs *VocdoniService) VochainIndexer() error {
 	log.Info("creating vochain indexer service")
 	var err error
-	vs.Indexer, err = indexer.New(filepath.Join(vs.Config.DataDir, "indexer"), vs.App,
-		indexer.Options{IgnoreLiveResults: vs.Config.Indexer.IgnoreLiveResults},
-	)
+	vs.Indexer, err = indexer.New(vs.App, indexer.Options{
+		DataDir:           filepath.Join(vs.Config.DataDir, "indexer"),
+		IgnoreLiveResults: vs.Config.Indexer.IgnoreLiveResults,
+	})
 	if err != nil {
 		return err
 	}

--- a/service/indexer.go
+++ b/service/indexer.go
@@ -12,7 +12,7 @@ func (vs *VocdoniService) VochainIndexer() error {
 	log.Info("creating vochain indexer service")
 	var err error
 	vs.Indexer, err = indexer.New(filepath.Join(vs.Config.DataDir, "indexer"), vs.App,
-		indexer.Options{CountLiveResults: !vs.Config.Indexer.IgnoreLiveResults},
+		indexer.Options{IgnoreLiveResults: vs.Config.Indexer.IgnoreLiveResults},
 	)
 	if err != nil {
 		return err

--- a/service/indexer.go
+++ b/service/indexer.go
@@ -11,10 +11,8 @@ import (
 func (vs *VocdoniService) VochainIndexer() error {
 	log.Info("creating vochain indexer service")
 	var err error
-	vs.Indexer, err = indexer.NewIndexer(
-		filepath.Join(vs.Config.DataDir, "indexer"),
-		vs.App,
-		!vs.Config.Indexer.IgnoreLiveResults,
+	vs.Indexer, err = indexer.New(filepath.Join(vs.Config.DataDir, "indexer"), vs.App,
+		indexer.Options{CountLiveResults: !vs.Config.Indexer.IgnoreLiveResults},
 	)
 	if err != nil {
 		return err

--- a/service/vochain.go
+++ b/service/vochain.go
@@ -44,7 +44,7 @@ func (vs *VocdoniService) Vochain() error {
 		vs.Config.PublicAddr = net.JoinHostPort(host, port)
 	}
 	log.Infow("vochain p2p enabled",
-		"network", vs.Config.Chain,
+		"network", vs.Config.Network,
 		"address", vs.Config.PublicAddr,
 		"listenHost", vs.Config.P2PListen)
 
@@ -66,18 +66,18 @@ func (vs *VocdoniService) Vochain() error {
 		if err == nil { // If genesis file found
 			log.Info("found genesis file")
 			// compare genesis
-			if !bytes.Equal(ethereum.HashRaw(genesisBytes), vocdoniGenesis.Genesis[vs.Config.Chain].Genesis.Hash()) {
+			if !bytes.Equal(ethereum.HashRaw(genesisBytes), vocdoniGenesis.Genesis[vs.Config.Network].Genesis.Hash()) {
 				// if auto-update genesis enabled, delete local genesis and use hardcoded genesis
-				if vocdoniGenesis.Genesis[vs.Config.Chain].AutoUpdateGenesis || vs.Config.Dev {
+				if vocdoniGenesis.Genesis[vs.Config.Network].AutoUpdateGenesis || vs.Config.Dev {
 					log.Warn("new genesis found, cleaning and restarting Vochain")
 					if err = os.RemoveAll(vs.Config.DataDir); err != nil {
 						return err
 					}
-					if _, ok := vocdoniGenesis.Genesis[vs.Config.Chain]; !ok {
-						err = fmt.Errorf("cannot find a valid genesis for the %s network", vs.Config.Chain)
+					if _, ok := vocdoniGenesis.Genesis[vs.Config.Network]; !ok {
+						err = fmt.Errorf("cannot find a valid genesis for the %s network", vs.Config.Network)
 						return err
 					}
-					genesisBytes = vocdoniGenesis.Genesis[vs.Config.Chain].Genesis.Marshal()
+					genesisBytes = vocdoniGenesis.Genesis[vs.Config.Network].Genesis.Marshal()
 				} else {
 					log.Warn("local and hardcoded genesis are different, risk of potential consensus failure")
 				}
@@ -89,11 +89,11 @@ func (vs *VocdoniService) Vochain() error {
 				return err
 			}
 			log.Info("genesis file does not exist, using factory")
-			if _, ok := vocdoniGenesis.Genesis[vs.Config.Chain]; !ok {
-				err = fmt.Errorf("cannot find a valid genesis for the %s network", vs.Config.Chain)
+			if _, ok := vocdoniGenesis.Genesis[vs.Config.Network]; !ok {
+				err = fmt.Errorf("cannot find a valid genesis for the %s network", vs.Config.Network)
 				return err
 			}
-			genesisBytes = vocdoniGenesis.Genesis[vs.Config.Chain].Genesis.Marshal()
+			genesisBytes = vocdoniGenesis.Genesis[vs.Config.Network].Genesis.Marshal()
 		}
 	}
 

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -105,7 +105,7 @@ func NewVochainStateWithProcess(tb testing.TB) *state.State {
 
 func NewMockIndexer(tb testing.TB, vnode *vochain.BaseApplication) *indexer.Indexer {
 	tb.Log("starting vochain indexer")
-	sc, err := indexer.New(tb.TempDir(), vnode, indexer.Options{})
+	sc, err := indexer.New(vnode, indexer.Options{DataDir: tb.TempDir()})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -105,7 +105,7 @@ func NewVochainStateWithProcess(tb testing.TB) *state.State {
 
 func NewMockIndexer(tb testing.TB, vnode *vochain.BaseApplication) *indexer.Indexer {
 	tb.Log("starting vochain indexer")
-	sc, err := indexer.NewIndexer(tb.TempDir(), vnode, true)
+	sc, err := indexer.New(tb.TempDir(), vnode, indexer.Options{CountLiveResults: true})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/test/testcommon/vochain.go
+++ b/test/testcommon/vochain.go
@@ -105,7 +105,7 @@ func NewVochainStateWithProcess(tb testing.TB) *state.State {
 
 func NewMockIndexer(tb testing.TB, vnode *vochain.BaseApplication) *indexer.Indexer {
 	tb.Log("starting vochain indexer")
-	sc, err := indexer.New(tb.TempDir(), vnode, indexer.Options{CountLiveResults: true})
+	sc, err := indexer.New(tb.TempDir(), vnode, indexer.Options{})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/util/zk.go
+++ b/util/zk.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"crypto/sha256"
+	"math/big"
+
+	"go.vocdoni.io/dvote/tree/arbo"
+)
+
+// bn254BaseField contains the Base Field of the twisted Edwards curve, whose
+// base field os the scalar field on the curve BN254. It helps to represent
+// a scalar number into the field.
+var bn254BaseField, _ = new(big.Int).SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
+
+// BigToFF function returns the finite field representation of the big.Int
+// provided. It uses Euclidean Modulus and the BN254 curve scalar field to
+// represent the provided number.
+func BigToFF(iv *big.Int) *big.Int {
+	z := big.NewInt(0)
+	if c := iv.Cmp(bn254BaseField); c == 0 {
+		return z
+	} else if c != 1 && iv.Cmp(z) != -1 {
+		return iv
+	}
+	return z.Mod(iv, bn254BaseField)
+}
+
+// BytesToArbo calculates the sha256 hash (32 bytes) of the slice of bytes
+// provided. Then, splits the hash into a two parts of 16 bytes, swap the
+// endianess of that parts and encodes they into a two big.Int's.
+func BytesToArbo(input []byte) []*big.Int {
+	hash := sha256.Sum256(input)
+	return []*big.Int{
+		new(big.Int).SetBytes(arbo.SwapEndianness(hash[:16])),
+		new(big.Int).SetBytes(arbo.SwapEndianness(hash[16:])),
+	}
+}
+
+// BytesToArboStr function wraps BytesToArbo to return the input as []string.
+func BytesToArboStr(input []byte) []string {
+	arboBytes := BytesToArbo(input)
+	return []string{arboBytes[0].String(), arboBytes[1].String()}
+}

--- a/util/zk_test.go
+++ b/util/zk_test.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"math/big"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBytesToArboStr(t *testing.T) {
+	c := qt.New(t)
+
+	input := new(big.Int).SetInt64(1233)
+	encoded := BytesToArboStr(input.Bytes())
+	expected := []string{
+		"145749485520268040037154566173721592631",
+		"243838562910071029186006881148627719363",
+	}
+	c.Assert(encoded, qt.DeepEquals, expected)
+}

--- a/vochain/apptest.go
+++ b/vochain/apptest.go
@@ -9,6 +9,7 @@ import (
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	tmtypes "github.com/cometbft/cometbft/types"
+	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/db/metadb"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/proto/build/go/models"
@@ -28,7 +29,10 @@ func TestBaseApplication(tb testing.TB) *BaseApplication {
 // Once the application is create, it is the caller's responsibility to call
 // app.AdvanceTestBlock() to advance the block height and commit the state.
 func TestBaseApplicationWithChainID(tb testing.TB, chainID string) *BaseApplication {
-	app, err := NewBaseApplication(metadb.ForTest(), tb.TempDir())
+	app, err := NewBaseApplication(&config.VochainCfg{
+		DBType:  metadb.ForTest(),
+		DataDir: tb.TempDir(),
+	})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/vochain/genesis/genesis.go
+++ b/vochain/genesis/genesis.go
@@ -14,8 +14,7 @@ var Genesis = map[string]Vochain{
 		SeedNodes: []string{
 			"7440a5b086e16620ce7b13198479016aa2b07988@seed.dev.vocdoni.net:26656",
 		},
-		CircuitsConfigTag: "dev",
-		Genesis:           &devGenesis,
+		Genesis: &devGenesis,
 	},
 
 	// Staging network
@@ -24,8 +23,7 @@ var Genesis = map[string]Vochain{
 		SeedNodes: []string{
 			"588133b8309363a2a852e853424251cd6e8c5330@seed.stg.vocdoni.net:26656",
 		},
-		CircuitsConfigTag: "dev",
-		Genesis:           &stageGenesis,
+		Genesis: &stageGenesis,
 	},
 
 	// LTS production network
@@ -35,8 +33,7 @@ var Genesis = map[string]Vochain{
 			"32acbdcda649fbcd35775f1dd8653206d940eee4@seed1.lts.vocdoni.net:26656",
 			"02bfac9bd98bf25429d12edc50552cca5e975080@seed2.lts.vocdoni.net:26656",
 		},
-		CircuitsConfigTag: "prod",
-		Genesis:           &ltsGenesis,
+		Genesis: &ltsGenesis,
 	},
 }
 

--- a/vochain/genesis/genesis.go
+++ b/vochain/genesis/genesis.go
@@ -353,11 +353,11 @@ var ltsGenesis = Doc{
 	},
 }
 
-// AvailableChains returns the list of hardcoded chains
-func AvailableChains() []string {
-	chains := []string{}
+// AvailableNetworks returns the list of hardcoded networks
+func AvailableNetworks() []string {
+	networks := []string{}
 	for k := range Genesis {
-		chains = append(chains, k)
+		networks = append(networks, k)
 	}
-	return chains
+	return networks
 }

--- a/vochain/genesis/types.go
+++ b/vochain/genesis/types.go
@@ -15,7 +15,6 @@ import (
 type Vochain struct {
 	AutoUpdateGenesis bool
 	SeedNodes         []string
-	CircuitsConfigTag string
 	Genesis           *Doc
 }
 

--- a/vochain/hysteresis_test.go
+++ b/vochain/hysteresis_test.go
@@ -23,9 +23,8 @@ func TestHysteresis(t *testing.T) {
 
 	// create test app and load zk circuit
 	app := TestBaseApplication(t)
-	devCircuit, err := circuit.LoadZkCircuitByTag(circuit.DefaultCircuitConfigurationTag)
+	err := circuit.Init()
 	c.Assert(err, qt.IsNil)
-	app.TransactionHandler.ZkCircuit = devCircuit
 
 	// initial accounts
 	testWeight := big.NewInt(10)
@@ -94,7 +93,7 @@ func TestHysteresis(t *testing.T) {
 			encInputs, err := json.Marshal(inputs)
 			c.Assert(err, qt.IsNil)
 
-			zkProof, err := prover.Prove(devCircuit.ProvingKey, devCircuit.Wasm, encInputs)
+			zkProof, err := prover.Prove(circuit.Global().ProvingKey, circuit.Global().Wasm, encInputs)
 			c.Assert(err, qt.IsNil)
 
 			protoZkProof, err := zk.ProverProofToProtobufZKProof(zkProof, nil, nil, nil, nil, nil)

--- a/vochain/indexer/archive_test.go
+++ b/vochain/indexer/archive_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestImportArchive(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	archive := []*ArchiveProcess{}
 	archiveProcess1 := &ArchiveProcess{}

--- a/vochain/indexer/bench_test.go
+++ b/vochain/indexer/bench_test.go
@@ -21,7 +21,7 @@ import (
 func BenchmarkIndexer(b *testing.B) {
 	app := vochain.TestBaseApplication(b)
 
-	idx := newTestIndexer(b, app, true)
+	idx := newTestIndexer(b, app)
 	pid := util.RandomBytes(32)
 	if err := app.State.AddProcess(&models.Process{
 		ProcessId:    pid,
@@ -131,7 +131,7 @@ func BenchmarkFetchTx(b *testing.B) {
 	numTxs := 1000
 	app := vochain.TestBaseApplication(b)
 
-	idx := newTestIndexer(b, app, true)
+	idx := newTestIndexer(b, app)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -164,7 +164,7 @@ func BenchmarkFetchTx(b *testing.B) {
 func BenchmarkNewProcess(b *testing.B) {
 	app := vochain.TestBaseApplication(b)
 
-	idx := newTestIndexer(b, app, true)
+	idx := newTestIndexer(b, app)
 	_ = idx // used via the callbacks; we want to benchmark it too
 	startTime := time.Now()
 	numProcesses := b.N

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -95,7 +95,7 @@ type Indexer struct {
 }
 
 type Options struct {
-	CountLiveResults bool
+	IgnoreLiveResults bool
 }
 
 // New returns an instance of the Indexer
@@ -103,7 +103,7 @@ type Options struct {
 func New(dataDir string, app *vochain.BaseApplication, opts Options) (*Indexer, error) {
 	idx := &Indexer{
 		App:               app,
-		ignoreLiveResults: !opts.CountLiveResults,
+		ignoreLiveResults: opts.IgnoreLiveResults,
 
 		// TODO(mvdan): these three maps are all keyed by process ID,
 		// and each of them needs to query existing data from the DB.
@@ -113,7 +113,7 @@ func New(dataDir string, app *vochain.BaseApplication, opts Options) (*Indexer, 
 		blockUpdateProcs:          make(map[string]bool),
 		blockUpdateProcVoteCounts: make(map[string]bool),
 	}
-	log.Infow("indexer initialization", "dataDir", dataDir, "liveResults", opts.CountLiveResults)
+	log.Infow("indexer initialization", "dataDir", dataDir, "liveResults", !opts.IgnoreLiveResults)
 
 	// The DB itself is opened in "rwc" mode, so it is created if it does not yet exist.
 	// Create the parent directory as well if it doesn't exist.

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -94,12 +94,16 @@ type Indexer struct {
 	ignoreLiveResults bool
 }
 
-// NewIndexer returns an instance of the Indexer
+type Options struct {
+	CountLiveResults bool
+}
+
+// New returns an instance of the Indexer
 // using the local storage database in dataDir and integrated into the state vochain instance
-func NewIndexer(dataDir string, app *vochain.BaseApplication, countLiveResults bool) (*Indexer, error) {
+func New(dataDir string, app *vochain.BaseApplication, opts Options) (*Indexer, error) {
 	idx := &Indexer{
 		App:               app,
-		ignoreLiveResults: !countLiveResults,
+		ignoreLiveResults: !opts.CountLiveResults,
 
 		// TODO(mvdan): these three maps are all keyed by process ID,
 		// and each of them needs to query existing data from the DB.
@@ -109,7 +113,7 @@ func NewIndexer(dataDir string, app *vochain.BaseApplication, countLiveResults b
 		blockUpdateProcs:          make(map[string]bool),
 		blockUpdateProcVoteCounts: make(map[string]bool),
 	}
-	log.Infow("indexer initialization", "dataDir", dataDir, "liveResults", countLiveResults)
+	log.Infow("indexer initialization", "dataDir", dataDir, "liveResults", opts.CountLiveResults)
 
 	// The DB itself is opened in "rwc" mode, so it is created if it does not yet exist.
 	// Create the parent directory as well if it doesn't exist.

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -95,12 +95,14 @@ type Indexer struct {
 }
 
 type Options struct {
+	DataDir string
+
 	IgnoreLiveResults bool
 }
 
 // New returns an instance of the Indexer
-// using the local storage database in dataDir and integrated into the state vochain instance
-func New(dataDir string, app *vochain.BaseApplication, opts Options) (*Indexer, error) {
+// using the local storage database in DataDir and integrated into the state vochain instance.
+func New(app *vochain.BaseApplication, opts Options) (*Indexer, error) {
 	idx := &Indexer{
 		App:               app,
 		ignoreLiveResults: opts.IgnoreLiveResults,
@@ -113,14 +115,14 @@ func New(dataDir string, app *vochain.BaseApplication, opts Options) (*Indexer, 
 		blockUpdateProcs:          make(map[string]bool),
 		blockUpdateProcVoteCounts: make(map[string]bool),
 	}
-	log.Infow("indexer initialization", "dataDir", dataDir, "liveResults", !opts.IgnoreLiveResults)
+	log.Infow("indexer initialization", "dataDir", opts.DataDir, "liveResults", !opts.IgnoreLiveResults)
 
 	// The DB itself is opened in "rwc" mode, so it is created if it does not yet exist.
 	// Create the parent directory as well if it doesn't exist.
-	if err := os.MkdirAll(dataDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(opts.DataDir, os.ModePerm); err != nil {
 		return nil, err
 	}
-	dbPath := filepath.Join(dataDir, "db.sqlite")
+	dbPath := filepath.Join(opts.DataDir, "db.sqlite")
 	var err error
 
 	// sqlite doesn't support multiple concurrent writers.

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -30,8 +30,8 @@ func init() {
 	goose.SetLogger(stdlog.New(io.Discard, "", 0))
 }
 
-func newTestIndexer(tb testing.TB, app *vochain.BaseApplication, countLiveResults bool) *Indexer {
-	idx, err := New(tb.TempDir(), app, Options{CountLiveResults: countLiveResults})
+func newTestIndexer(tb testing.TB, app *vochain.BaseApplication) *Indexer {
+	idx, err := New(tb.TempDir(), app, Options{})
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestEntityList(t *testing.T) {
 
 func testEntityList(t *testing.T, entityCount int) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 	baseProcess := &models.Process{
 		BlockCount:    10,
 		VoteOptions:   &models.ProcessVoteOptions{MaxCount: 8, MaxValue: 3},
@@ -110,7 +110,7 @@ func testEntityList(t *testing.T, entityCount int) {
 
 func TestEntitySearch(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	entityIds := []string{
 		"1011d50537fa164b6fef261141797bbe4014526e",
@@ -204,7 +204,7 @@ func TestProcessList(t *testing.T) {
 
 func testProcessList(t *testing.T, procsCount int) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	// Add 10 entities and process for storing random content
 	var eidOneProcess []byte // entity ID with one process
@@ -285,7 +285,7 @@ func testProcessList(t *testing.T, procsCount int) {
 
 func TestProcessSearch(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	// Add 10 entities and process for storing random content
 	for i := 0; i < 10; i++ {
@@ -436,7 +436,7 @@ func TestProcessSearch(t *testing.T) {
 func TestProcessListWithNamespaceAndStatus(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
 
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	// Add 10 processes with different namespaces (from 10 to 20) and status ENDED
 	for i := 0; i < 10; i++ {
@@ -503,7 +503,7 @@ func TestProcessListWithNamespaceAndStatus(t *testing.T) {
 
 func TestResults(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	keys, root, proofs := testvoteproof.CreateKeysAndBuildCensus(t, 30)
 	pid := util.RandomBytes(32)
@@ -668,7 +668,7 @@ func TestResults(t *testing.T) {
 
 func TestLiveResults(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	pid := util.RandomBytes(32)
 	if err := app.State.AddProcess(&models.Process{
@@ -720,7 +720,7 @@ func TestLiveResults(t *testing.T) {
 func TestAddVote(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
 
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	options := &models.ProcessVoteOptions{
 		MaxCount:     3,
@@ -810,7 +810,7 @@ func TestBallotProtocolRateProduct(t *testing.T) {
 	// Rate a product from 0 to 4
 	app := vochain.TestBaseApplication(t)
 
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	// Rate 2 products from 0 to 4
 	pid := util.RandomBytes(32)
@@ -848,7 +848,7 @@ func TestBallotProtocolQuadratic(t *testing.T) {
 	// Rate a product from 0 to 4
 	app := vochain.TestBaseApplication(t)
 
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	// Rate 2 products from 0 to 4
 	pid := util.RandomBytes(32)
@@ -898,7 +898,7 @@ func TestBallotProtocolMultiChoice(t *testing.T) {
 
 	app := vochain.TestBaseApplication(t)
 
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	// Rate 2 products from 0 to 4
 	pid := util.RandomBytes(32)
@@ -943,7 +943,7 @@ func TestBallotProtocolMultiChoice(t *testing.T) {
 
 func TestAfterSyncBootStrap(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 	pid := util.RandomBytes(32)
 	qt.Assert(t, app.IsSynchronizing(), qt.Equals, false)
 
@@ -1011,7 +1011,7 @@ func TestAfterSyncBootStrap(t *testing.T) {
 
 func TestCountVotes(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 	pid := util.RandomBytes(32)
 
 	err := app.State.AddProcess(&models.Process{
@@ -1069,7 +1069,7 @@ func TestCountVotes(t *testing.T) {
 
 func TestOverwriteVotes(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 	pid := util.RandomBytes(32)
 	keys, root, proofs := testvoteproof.CreateKeysAndBuildCensus(t, 10)
 
@@ -1257,7 +1257,7 @@ func TestOverwriteVotes(t *testing.T) {
 
 func TestTxIndexer(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	getTxID := func(i, j int) [32]byte {
 		return [32]byte{byte(i), byte(j)}
@@ -1316,7 +1316,7 @@ func TestTxIndexer(t *testing.T) {
 
 func TestCensusUpdate(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	originalCensusRoot := util.RandomBytes(32)
 	originalCensusURI := new(string)
@@ -1368,7 +1368,7 @@ func TestCensusUpdate(t *testing.T) {
 
 func TestEndBlock(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	pid := util.RandomBytes(32)
 
@@ -1418,7 +1418,7 @@ func TestEndBlock(t *testing.T) {
 
 func TestAccountsList(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	keys := make([]*ethereum.SignKeys, 0)
 	for i := 0; i < 25; i++ {
@@ -1479,7 +1479,7 @@ func TestAccountsList(t *testing.T) {
 
 func TestTokenTransfers(t *testing.T) {
 	app := vochain.TestBaseApplication(t)
-	idx := newTestIndexer(t, app, true)
+	idx := newTestIndexer(t, app)
 
 	keys := make([]*ethereum.SignKeys, 0)
 	// create 3 accounts

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func newTestIndexer(tb testing.TB, app *vochain.BaseApplication, countLiveResults bool) *Indexer {
-	idx, err := NewIndexer(tb.TempDir(), app, countLiveResults)
+	idx, err := New(tb.TempDir(), app, Options{CountLiveResults: countLiveResults})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func newTestIndexer(tb testing.TB, app *vochain.BaseApplication) *Indexer {
-	idx, err := New(tb.TempDir(), app, Options{})
+	idx, err := New(app, Options{DataDir: tb.TempDir()})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -133,9 +133,9 @@ func newTendermint(app *BaseApplication,
 		tconfig.P2P.AddrBookStrict = false
 	}
 	tconfig.P2P.Seeds = strings.Trim(strings.Join(localConfig.Seeds, ","), "[]\"")
-	if _, ok := vocdoniGenesis.Genesis[localConfig.Chain]; len(tconfig.P2P.Seeds) < 8 &&
+	if _, ok := vocdoniGenesis.Genesis[localConfig.Network]; len(tconfig.P2P.Seeds) < 8 &&
 		!localConfig.IsSeedNode && ok {
-		tconfig.P2P.Seeds = strings.Join(vocdoniGenesis.Genesis[localConfig.Chain].SeedNodes, ",")
+		tconfig.P2P.Seeds = strings.Join(vocdoniGenesis.Genesis[localConfig.Network].SeedNodes, ",")
 	}
 	if len(tconfig.P2P.Seeds) > 0 {
 		log.Infof("seed nodes: %s", tconfig.P2P.Seeds)

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -12,6 +12,7 @@ import (
 
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/zk/circuit"
 	vocdoniGenesis "go.vocdoni.io/dvote/vochain/genesis"
 
 	tmcfg "github.com/cometbft/cometbft/config"
@@ -274,6 +275,12 @@ func newTendermint(app *BaseApplication,
 	}
 	log.Infow("genesis file", "genesis", tconfig.GenesisFile(), "chainID", genesisCID.ChainID)
 	app.SetChainID(genesisCID.ChainID)
+
+	// the chain might need additional ZkCircuits, now that we know the chainID ensure they are downloaded now,
+	// to avoid delays at beginBlock during a fork
+	if err := circuit.DownloadArtifactsForChainID(genesisCID.ChainID); err != nil {
+		return nil, fmt.Errorf("cannot download zk circuits for chainID: %w", err)
+	}
 
 	// assign the default tendermint methods
 	app.SetDefaultMethods()

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -27,7 +27,9 @@ import (
 // NewVochain starts a node with an ABCI application
 func NewVochain(vochaincfg *config.VochainCfg, genesis []byte) *BaseApplication {
 	// creating new vochain app
-	app, err := NewBaseApplication(vochaincfg.DBType, filepath.Join(vochaincfg.DataDir, "data"))
+	c := *vochaincfg
+	c.DataDir = filepath.Join(vochaincfg.DataDir, "data")
+	app, err := NewBaseApplication(&c)
 	if err != nil {
 		log.Fatalf("cannot initialize vochain application: %s", err)
 	}

--- a/vochain/transaction/election_tx.go
+++ b/vochain/transaction/election_tx.go
@@ -6,6 +6,7 @@ import (
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/nacl"
+	"go.vocdoni.io/dvote/crypto/zk/circuit"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/vochain/processid"
@@ -72,10 +73,10 @@ func (t *TransactionHandler) NewProcessTxCheck(vtx *vochaintx.Tx) (*models.Proce
 			fmt.Errorf("maxCensusSize is greater than the maximum allowed (%d)", maxProcessSize)
 	}
 	// check that the census size is not bigger than the circuit levels
-	if tx.Process.EnvelopeType.Anonymous && !t.ZkCircuit.Config.SupportsCensusSize(txMaxCensusSize) {
+	if tx.Process.EnvelopeType.Anonymous && !circuit.Global().Config.SupportsCensusSize(txMaxCensusSize) {
 		return nil, ethereum.Address{}, fmt.Errorf("maxCensusSize for anonymous envelope "+
 			"cannot be bigger than the number of levels of the circuit (max:%d provided:%d)",
-			t.ZkCircuit.Config.MaxCensusSize().Int64(), txMaxCensusSize)
+			circuit.Global().Config.MaxCensusSize().Int64(), txMaxCensusSize)
 	}
 
 	// check signature

--- a/vochain/transaction/transaction.go
+++ b/vochain/transaction/transaction.go
@@ -6,7 +6,6 @@ import (
 
 	cometCrypto256k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 	"github.com/ethereum/go-ethereum/common"
-	snarkTypes "github.com/vocdoni/go-snark/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/zk/circuit"
 	"go.vocdoni.io/dvote/log"
@@ -47,8 +46,6 @@ type TransactionHandler struct {
 	istc *ist.Controller
 	// dataDir is the path for storing some files
 	dataDir string
-	// ZkVKs contains the VerificationKey for each circuit parameters index
-	ZkVKs []*snarkTypes.Vk
 	// ZkCircuit contains the current chain circuit
 	ZkCircuit *circuit.ZkCircuit
 }

--- a/vochain/transaction/transaction.go
+++ b/vochain/transaction/transaction.go
@@ -7,7 +7,6 @@ import (
 	cometCrypto256k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 	"github.com/ethereum/go-ethereum/common"
 	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/zk/circuit"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/vochain/ist"
 	vstate "go.vocdoni.io/dvote/vochain/state"
@@ -46,8 +45,6 @@ type TransactionHandler struct {
 	istc *ist.Controller
 	// dataDir is the path for storing some files
 	dataDir string
-	// ZkCircuit contains the current chain circuit
-	ZkCircuit *circuit.ZkCircuit
 }
 
 // NewTransactionHandler creates a new TransactionHandler.
@@ -57,15 +54,6 @@ func NewTransactionHandler(state *vstate.State, istc *ist.Controller, dataDir st
 		dataDir: dataDir,
 		istc:    istc,
 	}
-}
-
-func (t *TransactionHandler) LoadZkCircuit(configTag string) error {
-	circuit, err := circuit.LoadZkCircuitByTag(configTag)
-	if err != nil {
-		return fmt.Errorf("could not load zk verification keys: %w", err)
-	}
-	t.ZkCircuit = circuit
-	return nil
 }
 
 // CheckTx check the validity of a transaction and adds it to the state if forCommit=true.

--- a/vochain/transaction_zk_test.go
+++ b/vochain/transaction_zk_test.go
@@ -22,9 +22,8 @@ func TestVoteCheckZkSNARK(t *testing.T) {
 	c := qt.New(t)
 	// create test app and load zk circuit
 	app := TestBaseApplication(t)
-	devCircuit, err := circuit.LoadZkCircuitByTag(circuit.DefaultCircuitConfigurationTag)
+	err := circuit.Init()
 	c.Assert(err, qt.IsNil)
-	app.TransactionHandler.ZkCircuit = devCircuit
 	// set initial inputs
 	testWeight := big.NewInt(10)
 	accounts, censusRoot, proofs := testCreateKeysAndBuildWeightedZkCensus(t, 10, testWeight)
@@ -84,7 +83,7 @@ func TestVoteCheckZkSNARK(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	encInputs, err := json.Marshal(inputs)
 	c.Assert(err, qt.IsNil)
-	proof, err := prover.Prove(devCircuit.ProvingKey, devCircuit.Wasm, encInputs)
+	proof, err := prover.Prove(circuit.Global().ProvingKey, circuit.Global().Wasm, encInputs)
 	c.Assert(err, qt.IsNil)
 	// generate nullifier
 	nullifier, err := testAccount.AccountSIKnullifier(electionId, nil)

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -89,7 +89,7 @@ func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool, 
 
 	// Create indexer
 	if vc.Indexer, err = indexer.New(filepath.Join(dataDir, "indexer"), vc.App,
-		indexer.Options{CountLiveResults: true},
+		indexer.Options{},
 	); err != nil {
 		return nil, err
 	}

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -88,9 +88,9 @@ func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool, 
 	vc.App.State.SetHeight(uint32(vc.height.Load()))
 
 	// Create indexer
-	if vc.Indexer, err = indexer.New(filepath.Join(dataDir, "indexer"), vc.App,
-		indexer.Options{},
-	); err != nil {
+	if vc.Indexer, err = indexer.New(vc.App, indexer.Options{
+		DataDir: filepath.Join(dataDir, "indexer"),
+	}); err != nil {
 		return nil, err
 	}
 

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -88,10 +88,8 @@ func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool, 
 	vc.App.State.SetHeight(uint32(vc.height.Load()))
 
 	// Create indexer
-	if vc.Indexer, err = indexer.NewIndexer(
-		filepath.Join(dataDir, "indexer"),
-		vc.App,
-		true,
+	if vc.Indexer, err = indexer.New(filepath.Join(dataDir, "indexer"), vc.App,
+		indexer.Options{CountLiveResults: true},
 	); err != nil {
 		return nil, err
 	}

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -67,7 +67,7 @@ func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool, 
 	vc.Config = &config.VochainCfg{}
 	vc.Config.DataDir = dataDir
 	vc.Config.DBType = db.TypePebble
-	vc.App, err = vochain.NewBaseApplication(db.TypePebble, dataDir)
+	vc.App, err = vochain.NewBaseApplication(vc.Config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- cleanup unused leftovers
- vochain: pass whole vochainCfg to NewBaseApplication
- renamed confusing VochainCfg.Chain -> VochainCfg.Network
- util: move zk.BigToFF and zk.BytesToArboStr to util package
- vochain fork: refactor ZkCircuits handling
- vochain/indexer: add an Options struct
- vochain/indexer: invert "live results" option
- vochain/indexer: move DataDir to Options
- vochain/indexer: add support for backups
- vochain fork: bump vocdoni/STAGE/9 ForkBlock
