### PR TITLE
api: cleanup docs references to Tx_MintTokens

### DIFF
--- a/api/docs/models/models.go
+++ b/api/docs/models/models.go
@@ -12,7 +12,6 @@ import (
 //	@Success	200	{object}	models.Tx_Admin
 //	@Success	200	{object}	models.Tx_SetProcess
 //	@Success	200	{object}	models.Tx_RegisterKey
-//	@Success	200	{object}	models.Tx_MintTokens
 //	@Success	200	{object}	models.Tx_SendTokens
 //	@Success	200	{object}	models.Tx_SetTransactionCosts
 //	@Success	200	{object}	models.Tx_SetAccount

--- a/api/docs/models/transactions.yaml
+++ b/api/docs/models/transactions.yaml
@@ -4,7 +4,6 @@ target:
     - $ref: "#/components/schemas/models.Tx_Admin"
     - $ref: "#/components/schemas/models.Tx_SetProcess"
     - $ref: "#/components/schemas/models.Tx_RegisterKey"
-    - $ref: "#/components/schemas/models.Tx_MintTokens"
     - $ref: "#/components/schemas/models.Tx_SendTokens"
     - $ref: "#/components/schemas/models.Tx_SetTransactionCosts"
     - $ref: "#/components/schemas/models.Tx_SetAccount"


### PR DESCRIPTION
treasurer logic was removed in 2c357eb19 but these API Swagger references were left behind
