### PR TITLE
vocone: fix dateToBlock estimation endpoint

### DIFF
--- a/api/chain.go
+++ b/api/chain.go
@@ -300,9 +300,17 @@ func (a *API) chainInfoHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) 
 		return err
 	}
 
+	var blockTimesInMs [5]uint64
+	for i, v := range a.vocinfo.BlockTimes() {
+		blockTimesInMs[i] = uint64(v.Milliseconds())
+	}
+	if blockTimesInMs[0] == 0 {
+		blockTimesInMs[0] = uint64(a.vocapp.BlockTimeTarget().Milliseconds())
+	}
+
 	data, err := json.Marshal(&ChainInfo{
 		ID:                a.vocapp.ChainID(),
-		BlockTime:         a.vocinfo.BlockTimes(),
+		BlockTime:         blockTimesInMs,
 		ElectionCount:     a.indexer.CountTotalProcesses(),
 		OrganizationCount: a.indexer.CountTotalEntities(),
 		Height:            a.vocapp.Height(),

--- a/cmd/voconed/voconed.go
+++ b/cmd/voconed/voconed.go
@@ -223,7 +223,7 @@ func main() {
 		}
 	}
 
-	vc.SetBlockTimeTarget(time.Second * time.Duration(config.blockSeconds))
+	vc.App.SetBlockTimeTarget(time.Second * time.Duration(config.blockSeconds))
 	vc.SetBlockSize(config.blockSize)
 
 	go vc.Start()

--- a/service/vochain.go
+++ b/service/vochain.go
@@ -174,13 +174,13 @@ func VochainPrintInfo(interval time.Duration, vi *vochaininfo.VochainInfo) {
 		b.Reset()
 		a := vi.BlockTimes()
 		if a[1] > 0 {
-			fmt.Fprintf(&b, "10m:%.2f", float32(a[1])/1000)
+			fmt.Fprintf(&b, "10m:%s", a[1].Truncate(time.Millisecond))
 		}
 		if a[2] > 0 {
-			fmt.Fprintf(&b, " 1h:%.2f", float32(a[2])/1000)
+			fmt.Fprintf(&b, " 1h:%s", a[2].Truncate(time.Millisecond))
 		}
 		if a[4] > 0 {
-			fmt.Fprintf(&b, " 24h:%.2f", float32(a[4])/1000)
+			fmt.Fprintf(&b, " 24h:%s", a[4].Truncate(time.Millisecond))
 		}
 		h = vi.Height()
 		m = vi.MempoolSize()

--- a/types/consts.go
+++ b/types/consts.go
@@ -36,7 +36,7 @@ const (
 	ArchiveURL = "/ipns/k2k4r8otxrf176h1i08txap0ep6ynr1jac0vymozi068eedml7gk1595"
 
 	// DefaultBlockTime is the default block time in seconds.
-	DefaultBlockTime = 12 * time.Second
+	DefaultBlockTime = 10 * time.Second
 
 	// KeyKeeperMaxKeyIndex is the maxim number of allowed encryption keys.
 	KeyKeeperMaxKeyIndex = 16

--- a/vochain/app.go
+++ b/vochain/app.go
@@ -18,6 +18,7 @@ import (
 	"go.vocdoni.io/dvote/config"
 	"go.vocdoni.io/dvote/crypto/zk/circuit"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
+	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/vochain/ist"
 	vstate "go.vocdoni.io/dvote/vochain/state"
 	"go.vocdoni.io/dvote/vochain/transaction"
@@ -71,6 +72,9 @@ type BaseApplication struct {
 	// txLReferences is a map indexed by hashed transactions and storing the height where the transaction
 	// was seen frist time and the number of attempts failed for including it into a block.
 	txReferences sync.Map
+
+	// blockTime is the target block time that miners use
+	blockTime time.Duration
 
 	// endBlockTimestamp is the last block end timestamp calculated from local time.
 	endBlockTimestamp atomic.Int64
@@ -412,4 +416,17 @@ func (app *BaseApplication) TimestampFromBlock(height int64) *time.Time {
 // MempoolSize returns the size of the transaction mempool
 func (app *BaseApplication) MempoolSize() int {
 	return app.fnMempoolSize()
+}
+
+// BlockTimeTarget returns the current block time target
+func (app *BaseApplication) BlockTimeTarget() time.Duration {
+	if app.blockTime == 0 {
+		return types.DefaultBlockTime
+	}
+	return app.blockTime
+}
+
+// SetBlockTimeTarget sets the current block time target
+func (app *BaseApplication) SetBlockTimeTarget(d time.Duration) {
+	app.blockTime = d
 }

--- a/vocone/vocone_test.go
+++ b/vocone/vocone_test.go
@@ -34,7 +34,7 @@ func TestVocone(t *testing.T) {
 	vc, err := NewVocone(dir, &keymng, false, "", nil)
 	qt.Assert(t, err, qt.IsNil)
 
-	vc.SetBlockTimeTarget(time.Millisecond * 500)
+	vc.App.SetBlockTimeTarget(time.Millisecond * 500)
 	go vc.Start()
 	port := 13000 + util.RandomInt(0, 2000)
 	_, err = vc.EnableAPI("127.0.0.1", port, "/v2")


### PR DESCRIPTION
 vocone: fix dateToBlock estimation endpoint

* vocinfo.BlockTimes() now returns [5]time.Duration
* during startup, endpoint /chain/info now returns BlockTimeTarget instead of `[0, 0, 0, 0, 0]`
* vochain/app now has BlockTimeTarget and SetBlockTimeTarget
* types.DefaultBlockTime fixed (10s instead of 12s)
* vi.EstimateBlockHeight and vi.HeightTime refactored and fixed
* vocone now keeps track of blockTimestamps