### PR TITLE
testsuite: fix zkCircuits path

### DIFF
--- a/dockerfiles/testsuite/docker-compose.yml
+++ b/dockerfiles/testsuite/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - data-seed:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - /tmp/.vochain-zkCircuits/:/app/run/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/dev/zkCircuits/
       - gocoverage-seed:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -27,7 +27,7 @@ services:
     volumes:
       - data-miner0:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - /tmp/.vochain-zkCircuits/:/app/run/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/dev/zkCircuits/
       - gocoverage-miner0:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -41,7 +41,7 @@ services:
     volumes:
       - data-miner1:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - /tmp/.vochain-zkCircuits/:/app/run/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/dev/zkCircuits/
       - gocoverage-miner1:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -55,7 +55,7 @@ services:
     volumes:
       - data-miner2:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - /tmp/.vochain-zkCircuits/:/app/run/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/dev/zkCircuits/
       - gocoverage-miner2:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -69,7 +69,7 @@ services:
     volumes:
       - data-miner3:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - /tmp/.vochain-zkCircuits/:/app/run/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/dev/zkCircuits/
       - gocoverage-miner3:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage
@@ -85,7 +85,7 @@ services:
     volumes:
       - data-gateway0:/app/run/
       - ${COMPOSE_HOST_PATH:-.}/genesis.json:/app/misc/genesis.json
-      - /tmp/.vochain-zkCircuits/:/app/run/zkCircuits/
+      - /tmp/.vochain-zkCircuits/:/app/run/dev/zkCircuits/
       - gocoverage-gateway0:/app/run/gocoverage
     environment:
       - GOCOVERDIR=/app/run/gocoverage


### PR DESCRIPTION
since 42b43f6 "cmd/node: tidy up datadir and saveconfig flags"
dataDir changed, but testsuite docker-compose.yml was not updated.
