### PR TITLE
vochain: refactor proof verification logic

### DIFF
--- a/api/census_test.go
+++ b/api/census_test.go
@@ -222,14 +222,18 @@ func TestCensusProof(t *testing.T) {
 			ProcessId:    electionID,
 			CensusRoot:   censusData.CensusID,
 			CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED,
+			EnvelopeType: &models.EnvelopeType{},
 		},
-		&models.Proof{
-			Payload: &models.Proof_Arbo{
-				Arbo: &models.ProofArbo{
-					Type:            models.ProofArbo_BLAKE2B,
-					Siblings:        censusData.CensusProof,
-					AvailableWeight: censusData.Value,
-					VoteWeight:      censusData.Value,
+		&models.VoteEnvelope{
+			ProcessId: electionID,
+			Proof: &models.Proof{
+				Payload: &models.Proof_Arbo{
+					Arbo: &models.ProofArbo{
+						Type:            models.ProofArbo_BLAKE2B,
+						Siblings:        censusData.CensusProof,
+						AvailableWeight: censusData.Value,
+						VoteWeight:      censusData.Value,
+					},
 				},
 			},
 		},
@@ -329,14 +333,18 @@ func TestCensusZk(t *testing.T) {
 			ProcessId:    electionID,
 			CensusRoot:   censusData.CensusID,
 			CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED,
+			EnvelopeType: &models.EnvelopeType{},
 		},
-		&models.Proof{
-			Payload: &models.Proof_Arbo{
-				Arbo: &models.ProofArbo{
-					Type:            models.ProofArbo_POSEIDON,
-					Siblings:        censusData.CensusProof,
-					AvailableWeight: censusData.Value,
-					VoteWeight:      censusData.Value,
+		&models.VoteEnvelope{
+			ProcessId: electionID,
+			Proof: &models.Proof{
+				Payload: &models.Proof_Arbo{
+					Arbo: &models.ProofArbo{
+						Type:            models.ProofArbo_POSEIDON,
+						Siblings:        censusData.CensusProof,
+						AvailableWeight: censusData.Value,
+						VoteWeight:      censusData.Value,
+					},
 				},
 			},
 		},

--- a/apiclient/vote.go
+++ b/apiclient/vote.go
@@ -113,11 +113,10 @@ func (cl *HTTPclient) Vote(v *VoteData) (types.HexBytes, error) {
 			return nil, err
 		}
 		// include vote nullifier and the encoded proof in a VoteEnvelope
-		nullifier, err := proof.ExtractPubSignal("nullifier")
+		vote.Nullifier, err = proof.Nullifier()
 		if err != nil {
 			return nil, err
 		}
-		vote.Nullifier = nullifier.Bytes()
 		vote.Proof = &models.Proof{
 			Payload: &models.Proof_ZkSnark{
 				ZkSnark: protoProof,

--- a/crypto/ethereum/vocdoni_sik.go
+++ b/crypto/ethereum/vocdoni_sik.go
@@ -65,7 +65,7 @@ func (k *SignKeys) AccountSIKnullifier(electionID, secret []byte) ([]byte, error
 		seed = append(seed, big.NewInt(0))
 	}
 	// encode the election id for circom and include it into the nullifier
-	seed = append(seed, util.BytesToArbo(electionID)...)
+	seed = append(seed, util.BytesToArboSplit(electionID)...)
 	// calculate the poseidon image --> H(signature + secret + electionId)
 	hash, err := poseidon.Hash(seed)
 	if err != nil {

--- a/crypto/zk/circuit/inputs.go
+++ b/crypto/zk/circuit/inputs.go
@@ -78,10 +78,10 @@ func GenerateCircuitInput(p CircuitInputsParameters) (*CircuitInputs, error) {
 		return nil, err
 	}
 	return &CircuitInputs{
-		ElectionId:      util.BytesToArboStr(p.ElectionId),
+		ElectionId:      util.BytesToArboSplitStr(p.ElectionId),
 		Nullifier:       new(big.Int).SetBytes(nullifier).String(),
 		AvailableWeight: p.AvailableWeight.String(),
-		VoteHash:        util.BytesToArboStr(p.AvailableWeight.Bytes()),
+		VoteHash:        util.BytesToArboSplitStr(p.AvailableWeight.Bytes()),
 		SIKRoot:         arbo.BytesToBigInt(p.SIKRoot).String(),
 		CensusRoot:      arbo.BytesToBigInt(p.CensusRoot).String(),
 

--- a/crypto/zk/circuit/inputs_test.go
+++ b/crypto/zk/circuit/inputs_test.go
@@ -33,7 +33,7 @@ func TestGenerateCircuitInput(t *testing.T) {
 	// mock the availableWeight
 	availableWeight := new(big.Int).SetUint64(10)
 	// calc vote hash
-	voteHash := util.BytesToArboStr(availableWeight.Bytes())
+	voteHash := util.BytesToArboSplitStr(availableWeight.Bytes())
 	// decode the test root
 	hexTestRoot, err := hex.DecodeString(testRoot)
 	c.Assert(err, qt.IsNil)

--- a/crypto/zk/prover/prover.go
+++ b/crypto/zk/prover/prover.go
@@ -8,14 +8,11 @@ package prover
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 
 	"github.com/iden3/go-rapidsnark/prover"
 	"github.com/iden3/go-rapidsnark/types"
 	"github.com/iden3/go-rapidsnark/verifier"
 	"github.com/iden3/go-rapidsnark/witness"
-	"go.vocdoni.io/dvote/crypto/zk/circuit"
-	"go.vocdoni.io/dvote/tree/arbo"
 )
 
 // TODO: Refactor the error handling to include the trace of the original error
@@ -80,46 +77,6 @@ func (p *Proof) Bytes() ([]byte, []byte, error) {
 	}
 
 	return proofData, pubSignals, nil
-}
-
-// ExtractPubSignal decodes the requested public signal (identified by a string: "nullifier", "sikRoot", etc)
-// from the current proof and returns it as a big.Int.
-func (p *Proof) ExtractPubSignal(id string) (*big.Int, error) {
-	// Check if the current proof contains public signals and it contains the
-	// correct number of positions.
-	if p.PubSignals == nil || len(p.PubSignals) != len(circuit.Global().Config.PublicSignals) {
-		return nil, ErrPublicSignalFormat
-	}
-	idx, found := circuit.Global().Config.PublicSignals[id]
-	if !found {
-		return nil, ErrPubSignalNotFound
-	}
-	s := p.PubSignals[idx]
-	// Parse it into a big.Int
-	i, ok := new(big.Int).SetString(s, 10)
-	if !ok {
-		return nil, ErrParsingProofSignal
-	}
-	return i, nil
-
-}
-
-// SIKRoot function returns the SIKRoot included into the current proof.
-func (p *Proof) SIKRoot() ([]byte, error) {
-	sikRoot, err := p.ExtractPubSignal("sikRoot")
-	if err != nil {
-		return nil, err
-	}
-	return arbo.BigIntToBytes(arbo.HashFunctionPoseidon.Len(), sikRoot), nil
-}
-
-// Nullifier function returns the Nullifier included into the current proof.
-func (p *Proof) Nullifier() ([]byte, error) {
-	nullifier, err := p.ExtractPubSignal("nullifier")
-	if err != nil {
-		return nil, err
-	}
-	return nullifier.Bytes(), nil
 }
 
 // calcWitness perform the witness calculation using go-rapidsnark library based

--- a/crypto/zk/prover/pubsignals.go
+++ b/crypto/zk/prover/pubsignals.go
@@ -1,0 +1,112 @@
+package prover
+
+import (
+	"math/big"
+
+	"go.vocdoni.io/dvote/crypto/zk/circuit"
+	"go.vocdoni.io/dvote/tree/arbo"
+	"go.vocdoni.io/dvote/util"
+)
+
+// extractPubSignal decodes the requested public signal (identified by a string: "nullifier", "sikRoot", etc)
+// from the current proof and returns it as a big.Int.
+func (p *Proof) extractPubSignal(id string) (string, error) {
+	// Check if the current proof contains public signals and it contains the
+	// correct number of positions.
+	if p.PubSignals == nil || len(p.PubSignals) != len(circuit.Global().Config.PublicSignals) {
+		return "", ErrPublicSignalFormat
+	}
+	idx, found := circuit.Global().Config.PublicSignals[id]
+	if !found {
+		return "", ErrPubSignalNotFound
+	}
+	return p.PubSignals[idx], nil
+}
+
+// stringToBigInt converts a string into a standard big.Int.
+func stringToBigInt(s string) (*big.Int, error) {
+	i, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return nil, ErrParsingProofSignal
+	}
+	return i, nil
+}
+
+// ElectionID returns the ElectionID used as public input to generate the proof.
+func (p *Proof) ElectionID() ([]byte, error) {
+	electionID1str, err := p.extractPubSignal("electionId[0]")
+	if err != nil {
+		return nil, err
+	}
+	electionID2str, err := p.extractPubSignal("electionId[1]")
+	if err != nil {
+		return nil, err
+	}
+	return util.SplittedArboStrToBytes(electionID1str, electionID2str), nil
+}
+
+// VoteHash returns the VoteHash included into the current proof.
+func (p *Proof) VoteHash() ([]byte, error) {
+	voteHash1str, err := p.extractPubSignal("voteHash[0]")
+	if err != nil {
+		return nil, err
+	}
+	voteHash2str, err := p.extractPubSignal("voteHash[1]")
+	if err != nil {
+		return nil, err
+	}
+	return util.SplittedArboStrToBytes(voteHash1str, voteHash2str), nil
+}
+
+// CensusRoot returns the CensusRoot included into the current proof.
+func (p *Proof) CensusRoot() ([]byte, error) {
+	censusRoot, err := p.extractPubSignal("censusRoot")
+	if err != nil {
+		return nil, err
+	}
+	bi, err := stringToBigInt(censusRoot)
+	if err != nil {
+		return nil, err
+	}
+	return arbo.BigIntToBytes(arbo.HashFunctionPoseidon.Len(), bi), nil
+}
+
+// VoteWeight returns the VoteWeight included into the current proof.
+func (p *Proof) VoteWeight() (*big.Int, error) {
+	weight, err := p.extractPubSignal("voteWeight")
+	if err != nil {
+		return nil, err
+	}
+	return stringToBigInt(weight)
+}
+
+// AvailableWeight returns the AvailableWeight included into the current proof (not implemented).
+func (p *Proof) AvailableWeight() (*big.Int, error) {
+	panic("not implemented")
+}
+
+// Nullifier returns the Nullifier included into the current proof.
+func (p *Proof) Nullifier() ([]byte, error) {
+	nullifier, err := p.extractPubSignal("nullifier")
+	if err != nil {
+		return nil, err
+	}
+	bi, err := stringToBigInt(nullifier)
+	if err != nil {
+		return nil, err
+	}
+	return bi.Bytes(), err
+}
+
+// SIKRoot function returns the SIKRoot included into the current proof.
+func (p *Proof) SIKRoot() ([]byte, error) {
+	sikRoot, err := p.extractPubSignal("sikRoot")
+	if err != nil {
+		return nil, err
+	}
+	bi, err := stringToBigInt(sikRoot)
+	if err != nil {
+		return nil, err
+	}
+	return arbo.BigIntToBytes(arbo.HashFunctionPoseidon.Len(), bi), nil
+}

--- a/util/zk.go
+++ b/util/zk.go
@@ -25,10 +25,10 @@ func BigToFF(iv *big.Int) *big.Int {
 	return z.Mod(iv, bn254BaseField)
 }
 
-// BytesToArbo calculates the sha256 hash (32 bytes) of the slice of bytes
+// BytesToArboSplit calculates the sha256 hash (32 bytes) of the slice of bytes
 // provided. Then, splits the hash into a two parts of 16 bytes, swap the
 // endianess of that parts and encodes they into a two big.Int's.
-func BytesToArbo(input []byte) []*big.Int {
+func BytesToArboSplit(input []byte) []*big.Int {
 	hash := sha256.Sum256(input)
 	return []*big.Int{
 		new(big.Int).SetBytes(arbo.SwapEndianness(hash[:16])),
@@ -36,8 +36,24 @@ func BytesToArbo(input []byte) []*big.Int {
 	}
 }
 
-// BytesToArboStr function wraps BytesToArbo to return the input as []string.
-func BytesToArboStr(input []byte) []string {
-	arboBytes := BytesToArbo(input)
+// BytesToArboSplitStr function wraps BytesToArbo to return the input as []string.
+func BytesToArboSplitStr(input []byte) []string {
+	arboBytes := BytesToArboSplit(input)
 	return []string{arboBytes[0].String(), arboBytes[1].String()}
+}
+
+// SplittedArboToBytes function receives a slice of big.Int's and returns the
+func SplittedArboToBytes(input1, input2 *big.Int) []byte {
+	b1 := arbo.SwapEndianness(input1.Bytes())
+	b2 := arbo.SwapEndianness(input2.Bytes())
+	return append(b1, b2...)
+}
+
+// SplittedArboStrToBytes function wraps SplittedArboToBytes to return the input as []byte
+func SplittedArboStrToBytes(input1, input2 string) []byte {
+	b1 := new(big.Int)
+	b1.SetString(input1, 10)
+	b2 := new(big.Int)
+	b2.SetString(input2, 10)
+	return SplittedArboToBytes(b1, b2)
 }

--- a/util/zk_test.go
+++ b/util/zk_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"math/big"
 	"testing"
 
@@ -11,10 +13,26 @@ func TestBytesToArboStr(t *testing.T) {
 	c := qt.New(t)
 
 	input := new(big.Int).SetInt64(1233)
-	encoded := BytesToArboStr(input.Bytes())
+	encoded := BytesToArboSplitStr(input.Bytes())
 	expected := []string{
 		"145749485520268040037154566173721592631",
 		"243838562910071029186006881148627719363",
 	}
 	c.Assert(encoded, qt.DeepEquals, expected)
+}
+
+func TestConversionConsistency(t *testing.T) {
+	originalInput := []byte("test input")
+
+	// Convert to strings
+	strParts := BytesToArboSplitStr(originalInput)
+
+	// Convert strings back to bytes
+	reconstructedBytes := SplittedArboStrToBytes(strParts[0], strParts[1])
+
+	// Hash the original input to compare with reconstructed bytes
+	expectedHash := sha256.Sum256(originalInput)
+
+	// Check if reconstructed bytes match the hash of the original input
+	qt.Assert(t, bytes.Equal(reconstructedBytes, expectedHash[:]), qt.IsTrue)
 }

--- a/vochain/processid/process_id.go
+++ b/vochain/processid/process_id.go
@@ -35,10 +35,9 @@ type ProcessID struct {
 	nonce            uint32
 }
 
-// Marshal encodes to bytes
+// Marshal encodes to bytes:
+// processID = chainID[6bytes] + organizationAddress[20bytes] + proofType[1byte] + envelopeType[1byte] + nonce[4bytes]
 func (p *ProcessID) Marshal() []byte {
-	// processID =
-	//  chainID[6bytes] + organizationAddress[20bytes] + proofType[1byte] + envelopeType[1byte] + nonce[4bytes]
 	chainID := ethereum.HashRaw([]byte(p.chainID))
 
 	nonce := make([]byte, 4)
@@ -195,6 +194,9 @@ func BuildProcessID(proc *models.Process, state *state.State) (*ProcessID, error
 	acc, err := state.GetAccount(addr, false)
 	if err != nil {
 		return nil, err
+	}
+	if acc == nil {
+		return nil, fmt.Errorf("account not found %s", addr.Hex())
 	}
 	pid.SetAddr(addr)
 	pid.SetNonce(acc.GetProcessIndex())

--- a/vochain/transaction/proof.go
+++ b/vochain/transaction/proof.go
@@ -5,45 +5,41 @@ import (
 	"fmt"
 	"math/big"
 
-	"go.vocdoni.io/dvote/censustree"
-	"go.vocdoni.io/dvote/crypto/ethereum"
-	"go.vocdoni.io/dvote/crypto/saltedkey"
 	"go.vocdoni.io/dvote/log"
-	"go.vocdoni.io/dvote/tree"
 	"go.vocdoni.io/dvote/vochain/state"
-	"google.golang.org/protobuf/proto"
+	"go.vocdoni.io/dvote/vochain/transaction/proofs/arboproof"
+	"go.vocdoni.io/dvote/vochain/transaction/proofs/cspproof"
+	"go.vocdoni.io/dvote/vochain/transaction/proofs/ethereumproof"
+	"go.vocdoni.io/dvote/vochain/transaction/proofs/zkproof"
 
-	blind "github.com/arnaucube/go-blindsecp256k1"
-	ethcommon "github.com/ethereum/go-ethereum/common"
-	ethcrypto "github.com/ethereum/go-ethereum/crypto"
-
-	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
-	"github.com/vocdoni/storage-proofs-eth-go/token/mapbased"
-	"github.com/vocdoni/storage-proofs-eth-go/token/minime"
-	"go.vocdoni.io/dvote/tree/arbo"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
-var (
-	bigZero = big.NewInt(0)
-	bigOne  = big.NewInt(1)
-)
-
-// VerifyProofFunc is the generic function type to verify a proof of belonging
-// into a census within a process.
-type VerifyProofFunc func(process *models.Process, proof *models.Proof,
-	censusOrigin models.CensusOrigin,
-	censusRoot, processID []byte, vID state.VoterID) (bool, *big.Int, error)
+// ProofVerifier defines the interface for proof verification systems.
+type ProofVerifier interface {
+	Verify(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error)
+}
 
 // VerifyProof is a wrapper over all VerifyProofFunc(s) available which uses the process.CensusOrigin
 // to execute the correct verification function.
-func VerifyProof(process *models.Process, proof *models.Proof, vID state.VoterID) (bool, *big.Int, error) {
-	if proof == nil {
+func VerifyProof(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
+	// sanity checks
+	if envelope == nil {
+		return false, nil, fmt.Errorf("envelope is nil")
+	}
+	if envelope.Proof == nil {
 		return false, nil, fmt.Errorf("proof is nil")
 	}
-	if process == nil {
-		return false, nil, fmt.Errorf("process is nil")
+	if process == nil || process.CensusRoot == nil {
+		return false, nil, fmt.Errorf("process or census root are nil")
 	}
+	if !bytes.Equal(process.ProcessId, envelope.ProcessId) {
+		return false, nil, fmt.Errorf("processID does not match")
+	}
+	if process.EnvelopeType == nil {
+		return false, nil, fmt.Errorf("envelope type is nil")
+	}
+
 	log.Debugw("verify proof",
 		"censusOrigin", process.CensusOrigin,
 		"electionID", fmt.Sprintf("%x", process.ProcessId),
@@ -51,246 +47,27 @@ func VerifyProof(process *models.Process, proof *models.Proof, vID state.VoterID
 		"address", fmt.Sprintf("%x", vID.Address()),
 		"censusRoot", fmt.Sprintf("%x", process.CensusRoot),
 	)
-	// check census origin and compute vote digest identifier
-	var verifyProof VerifyProofFunc
+
+	// select the correct proof verifier
+	var verifier ProofVerifier
 	switch process.CensusOrigin {
 	case models.CensusOrigin_OFF_CHAIN_TREE, models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED:
-		verifyProof = VerifyProofOffChainTree
+		if process.EnvelopeType.Anonymous {
+			verifier = &zkproof.ProofVerifierZk{}
+		} else {
+			verifier = &arboproof.ProofVerifierArbo{}
+		}
 	case models.CensusOrigin_OFF_CHAIN_CA:
-		verifyProof = VerifyProofOffChainCSP
-	case models.CensusOrigin_ERC20:
-		verifyProof = VerifyProofERC20
-	case models.CensusOrigin_MINI_ME:
-		verifyProof = VerifyProofMiniMe
+		verifier = &cspproof.ProofVerifierCSP{}
+	case models.CensusOrigin_ERC20, models.CensusOrigin_MINI_ME:
+		verifier = &ethereumproof.ProofVerifierEthereumStorage{}
 	default:
 		return false, nil, fmt.Errorf("census origin not compatible")
 	}
-	valid, weight, err := verifyProof(process, proof,
-		process.CensusOrigin, process.CensusRoot, process.ProcessId,
-		vID)
+	// execute the verification
+	valid, weight, err := verifier.Verify(process, envelope, vID)
 	if err != nil {
 		return false, nil, fmt.Errorf("proof not valid: %w", err)
 	}
 	return valid, weight, nil
-}
-
-// VerifyProofOffChainTree verifies a proof with census origin OFF_CHAIN_TREE.
-// Returns verification result and weight.
-func VerifyProofOffChainTree(_ *models.Process, proof *models.Proof,
-	_ models.CensusOrigin,
-	censusRoot, _ []byte, vID state.VoterID) (bool, *big.Int, error) {
-	switch proof.Payload.(type) {
-	case *models.Proof_Arbo:
-		p := proof.GetArbo()
-		if p == nil {
-			return false, nil, fmt.Errorf("arbo proof is empty")
-		}
-		// get the merkle tree hashing function
-		var hashFunc arbo.HashFunction = arbo.HashFunctionBlake2b
-		switch p.Type {
-		case models.ProofArbo_BLAKE2B:
-			hashFunc = arbo.HashFunctionBlake2b
-		case models.ProofArbo_POSEIDON:
-			hashFunc = arbo.HashFunctionPoseidon
-		default:
-			return false, nil, fmt.Errorf("not recognized ProofArbo type: %s", p.Type)
-		}
-		if vID == nil {
-			return false, nil, fmt.Errorf("voterID is nil")
-		}
-		// check if the proof key is for an address (default) or a pubKey
-		var err error
-		key := vID.Address()
-		// TODO (lucasmenendez): Remove hashing of the address
-		if p.Type != models.ProofArbo_POSEIDON {
-			if key, err = hashFunc.Hash(key); err != nil {
-				return false, nil, fmt.Errorf("cannot hash proof key: %w", err)
-			}
-			if len(key) > censustree.DefaultMaxKeyLen {
-				key = key[:censustree.DefaultMaxKeyLen]
-			}
-		}
-		valid, err := tree.VerifyProof(hashFunc, key, p.AvailableWeight, p.Siblings, censusRoot)
-		if !valid || err != nil {
-			return false, nil, err
-		}
-		// Legacy: support p.LeafWeight == nil, assume then value=1
-		if p.AvailableWeight == nil {
-			return true, bigOne, nil
-		}
-
-		availableWeight := arbo.BytesToBigInt(p.AvailableWeight)
-		if p.VoteWeight == nil {
-			return true, availableWeight, nil
-		}
-
-		voteWeight := arbo.BytesToBigInt(p.VoteWeight)
-		if voteWeight.Cmp(availableWeight) == 1 {
-			return false, nil, fmt.Errorf("assigned weight exceeded")
-		}
-		return true, voteWeight, nil
-	default:
-		return false, nil, fmt.Errorf("unexpected proof.Payload type: %T",
-			proof.Payload)
-	}
-}
-
-// VerifyProofOffChainCSP verifies a proof with census origin OFF_CHAIN_CA.
-// Returns verification result and weight.
-func VerifyProofOffChainCSP(_ *models.Process, proof *models.Proof,
-	_ models.CensusOrigin,
-	censusRoot, processID []byte, vID state.VoterID) (bool, *big.Int, error) {
-	key := vID.Address()
-
-	p := proof.GetCa()
-	if p == nil || p.Bundle == nil {
-		return false, nil, fmt.Errorf("CSP proof or bundle are nil")
-	}
-	if !bytes.Equal(p.Bundle.Address, key) {
-		return false, nil, fmt.Errorf(
-			"CSP bundle address and key do not match: %x != %x", key, p.Bundle.Address)
-	}
-	if !bytes.Equal(p.Bundle.ProcessId, processID) {
-		return false, nil, fmt.Errorf("CSP bundle processID does not match")
-	}
-	cspBundle, err := proto.Marshal(p.Bundle)
-	if err != nil {
-		return false, nil, fmt.Errorf("cannot marshal CSP bundle to protobuf: %w", err)
-	}
-
-	// depending on signature type, use a mechanism for extracting the ca publickey from signature
-	switch p.GetType() {
-	case models.ProofCA_ECDSA, models.ProofCA_ECDSA_PIDSALTED:
-		bundlePub, err := ethereum.PubKeyFromSignature(cspBundle, p.GetSignature())
-		if err != nil {
-			return false, nil, fmt.Errorf("cannot fetch CSP public key from signature: %w", err)
-		}
-		if p.GetType() == models.ProofCA_ECDSA_PIDSALTED {
-			rootPub, err := ethereum.DecompressPubKey(censusRoot)
-			if err != nil {
-				return false, nil, fmt.Errorf("cannot decompress CSP public key: %w", err)
-			}
-			rootPubSalted, err := ethcrypto.UnmarshalPubkey(rootPub)
-			if err != nil {
-				return false, nil, fmt.Errorf("cannot unmarshal ECDSA CSP public key: %w", err)
-			}
-			rootPubSalted, err = saltedkey.SaltECDSAPubKey(rootPubSalted, processID)
-			if err != nil {
-				return false, nil, fmt.Errorf("cannot salt ECDSA public key: %w", err)
-			}
-			censusRoot = ethcrypto.FromECDSAPub(rootPubSalted)
-			// if salted, pubKey should be decompressed
-			if bundlePub, err = ethereum.DecompressPubKey(bundlePub); err != nil {
-				return false, nil, fmt.Errorf("unable to decompress proof pub key: %w", err)
-			}
-		}
-		if !bytes.Equal(bundlePub, censusRoot) {
-			return false, nil, fmt.Errorf("CSP bundle signature does not match")
-		}
-	case models.ProofCA_ECDSA_BLIND, models.ProofCA_ECDSA_BLIND_PIDSALTED:
-		// Blind CSP check
-		rootPubdesc, err := ethereum.DecompressPubKey(censusRoot)
-		if err != nil {
-			return false, nil, fmt.Errorf("cannot decompress CSP public key: %w", err)
-		}
-		rootPub, err := blind.NewPublicKeyFromECDSA(rootPubdesc)
-		if err != nil {
-			return false, nil, fmt.Errorf("cannot compute blind CSP public key: %w", err)
-		}
-		signature, err := blind.NewSignatureFromBytesUncompressed(p.GetSignature())
-		if err != nil {
-			return false, nil, fmt.Errorf("cannot compute blind CSP signature: %w", err)
-		}
-		// If pid salted, apply the salt (processId) to the censusRoot public key
-		if p.GetType() == models.ProofCA_ECDSA_BLIND_PIDSALTED {
-			rootPub, err = saltedkey.SaltBlindPubKey(rootPub, processID)
-			if err != nil {
-				return false, nil, fmt.Errorf("cannot salt blind pubkey: %w", err)
-			}
-		}
-		if !blind.Verify(new(big.Int).SetBytes(ethereum.HashRaw(cspBundle)), signature, rootPub) {
-			cspbundleDec := &models.CAbundle{}
-			if err := proto.Unmarshal(cspBundle, cspbundleDec); err != nil {
-				log.Warnf("cannot unmarshal CSP bundle: %v", err)
-			}
-			return false, nil, fmt.Errorf("blind CSP verification failed for "+
-				"pid %x with CSP key %x. CSP bundle {pid:%x, addr:%x}. CSP signature %x",
-				processID, rootPub.Bytes(), cspbundleDec.ProcessId, cspbundleDec.Address, signature.Bytes())
-		}
-	default:
-		return false, nil, fmt.Errorf("CSP proof %s type not supported", p.Type)
-	}
-	return true, bigOne, nil
-}
-
-// VerifyProofERC20 verifies a proof with census origin ERC20 (mapbased).
-// Returns verification result and weight.
-func VerifyProofERC20(process *models.Process, proof *models.Proof,
-	_ models.CensusOrigin,
-	censusRoot, _ []byte, vID state.VoterID) (bool, *big.Int, error) {
-	if process.EthIndexSlot == nil {
-		return false, nil, fmt.Errorf("index slot not found for process %x", process.ProcessId)
-	}
-	p := proof.GetEthereumStorage()
-	if p == nil {
-		return false, nil, fmt.Errorf("ethereum proof is empty")
-	}
-
-	balance := new(big.Int).SetBytes(p.Value)
-	if balance.Cmp(bigZero) == 0 {
-		return false, nil, fmt.Errorf("balance at proof is 0")
-	}
-	log.Debugf("validating erc20 storage proof for key %x and balance %v", p.Key, balance)
-	err := mapbased.VerifyProof(ethereum.AddrFromBytes(vID.Address()), ethcommon.BytesToHash(censusRoot),
-		ethstorageproof.StorageResult{
-			Key:   p.Key,
-			Proof: p.Siblings,
-			Value: p.Value,
-		},
-		int(*process.EthIndexSlot),
-		balance,
-		nil)
-	return err == nil, balance, err
-}
-
-// VerifyProofMiniMe verifies a proof with census origin MiniMe.
-// Returns verification result and weight.
-func VerifyProofMiniMe(process *models.Process, proof *models.Proof,
-	_ models.CensusOrigin,
-	censusRoot, _ []byte, vID state.VoterID) (bool, *big.Int, error) {
-	if process.EthIndexSlot == nil {
-		return false, nil, fmt.Errorf("index slot not found for process %x", process.ProcessId)
-	}
-	if process.SourceBlockHeight == nil {
-		return false, nil, fmt.Errorf("source block height not found for process %x",
-			process.ProcessId)
-	}
-	p := proof.GetMinimeStorage()
-	if p == nil {
-		return false, nil, fmt.Errorf("minime proof is empty")
-	}
-
-	_, proof0Balance, _ := minime.ParseMinimeValue(p.ProofPrevBlock.Value, 0)
-	if proof0Balance.Cmp(bigZero) == 0 {
-		return false, nil, fmt.Errorf("balance at proofPrevBlock is 0")
-	}
-	log.Debugf("validating minime storage proof for key %x and balance %v",
-		p.ProofPrevBlock.Key, proof0Balance)
-	err := minime.VerifyProof(ethereum.AddrFromBytes(vID.Address()), ethcommon.BytesToHash(censusRoot),
-		[]ethstorageproof.StorageResult{
-			{
-				Key:   p.ProofPrevBlock.Key,
-				Proof: p.ProofPrevBlock.Siblings,
-				Value: p.ProofPrevBlock.Value,
-			},
-			{
-				Key:   p.ProofNextBlock.Key,
-				Proof: p.ProofNextBlock.Siblings,
-				Value: p.ProofNextBlock.Value,
-			},
-		},
-		int(*process.EthIndexSlot),
-		proof0Balance,
-		new(big.Int).SetUint64(*process.SourceBlockHeight))
-	return err == nil, proof0Balance, err
 }

--- a/vochain/transaction/proofs/arboproof/arboproof.go
+++ b/vochain/transaction/proofs/arboproof/arboproof.go
@@ -1,0 +1,77 @@
+package arboproof
+
+import (
+	"fmt"
+	"math/big"
+
+	"go.vocdoni.io/dvote/censustree"
+	"go.vocdoni.io/dvote/tree"
+	"go.vocdoni.io/dvote/tree/arbo"
+	"go.vocdoni.io/dvote/vochain/state"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+var bigOne = big.NewInt(1)
+
+// ProofVerifierArbo defines the interface for Arbo merkle-tree based proof verification systems.
+type ProofVerifierArbo struct{}
+
+// Verify verifies a proof with census origin OFF_CHAIN_TREE.
+// Returns verification result and weight.
+func (*ProofVerifierArbo) Verify(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
+	proof := envelope.Proof
+	switch proof.Payload.(type) {
+	case *models.Proof_Arbo:
+		p := proof.GetArbo()
+		if p == nil {
+			return false, nil, fmt.Errorf("arbo proof is empty")
+		}
+		// get the merkle tree hashing function
+		var hashFunc arbo.HashFunction = arbo.HashFunctionBlake2b
+		switch p.Type {
+		case models.ProofArbo_BLAKE2B:
+			hashFunc = arbo.HashFunctionBlake2b
+		case models.ProofArbo_POSEIDON:
+			hashFunc = arbo.HashFunctionPoseidon
+		default:
+			return false, nil, fmt.Errorf("not recognized ProofArbo type: %s", p.Type)
+		}
+		if vID == nil {
+			return false, nil, fmt.Errorf("voterID is nil")
+		}
+		// check if the proof key is for an address (default) or a pubKey
+		var err error
+		key := vID.Address()
+		// TODO (lucasmenendez): Remove hashing of the address
+		if p.Type != models.ProofArbo_POSEIDON {
+			if key, err = hashFunc.Hash(key); err != nil {
+				return false, nil, fmt.Errorf("cannot hash proof key: %w", err)
+			}
+			if len(key) > censustree.DefaultMaxKeyLen {
+				key = key[:censustree.DefaultMaxKeyLen]
+			}
+		}
+		valid, err := tree.VerifyProof(hashFunc, key, p.AvailableWeight, p.Siblings, process.CensusRoot)
+		if !valid || err != nil {
+			return false, nil, err
+		}
+		// Legacy: support p.LeafWeight == nil, assume then value=1
+		if p.AvailableWeight == nil {
+			return true, bigOne, nil
+		}
+
+		availableWeight := arbo.BytesToBigInt(p.AvailableWeight)
+		if p.VoteWeight == nil {
+			return true, availableWeight, nil
+		}
+
+		voteWeight := arbo.BytesToBigInt(p.VoteWeight)
+		if voteWeight.Cmp(availableWeight) == 1 {
+			return false, nil, fmt.Errorf("assigned weight exceeded")
+		}
+		return true, voteWeight, nil
+	default:
+		return false, nil, fmt.Errorf("unexpected proof.Payload type: %T",
+			proof.Payload)
+	}
+}

--- a/vochain/transaction/proofs/cspproof/cspproof.go
+++ b/vochain/transaction/proofs/cspproof/cspproof.go
@@ -1,0 +1,107 @@
+package cspproof
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+
+	blind "github.com/arnaucube/go-blindsecp256k1"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/saltedkey"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/vochain/state"
+	"go.vocdoni.io/proto/build/go/models"
+	"google.golang.org/protobuf/proto"
+)
+
+var bigOne = big.NewInt(1)
+
+// ProofVerifierCSP defines the interface for CSP (Credential Service Provider) proof verification systems.
+type ProofVerifierCSP struct{}
+
+// VerifyProof verifies a proof with census origin OFF_CHAIN_CA.
+// Returns verification result and weight.
+func (*ProofVerifierCSP) Verify(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
+	key := vID.Address()
+	censusRoot := process.CensusRoot
+	p := envelope.Proof.GetCa()
+	if p == nil || p.Bundle == nil {
+		return false, nil, fmt.Errorf("CSP proof or bundle are nil")
+	}
+	if !bytes.Equal(p.Bundle.Address, key) {
+		return false, nil, fmt.Errorf(
+			"CSP bundle address and key do not match: %x != %x", key, p.Bundle.Address)
+	}
+	if !bytes.Equal(p.Bundle.ProcessId, envelope.ProcessId) {
+		return false, nil, fmt.Errorf("CSP bundle processID does not match")
+	}
+	cspBundle, err := proto.Marshal(p.Bundle)
+	if err != nil {
+		return false, nil, fmt.Errorf("cannot marshal CSP bundle to protobuf: %w", err)
+	}
+
+	// depending on signature type, use a mechanism for extracting the ca publickey from signature
+	switch p.GetType() {
+	case models.ProofCA_ECDSA, models.ProofCA_ECDSA_PIDSALTED:
+		bundlePub, err := ethereum.PubKeyFromSignature(cspBundle, p.GetSignature())
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot fetch CSP public key from signature: %w", err)
+		}
+		if p.GetType() == models.ProofCA_ECDSA_PIDSALTED {
+			rootPub, err := ethereum.DecompressPubKey(censusRoot)
+			if err != nil {
+				return false, nil, fmt.Errorf("cannot decompress CSP public key: %w", err)
+			}
+			rootPubSalted, err := ethcrypto.UnmarshalPubkey(rootPub)
+			if err != nil {
+				return false, nil, fmt.Errorf("cannot unmarshal ECDSA CSP public key: %w", err)
+			}
+			rootPubSalted, err = saltedkey.SaltECDSAPubKey(rootPubSalted, envelope.ProcessId)
+			if err != nil {
+				return false, nil, fmt.Errorf("cannot salt ECDSA public key: %w", err)
+			}
+			censusRoot = ethcrypto.FromECDSAPub(rootPubSalted)
+			// if salted, pubKey should be decompressed
+			if bundlePub, err = ethereum.DecompressPubKey(bundlePub); err != nil {
+				return false, nil, fmt.Errorf("unable to decompress proof pub key: %w", err)
+			}
+		}
+		if !bytes.Equal(bundlePub, censusRoot) {
+			return false, nil, fmt.Errorf("CSP bundle signature does not match")
+		}
+	case models.ProofCA_ECDSA_BLIND, models.ProofCA_ECDSA_BLIND_PIDSALTED:
+		// Blind CSP check
+		rootPubdesc, err := ethereum.DecompressPubKey(censusRoot)
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot decompress CSP public key: %w", err)
+		}
+		rootPub, err := blind.NewPublicKeyFromECDSA(rootPubdesc)
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot compute blind CSP public key: %w", err)
+		}
+		signature, err := blind.NewSignatureFromBytesUncompressed(p.GetSignature())
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot compute blind CSP signature: %w", err)
+		}
+		// If pid salted, apply the salt (processId) to the censusRoot public key
+		if p.GetType() == models.ProofCA_ECDSA_BLIND_PIDSALTED {
+			rootPub, err = saltedkey.SaltBlindPubKey(rootPub, envelope.ProcessId)
+			if err != nil {
+				return false, nil, fmt.Errorf("cannot salt blind pubkey: %w", err)
+			}
+		}
+		if !blind.Verify(new(big.Int).SetBytes(ethereum.HashRaw(cspBundle)), signature, rootPub) {
+			cspbundleDec := &models.CAbundle{}
+			if err := proto.Unmarshal(cspBundle, cspbundleDec); err != nil {
+				log.Warnf("cannot unmarshal CSP bundle: %v", err)
+			}
+			return false, nil, fmt.Errorf("blind CSP verification failed for "+
+				"pid %x with CSP key %x. CSP bundle {pid:%x, addr:%x}. CSP signature %x",
+				envelope.ProcessId, rootPub.Bytes(), cspbundleDec.ProcessId, cspbundleDec.Address, signature.Bytes())
+		}
+	default:
+		return false, nil, fmt.Errorf("CSP proof %s type not supported", p.Type)
+	}
+	return true, bigOne, nil
+}

--- a/vochain/transaction/proofs/ethereumproof/ethereumproof.go
+++ b/vochain/transaction/proofs/ethereumproof/ethereumproof.go
@@ -1,0 +1,101 @@
+package ethereumproof
+
+import (
+	"fmt"
+	"math/big"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
+	"github.com/vocdoni/storage-proofs-eth-go/token/mapbased"
+	"github.com/vocdoni/storage-proofs-eth-go/token/minime"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/vochain/state"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+var bigZero = big.NewInt(0)
+
+// ProofVerifierEthereumStorage defines the interface for Ethereum storage based proof verification systems.
+type ProofVerifierEthereumStorage struct{}
+
+// Verify verifies a proof with census origin ERC20 or MINI_ME.
+func (*ProofVerifierEthereumStorage) Verify(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
+	switch process.CensusOrigin {
+	case models.CensusOrigin_ERC20:
+		return VerifyProofERC20(process, envelope, vID)
+
+	case models.CensusOrigin_MINI_ME:
+		return VerifyProofMiniMe(process, envelope, vID)
+	default:
+		return false, nil, fmt.Errorf("census origin not ethereum storage: %s", process.CensusOrigin)
+	}
+}
+
+// VerifyProofERC20 verifies a proof with census origin ERC20 (mapbased).
+// Returns verification result and weight.
+func VerifyProofERC20(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
+	if process.EthIndexSlot == nil {
+		return false, nil, fmt.Errorf("index slot not found for process %x", process.ProcessId)
+	}
+	p := envelope.Proof.GetEthereumStorage()
+	if p == nil {
+		return false, nil, fmt.Errorf("ethereum proof is empty")
+	}
+
+	balance := new(big.Int).SetBytes(p.Value)
+	if balance.Cmp(bigZero) == 0 {
+		return false, nil, fmt.Errorf("balance at proof is 0")
+	}
+	log.Debugf("validating erc20 storage proof for key %x and balance %v", p.Key, balance)
+	err := mapbased.VerifyProof(ethereum.AddrFromBytes(vID.Address()), ethcommon.BytesToHash(process.CensusRoot),
+		ethstorageproof.StorageResult{
+			Key:   p.Key,
+			Proof: p.Siblings,
+			Value: p.Value,
+		},
+		int(*process.EthIndexSlot),
+		balance,
+		nil)
+	return err == nil, balance, err
+}
+
+// VerifyProofMiniMe verifies a proof with census origin MiniMe.
+// Returns verification result and weight.
+func VerifyProofMiniMe(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
+	if process.EthIndexSlot == nil {
+		return false, nil, fmt.Errorf("index slot not found for process %x", process.ProcessId)
+	}
+	if process.SourceBlockHeight == nil {
+		return false, nil, fmt.Errorf("source block height not found for process %x",
+			process.ProcessId)
+	}
+	p := envelope.Proof.GetMinimeStorage()
+	if p == nil {
+		return false, nil, fmt.Errorf("minime proof is empty")
+	}
+
+	_, proof0Balance, _ := minime.ParseMinimeValue(p.ProofPrevBlock.Value, 0)
+	if proof0Balance.Cmp(bigZero) == 0 {
+		return false, nil, fmt.Errorf("balance at proofPrevBlock is 0")
+	}
+	log.Debugf("validating minime storage proof for key %x and balance %v",
+		p.ProofPrevBlock.Key, proof0Balance)
+	err := minime.VerifyProof(ethereum.AddrFromBytes(vID.Address()), ethcommon.BytesToHash(process.CensusRoot),
+		[]ethstorageproof.StorageResult{
+			{
+				Key:   p.ProofPrevBlock.Key,
+				Proof: p.ProofPrevBlock.Siblings,
+				Value: p.ProofPrevBlock.Value,
+			},
+			{
+				Key:   p.ProofNextBlock.Key,
+				Proof: p.ProofNextBlock.Siblings,
+				Value: p.ProofNextBlock.Value,
+			},
+		},
+		int(*process.EthIndexSlot),
+		proof0Balance,
+		new(big.Int).SetUint64(*process.SourceBlockHeight))
+	return err == nil, proof0Balance, err
+}

--- a/vochain/transaction/proofs/zkproof/zkproof.go
+++ b/vochain/transaction/proofs/zkproof/zkproof.go
@@ -1,0 +1,83 @@
+package zkproof
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"math/big"
+
+	"go.vocdoni.io/dvote/crypto/zk"
+	"go.vocdoni.io/dvote/crypto/zk/circuit"
+	"go.vocdoni.io/dvote/crypto/zk/prover"
+	"go.vocdoni.io/dvote/vochain/state"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+// ProofVerifierZk defines the interface for Zk proof verification systems.
+type ProofVerifierZk struct{}
+
+// Verify verifies a proof with census origin ZK. It returns the voting weight included in the proof.
+// Note that SIK root is not verified here, the caller should verify it separately.
+func (*ProofVerifierZk) Verify(process *models.Process, envelope *models.VoteEnvelope, _ state.VoterID) (bool, *big.Int, error) {
+	if !circuit.IsLoaded() {
+		return false, nil, fmt.Errorf("anonymous voting not supported, missing zk circuits data")
+	}
+	// get snark proof from vote envelope
+	proof, err := ProofFromEnvelope(envelope)
+	if err != nil {
+		return false, nil, err
+	}
+	// verify the process id
+	proofProcessID, err := proof.ElectionID()
+	if err != nil {
+		return false, nil, fmt.Errorf("failed on parsing process id from public inputs provided: %w", err)
+	}
+	hashedPid := sha256.Sum256(process.ProcessId)
+	if !bytes.Equal(hashedPid[:], proofProcessID) {
+		return false, nil, fmt.Errorf("process id mismatch %x != %x", process.ProcessId, proofProcessID)
+	}
+	// verify the census root
+	proofCensusRoot, err := proof.CensusRoot()
+	if err != nil {
+		return false, nil, fmt.Errorf("failed on parsing census root from public inputs provided: %w", err)
+	}
+	if !bytes.Equal(process.CensusRoot, proofCensusRoot) {
+		return false, nil, fmt.Errorf("census root mismatch")
+	}
+
+	// verify the votePackage hash TODO
+	//hashedVotePackage := sha256.Sum256(envelope.VotePackage)
+	//proofVoteHash, err := proof.VoteHash()
+	//if err != nil {
+	//	return false, nil, fmt.Errorf("failed on parsing vote hash from public inputs provided: %w", err)
+	//}
+	//if !bytes.Equal(hashedVotePackage[:], proofVoteHash) {
+	//	return false, nil, fmt.Errorf("vote hash mismatch")
+	//}
+
+	// get vote weight from proof publicSignals
+	weight, err := proof.VoteWeight()
+	if err != nil {
+		return false, nil, fmt.Errorf("failed on parsing vote weight from public inputs provided: %w", err)
+	}
+
+	// verify the proof with the circuit verification key
+	if err := proof.Verify(circuit.Global().VerificationKey); err != nil {
+		return false, nil, fmt.Errorf("zkSNARK proof verification failed: %w", err)
+	}
+	return true, weight, nil
+}
+
+// ProofFromEnvelope returns the parsed ZkProof from the vote envelope.
+func ProofFromEnvelope(voteEnvelope *models.VoteEnvelope) (*prover.Proof, error) {
+	proofZkSNARK := voteEnvelope.Proof.GetZkSnark()
+	if proofZkSNARK == nil {
+		return nil, fmt.Errorf("zkSNARK proof is empty")
+	}
+	// parse the ZkProof protobuf to prover.Proof
+	proof, err := zk.ProtobufZKProofToProverProof(proofZkSNARK)
+	if err != nil {
+		return nil, fmt.Errorf("failed on zk.ProtobufZKProofToCircomProof: %w", err)
+	}
+	return proof, nil
+}

--- a/vochain/transaction_zk_test.go
+++ b/vochain/transaction_zk_test.go
@@ -58,6 +58,7 @@ func TestVoteCheckZkSNARK(t *testing.T) {
 		VoteOptions:   &models.ProcessVoteOptions{MaxCount: 1},
 		Status:        models.ProcessStatus_READY,
 		CensusRoot:    censusRoot,
+		CensusOrigin:  models.CensusOrigin_OFF_CHAIN_TREE_WEIGHTED,
 		Duration:      uint32((time.Second * 60).Seconds()),
 		MaxCensusSize: 100,
 	}
@@ -189,7 +190,7 @@ func TestMaxCensusSizeRegisterSIKTx(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	for i := 0; i < 10; i++ {
-		app.State.IncreaseRegisterSIKCounter(pid)
+		c.Assert(app.State.IncreaseRegisterSIKCounter(pid), qt.IsNil)
 	}
 	_, _, _, _, err = app.TransactionHandler.RegisterSIKTxCheck(tx)
 	c.Assert(err, qt.IsNotNil)


### PR DESCRIPTION
Add a new interface that all proving systems must implement. Split the proving systems in different packages.
On zkProof validation, check for the missing inputs.