### PR TITLE
all: ensure safety of slices on db.Iterate callbacks

### DIFF
--- a/api/censusdb/censusdb.go
+++ b/api/censusdb/censusdb.go
@@ -325,8 +325,7 @@ func (c *CensusDB) List() ([]*CensusList, error) {
 	defer c.Unlock()
 	var list []*CensusList
 	if err := c.db.Iterate([]byte(censusDBreferencePrefix), func(key, data []byte) bool {
-		censusID := make([]byte, len(key))
-		copy(censusID, key)
+		censusID := bytes.Clone(key)
 		dec := gob.NewDecoder(bytes.NewReader(data))
 		ref := CensusRef{}
 		if err := dec.Decode(&ref); err != nil {
@@ -376,8 +375,7 @@ func (c *CensusDB) ExportCensusDB(buffer io.Writer) error {
 	defer c.Unlock()
 	// Iterate through all census entries in the DB
 	err := c.db.Iterate([]byte(censusDBreferencePrefix), func(key, data []byte) bool {
-		censusID := make([]byte, len(key))
-		copy(censusID, key)
+		censusID := bytes.Clone(key)
 		dec := gob.NewDecoder(bytes.NewReader(data))
 		ref := CensusRef{}
 		if err := dec.Decode(&ref); err != nil {

--- a/censustree/censustree.go
+++ b/censustree/censustree.go
@@ -58,7 +58,7 @@ func DeleteCensusTreeFromDatabase(kv db.Database, name string) (int, error) {
 	database := prefixeddb.NewPrefixedDatabase(kv, []byte(name))
 	wTx := database.WriteTx()
 	i := 0
-	if err := database.Iterate(nil, func(k, v []byte) bool {
+	if err := database.Iterate(nil, func(k, _ []byte) bool {
 		if err := wTx.Delete(k); err != nil {
 			log.Warnf("could not remove key %x from database", k)
 		} else {

--- a/db/internal/dbtest/dbtest.go
+++ b/db/internal/dbtest/dbtest.go
@@ -62,7 +62,7 @@ func TestIterate(t *testing.T, d db.Database) {
 	qt.Assert(t, err, qt.IsNil)
 
 	noPrefixKeysFound := 0
-	err = d.Iterate(nil, func(k, v []byte) bool {
+	err = d.Iterate(nil, func(_, _ []byte) bool {
 		noPrefixKeysFound++
 		return true
 	})
@@ -70,7 +70,7 @@ func TestIterate(t *testing.T, d db.Database) {
 	qt.Assert(t, noPrefixKeysFound, qt.Equals, prefix0NumKeys+prefix1NumKeys)
 
 	prefix0KeysFound := 0
-	err = d.Iterate(prefix0, func(k, v []byte) bool {
+	err = d.Iterate(prefix0, func(_, _ []byte) bool {
 		prefix0KeysFound++
 		return true
 	})
@@ -78,7 +78,7 @@ func TestIterate(t *testing.T, d db.Database) {
 	qt.Assert(t, prefix0KeysFound, qt.Equals, prefix0NumKeys)
 
 	prefix1KeysFound := 0
-	err = d.Iterate(prefix1, func(k, v []byte) bool {
+	err = d.Iterate(prefix1, func(_, _ []byte) bool {
 		prefix1KeysFound++
 		return true
 	})

--- a/tree/arbo/tree_test.go
+++ b/tree/arbo/tree_test.go
@@ -1058,7 +1058,7 @@ func TestDiskSizeBench(t *testing.T) {
 
 	countDBitems := func() int {
 		count := 0
-		if err := tree.db.Iterate(nil, func(k, v []byte) bool {
+		if err := tree.db.Iterate(nil, func(_, _ []byte) bool {
 			//fmt.Printf("db item: %x\n", k)
 			count++
 			return true

--- a/vochain/state/processblockregistry.go
+++ b/vochain/state/processblockregistry.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"encoding/binary"
 )
 
@@ -52,7 +53,7 @@ func (pbr *ProcessBlockRegistry) MinStartBlock(fromBlock uint32) (uint32, error)
 func (pbr *ProcessBlockRegistry) MaxEndBlock(fromBlock uint32) (uint32, error) {
 	maxEndBlock := fromBlock
 	if err := pbr.db.Iterate(pbrDBPrefix, func(pid, _ []byte) bool {
-		p, err := pbr.state.Process(pid, false)
+		p, err := pbr.state.Process(bytes.Clone(pid), false)
 		if err != nil {
 			return false
 		}

--- a/vochain/state/sik.go
+++ b/vochain/state/sik.go
@@ -148,7 +148,7 @@ func (v *State) ValidSIKRoots() [][]byte {
 func (v *State) FetchValidSIKRoots() error {
 	var validRoots [][]byte
 	if err := v.NoState(true).Iterate(sikDBPrefix, func(_, root []byte) bool {
-		validRoots = append(validRoots, root)
+		validRoots = append(validRoots, bytes.Clone(root))
 		return true
 	}); err != nil {
 		return fmt.Errorf("%w: %w", ErrSIKIterate, err)
@@ -224,7 +224,7 @@ func (v *State) UpdateSIKRoots() error {
 		// block to delete them.
 		var toPurge [][]byte
 		var nearestLowerBlock uint32
-		if err := sikNoStateDB.Iterate(sikDBPrefix, func(key, value []byte) bool {
+		if err := sikNoStateDB.Iterate(sikDBPrefix, func(key, _ []byte) bool {
 			candidateKey := bytes.Clone(key)
 			blockNumber := binary.LittleEndian.Uint32(candidateKey)
 			if blockNumber < minBlock {

--- a/vochain/state/snapshot.go
+++ b/vochain/state/snapshot.go
@@ -447,7 +447,7 @@ type DBPair struct {
 func ExportNoStateDB(w io.Writer, reader *NoState) (uint32, error) {
 	pairs := []DBPair{}
 	err := reader.Iterate(nil, func(key []byte, value []byte) bool {
-		pairs = append(pairs, DBPair{Key: key, Value: value})
+		pairs = append(pairs, DBPair{Key: bytes.Clone(key), Value: bytes.Clone(value)})
 		return true
 	})
 	if err != nil {


### PR DESCRIPTION
i included here some cosmetic changes (_ for unused vars, and using bytes.Clone instead of make()+copy()).

the real bugs are only 2 AFAIU, in ExportNoStateDB and FetchValidSIKRoots, but i'm not even sure about the FetchValidSIKRoots, if it's really a bug how didn't we notice this until now?