### PR TITLE
statesync: fetch the block before the snapshot, and use RPC instead of API

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -36,16 +36,6 @@ const (
 	DefaultTimeout = 10 * time.Second
 )
 
-// DefaultAPIUrls is a map of default API URLs for each network.
-var DefaultAPIUrls = map[string]string{
-	"dev":     "https://api-dev.vocdoni.net/v2/",
-	"develop": "https://api-dev.vocdoni.net/v2/",
-	"stg":     "https://api-stg.vocdoni.net/v2/",
-	"stage":   "https://api-stg.vocdoni.net/v2/",
-	"lts":     "https://api.vocdoni.io/v2/",
-	"prod":    "https://api.vocdoni.io/v2/",
-}
-
 // HTTPclient is the Vocdoni API HTTP client.
 type HTTPclient struct {
 	c       *http.Client

--- a/apiclient/helpers.go
+++ b/apiclient/helpers.go
@@ -337,35 +337,3 @@ func UnmarshalFaucetPackage(data []byte) (*models.FaucetPackage, error) {
 		Signature: fpackage.Signature,
 	}, nil
 }
-
-// FetchChainHeightAndHashFromDefaultAPI returns the current chain height and block hash
-// from the default API url for the given network.
-func FetchChainHeightAndHashFromDefaultAPI(network string) (int64, types.HexBytes, error) {
-	apiURL, ok := DefaultAPIUrls[network]
-	if !ok {
-		return 0, nil, fmt.Errorf("no default API URL for network %s", network)
-	}
-	height, hash, err := FetchChainHeightAndHash(apiURL)
-	if err != nil {
-		return 0, nil, fmt.Errorf("couldn't fetch info: %w", err)
-	}
-	return height, hash, nil
-}
-
-// FetchChainHeightAndHash returns current chain height and block hash from an API endpoint.
-func FetchChainHeightAndHash(apiURL string) (int64, types.HexBytes, error) {
-	log.Infow("requesting chain height and hash", "url", apiURL)
-	c, err := New(apiURL)
-	if err != nil {
-		return 0, nil, fmt.Errorf("couldn't init apiclient: %w", err)
-	}
-	chain, err := c.ChainInfo()
-	if err != nil {
-		return 0, nil, fmt.Errorf("couldn't fetch chain info: %w", err)
-	}
-	block, err := c.Block(chain.Height)
-	if err != nil {
-		return 0, nil, fmt.Errorf("couldn't fetch block: %w", err)
-	}
-	return int64(chain.Height), block.Hash, nil
-}

--- a/config/config.go
+++ b/config/config.go
@@ -140,9 +140,8 @@ type VochainCfg struct {
 	StateSyncTrustHash string
 	// StateSyncChunkSize defines the size of the chunks when splitting a Snapshot for sending via StateSync
 	StateSyncChunkSize int64
-	// StateSyncFetchParamsFromAPI defines an API URL to fetch the params from.
-	// If empty it will use default API urls, special keyword "disable" means to skip this feature altogether
-	StateSyncFetchParamsFromAPI string
+	// StateSyncFetchParamsFromRPC allows statesync to fetch TrustHash and TrustHeight from the first RPCServer
+	StateSyncFetchParamsFromRPC bool
 }
 
 // IndexerCfg handles the configuration options of the indexer

--- a/dockerfiles/testsuite/docker-compose.yml
+++ b/dockerfiles/testsuite/docker-compose.yml
@@ -173,10 +173,6 @@ services:
     environment:
       - GOCOVERDIR=/app/run/gocoverage
       - LOG_PANIC_ON_INVALIDCHARS
-      - VOCDONI_LOGLEVEL=debug
-      - VOCDONI_VOCHAIN_STATESYNCENABLED=true
-      - VOCDONI_VOCHAIN_STATESYNCRPCSERVERS=miner0:26657,miner0:26657
-      - VOCDONI_VOCHAIN_STATESYNCFETCHPARAMSFROMAPI
 
 networks:
   blockchain:

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -160,7 +160,6 @@ e2etest_ballotelection() {
 }
 
 test_statesync() {
-	export VOCDONI_VOCHAIN_STATESYNCFETCHPARAMSFROMAPI=$APIHOST
 	$COMPOSE_CMD up gatewaySync -d
 	# watch logs for 2 minutes, until catching 'startup complete'. in case of timeout, or panic, or whatever, test will fail
 	timeout 120 sh -c "($COMPOSE_CMD logs gatewaySync -f | grep -m 1 'startup complete')"

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -19,6 +20,7 @@ import (
 	crypto256k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 	cometp2p "github.com/cometbft/cometbft/p2p"
 	cometprivval "github.com/cometbft/cometbft/privval"
+	cometrpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	comettypes "github.com/cometbft/cometbft/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 )
@@ -182,4 +184,16 @@ func NewTemplateGenesisFile(dir string, validators int) (*comettypes.GenesisDoc,
 	}
 	gd.AppState = appStateBytes
 	return &gd, gd.SaveAs(filepath.Join(dir, "genesis.json"))
+}
+
+// newCometRPCClient sets up a new cometbft RPC client
+func newCometRPCClient(server string) (*cometrpchttp.HTTP, error) {
+	if !strings.Contains(server, "://") {
+		server = "http://" + server
+	}
+	c, err := cometrpchttp.New(server)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }


### PR DESCRIPTION
so this is the weirdest hack ever.

turns out during statesync, cometbft needs the block exactly before the snapshot (i.e. if snapshot was done at height=100, then block 100) but a node bootstrapped via statesync will not have this block, because that block in particular is not saved to blockstore, it's just used to verify headers and then discarded. so BlockStore starts at height+1 (in my example above, at block 101)

so a node that was bootstrapped via statesync can't bootstrap another node. 
so i made this curious workaround to fetch that important block and save it to blockstore, and IT WORKS.
 but the code is scattered over weird places, mainly because i couldn't import apiclient from vochain, due to an import cycle. suggestions welcome.