### PR TITLE
    snapshot: when restoring, repopulate IPFS with metadata and censuses

### DIFF
--- a/service/offchaindata.go
+++ b/service/offchaindata.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -8,7 +9,10 @@ import (
 	"go.vocdoni.io/dvote/data/downloader"
 	"go.vocdoni.io/dvote/db/metadb"
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/snapshot"
 	"go.vocdoni.io/dvote/vochain/offchaindatahandler"
+	"go.vocdoni.io/dvote/vochain/state"
+	"go.vocdoni.io/proto/build/go/models"
 )
 
 // OffChainDataHandler creates the offchain data downloader handler service and a censusDB.
@@ -32,5 +36,47 @@ func (vs *VocdoniService) OffChainDataHandler() error {
 		vs.CensusDB,
 		vs.Config.SkipPreviousOffchainData,
 	)
+
+	snapshot.SetFnImportOffChainData(func(s *state.State) error {
+		log.Debugf("importing offchain data after snapshot restore")
+
+		// IPFS is not restored during StateSync, so:
+		// * fetch metadata from all accounts
+		// * fetch metadata for all elections
+		// * fetch censuses from all open elections
+		// all of these actions triggers pinning and repopulates IPFS
+
+		// accounts
+		accts, err := s.ListAccounts(true)
+		if err != nil {
+			return fmt.Errorf("couldn't list accounts: %w", err)
+		}
+		for addr, acct := range accts {
+			vs.OffChainData.OnSetAccount(addr.Bytes(), acct)
+		}
+
+		// elections
+		pids, err := s.ListProcessIDs(true)
+		if err != nil {
+			return fmt.Errorf("couldn't list process IDs: %w", err)
+		}
+		for _, pid := range pids {
+			p, err := s.Process(pid, true)
+			if err != nil {
+				log.Errorf("couldn't fetch process %x", pid)
+			}
+			if !(p.GetStatus() == models.ProcessStatus_READY ||
+				p.GetStatus() == models.ProcessStatus_PAUSED) {
+				// we want to download only censuses from open elections
+				// and skip downloading censuses from past elections, so if not READY or PAUSED
+				// set a nil CensusURI before passing to OffChainData.OnProcess()
+				p.CensusURI = nil
+			}
+			vs.OffChainData.OnProcess(p, 0)
+		}
+
+		return nil
+	})
+
 	return nil
 }

--- a/snapshot/offchaindata.go
+++ b/snapshot/offchaindata.go
@@ -1,0 +1,27 @@
+package snapshot
+
+import (
+	"sync"
+
+	"go.vocdoni.io/dvote/vochain/state"
+)
+
+// fnImportOffChainData holds the func that imports the offchain data
+var fnImportOffChainData struct {
+	sync.Mutex
+	fn func(*state.State) error
+}
+
+// SetFnImportOffChainData sets the func that imports the offchain data
+func SetFnImportOffChainData(fn func(*state.State) error) {
+	fnImportOffChainData.Lock()
+	defer fnImportOffChainData.Unlock()
+	fnImportOffChainData.fn = fn
+}
+
+// FnImportOffChainData returns the func that imports the offchain data
+func FnImportOffChainData() (fn func(*state.State) error) {
+	fnImportOffChainData.Lock()
+	defer fnImportOffChainData.Unlock()
+	return fnImportOffChainData.fn
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -301,6 +301,22 @@ func (s *Snapshot) Restore(dbType, dataDir string) (string, error) {
 	if err := newState.Close(); err != nil {
 		return tmpDir, fmt.Errorf("error closing newState: %w", err)
 	}
+
+	if importOffChainData := FnImportOffChainData(); importOffChainData != nil {
+		newState, err := state.New(dbType, tmpDir)
+		if err != nil {
+			return tmpDir, fmt.Errorf("error reopening newState: %w", err)
+		}
+
+		if err := importOffChainData(newState); err != nil {
+			return tmpDir, fmt.Errorf("error importing offchain data: %w", err)
+		}
+
+		if err := newState.Close(); err != nil {
+			return tmpDir, fmt.Errorf("error reclosing newState: %w", err)
+		}
+	}
+
 	return tmpDir, nil
 }
 

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -553,7 +553,8 @@ func (idx *Indexer) Rollback() {
 }
 
 // OnProcess indexer stores the processID
-func (idx *Indexer) OnProcess(pid, _ []byte, _, _ string, _ int32) {
+func (idx *Indexer) OnProcess(p *models.Process, _ int32) {
+	pid := p.GetProcessId()
 	if err := idx.newEmptyProcess(pid); err != nil {
 		log.Errorw(err, "commit: cannot create new empty process")
 	}

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -97,14 +97,9 @@ func (k *KeyKeeper) Rollback() {
 }
 
 // OnProcess creates the keys and add them to the pool queue, if the process requires it
-func (k *KeyKeeper) OnProcess(pid, _ []byte, _, _ string, _ int32) {
+func (k *KeyKeeper) OnProcess(p *models.Process, _ int32) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	p, err := k.vochain.State.Process(pid, false)
-	if err != nil {
-		log.Errorf("cannot get process from state: (%s)", err)
-		return
-	}
 	if !p.EnvelopeType.EncryptedVotes {
 		return
 	}
@@ -114,7 +109,7 @@ func (k *KeyKeeper) OnProcess(pid, _ []byte, _, _ string, _ int32) {
 	}
 
 	// Add the process to the pool queue
-	k.pidsToAddKeys = append(k.pidsToAddKeys, pid)
+	k.pidsToAddKeys = append(k.pidsToAddKeys, p.GetProcessId())
 }
 
 // OnProcessStatusChange will publish the private

--- a/vochain/offchaindatahandler/offchaindatahandler.go
+++ b/vochain/offchaindatahandler/offchaindatahandler.go
@@ -2,6 +2,7 @@ package offchaindatahandler
 
 import (
 	"encoding/hex"
+	"fmt"
 	"sync"
 
 	"go.vocdoni.io/dvote/api/censusdb"
@@ -95,15 +96,10 @@ func (d *OffChainDataHandler) Commit(_ uint32) error {
 
 // OnProcess is triggered when a new election is created. It checks if the election contains offchain data
 // that needs to be imported and enqueues it for being handled by Commit.
-func (d *OffChainDataHandler) OnProcess(pid, _ []byte, censusRoot, censusURI string, _ int32) {
+func (d *OffChainDataHandler) OnProcess(p *models.Process, _ int32) {
 	d.queueLock.Lock()
 	defer d.queueLock.Unlock()
 	if d.importOnlyNew && !d.isSynced {
-		return
-	}
-	p, err := d.vochain.State.Process(pid, false)
-	if err != nil || p == nil {
-		log.Errorw(err, "onProcess: could get process from state")
 		return
 	}
 	// enqueue for import election metadata information
@@ -114,10 +110,10 @@ func (d *OffChainDataHandler) OnProcess(pid, _ []byte, censusRoot, censusURI str
 		})
 	}
 	// enqueue for download external census if needs to be imported
-	if state.CensusOrigins[p.CensusOrigin].NeedsDownload && len(censusURI) > 0 {
+	if state.CensusOrigins[p.CensusOrigin].NeedsDownload && len(p.GetCensusURI()) > 0 {
 		d.queue = append(d.queue, importItem{
-			censusRoot: util.TrimHex(censusRoot),
-			uri:        censusURI,
+			censusRoot: util.TrimHex(fmt.Sprintf("%x", p.CensusRoot)),
+			uri:        p.GetCensusURI(),
 			itemType:   itemTypeExternalCensus,
 		})
 	}

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -182,6 +182,15 @@ func newTendermint(app *BaseApplication,
 					log.Warnf("cannot fetch status from remote RPC server: %v", err)
 					return 0, ""
 				}
+				// try to get the hash exactly at the snapshot height, to avoid a long verification chain
+				height := status.SyncInfo.LatestBlockHeight - (status.SyncInfo.LatestBlockHeight % int64(localConfig.SnapshotInterval))
+				b, err := cli.Block(context.TODO(), &height)
+				if err == nil {
+					log.Infow("fetched statesync params from remote RPC",
+						"height", height, "hash", b.BlockID.Hash.String())
+					return height, b.BlockID.Hash.String()
+				}
+				// else at least fallback to the latest height and hash
 				log.Infow("fetched statesync params from remote RPC",
 					"height", status.SyncInfo.LatestBlockHeight, "hash", status.SyncInfo.LatestBlockHash.String())
 				return status.SyncInfo.LatestBlockHeight, status.SyncInfo.LatestBlockHash.String()

--- a/vochain/state/eventlistener.go
+++ b/vochain/state/eventlistener.go
@@ -19,7 +19,7 @@ import (
 type EventListener interface {
 	OnVote(vote *Vote, txIndex int32)
 	OnNewTx(tx *vochaintx.Tx, blockHeight uint32, txIndex int32)
-	OnProcess(pid, eid []byte, censusRoot, censusURI string, txIndex int32)
+	OnProcess(process *models.Process, txIndex int32)
 	OnProcessStatusChange(pid []byte, status models.ProcessStatus, txIndex int32)
 	OnCancel(pid []byte, txIndex int32)
 	OnProcessKeys(pid []byte, encryptionPub string, txIndex int32)

--- a/vochain/state/process.go
+++ b/vochain/state/process.go
@@ -33,10 +33,6 @@ func (v *State) AddProcess(p *models.Process) error {
 	if err != nil {
 		return err
 	}
-	censusURI := ""
-	if p.CensusURI != nil {
-		censusURI = *p.CensusURI
-	}
 	log.Infow("new election",
 		"processId", fmt.Sprintf("%x", p.ProcessId),
 		"entityId", fmt.Sprintf("%x", p.EntityId),
@@ -52,9 +48,9 @@ func (v *State) AddProcess(p *models.Process) error {
 		"maxCensusSize", p.MaxCensusSize,
 		"status", p.Status,
 		"height", v.CurrentHeight(),
-		"censusURI", censusURI)
+		"censusURI", p.GetCensusURI())
 	for _, l := range v.eventListeners {
-		l.OnProcess(p.ProcessId, p.EntityId, fmt.Sprintf("%x", p.CensusRoot), censusURI, v.txCounter.Load())
+		l.OnProcess(p, v.txCounter.Load())
 	}
 	return nil
 }

--- a/vochain/state/state_test.go
+++ b/vochain/state/state_test.go
@@ -184,7 +184,7 @@ type Listener struct {
 func (*Listener) OnVote(_ *Vote, _ int32)                                         {}
 func (*Listener) OnNewTx(_ *vochaintx.Tx, _ uint32, _ int32)                      {}
 func (*Listener) OnBeginBlock(BeginBlock)                                         {}
-func (*Listener) OnProcess(_, _ []byte, _, _ string, _ int32)                     {}
+func (*Listener) OnProcess(_ *models.Process, _ int32)                            {}
 func (*Listener) OnProcessStatusChange(_ []byte, _ models.ProcessStatus, _ int32) {}
 func (*Listener) OnCancel(_ []byte, _ int32)                                      {}
 func (*Listener) OnProcessKeys(_ []byte, _ string, _ int32)                       {}


### PR DESCRIPTION
    snapshot: when restoring, repopulate IPFS with metadata and censuses
    
     * fetch metadata from all accounts
     * fetch metadata for all elections
     * fetch censuses from all open elections

also includes a needed refactor:

* state: EventListener.OnProcess now simply passes *models.Process
