### PR TITLE
release lts startblockfix

### DIFF
--- a/service/indexer.go
+++ b/service/indexer.go
@@ -28,6 +28,7 @@ func (vs *VocdoniService) VochainIndexer() error {
 	}
 	// launch the indexer after sync routine (executed when the blockchain is ready)
 	go vs.Indexer.AfterSyncBootstrap(false)
+	go vs.Indexer.PopulateStartAndEndDate(false)
 
 	snapshot.SetFnImportIndexer(func(r io.Reader) error {
 		log.Debugf("restoring indexer backup")

--- a/vochain/indexer/db/models.go
+++ b/vochain/indexer/db/models.go
@@ -25,8 +25,11 @@ type Block struct {
 type Process struct {
 	ID                 types.ProcessID
 	EntityID           types.EntityID
+	StartBlock         int64
+	EndBlock           int64
 	StartDate          time.Time
 	EndDate            time.Time
+	BlockCount         int64
 	VoteCount          int64
 	ChainID            string
 	HaveResults        bool

--- a/vochain/indexer/indexertypes/types.go
+++ b/vochain/indexer/indexertypes/types.go
@@ -21,6 +21,8 @@ type Process struct {
 	StartDate         time.Time                  `json:"startDate,omitempty"`
 	EndDate           time.Time                  `json:"endDate,omitempty"`
 	ManuallyEnded     bool                       `json:"manuallyEnded"`
+	StartBlock        uint64                     `json:"startBlock"` // for backwards compatibility with LTS
+	EndBlock          uint64                     `json:"endBlock"`   // for backwards compatibility with LTS
 	BlockCount        uint64                     `json:"blockCount"` // for backwards compatibility with archive
 	VoteCount         uint64                     `json:"voteCount"`
 	CensusRoot        types.HexBytes             `json:"censusRoot"`
@@ -65,6 +67,9 @@ func ProcessFromDB(dbproc *indexerdb.Process) *Process {
 	proc := &Process{
 		ID:                dbproc.ID,
 		EntityID:          nonEmptyBytes(dbproc.EntityID),
+		StartBlock:        uint64(dbproc.StartBlock),
+		EndBlock:          uint64(dbproc.EndBlock),
+		BlockCount:        uint64(dbproc.BlockCount),
 		StartDate:         dbproc.StartDate,
 		EndDate:           dbproc.EndDate,
 		ManuallyEnded:     dbproc.ManuallyEnded,

--- a/vochain/indexer/migrations/0010_processes_manually_ended.sql
+++ b/vochain/indexer/migrations/0010_processes_manually_ended.sql
@@ -4,7 +4,3 @@ ADD COLUMN manually_ended BOOLEAN NOT NULL DEFAULT FALSE;
 
 UPDATE processes
 SET manually_ended = end_block < (start_block+block_count);
-
-ALTER TABLE processes DROP COLUMN start_block;
-ALTER TABLE processes DROP COLUMN end_block;
-ALTER TABLE processes DROP COLUMN block_count;

--- a/vochain/indexer/process.go
+++ b/vochain/indexer/process.go
@@ -149,6 +149,9 @@ func (idx *Indexer) newEmptyProcess(pid []byte) error {
 	procParams := indexerdb.CreateProcessParams{
 		ID:                pid,
 		EntityID:          nonNullBytes(eid),
+		StartBlock:        int64(p.StartBlock),
+		EndBlock:          int64(p.BlockCount + p.StartBlock),
+		BlockCount:        int64(p.BlockCount),
 		StartDate:         time.Unix(int64(p.StartTime), 0),
 		EndDate:           time.Unix(int64(p.StartTime+p.Duration), 0),
 		ManuallyEnded:     false,

--- a/vochain/indexer/queries/processes.sql
+++ b/vochain/indexer/queries/processes.sql
@@ -1,6 +1,7 @@
 -- name: CreateProcess :execresult
 INSERT INTO processes (
 	id, entity_id, start_date, end_date, manually_ended,
+	start_block, end_block, block_count,
 	vote_count, have_results, final_results, census_root,
 	max_census_size, census_uri, metadata,
 	census_origin, status, namespace,
@@ -13,6 +14,7 @@ INSERT INTO processes (
 	results_votes, results_weight, results_block_height
 ) VALUES (
 	?, ?, ?, ?, ?,
+	?, ?, ?,
 	?, ?, ?, ?,
 	?, ?, ?,
 	?, ?, ?,
@@ -112,6 +114,19 @@ SET results_votes  = sqlc.arg(votes),
     results_weight = sqlc.arg(weight),
     vote_opts = sqlc.arg(vote_opts),
     envelope = sqlc.arg(envelope)
+WHERE id = sqlc.arg(id);
+
+-- name: GetProcessIDsWithBlockCount :many
+SELECT id FROM processes
+WHERE block_count > 0;
+
+-- name: UpdateProcessStartAndEndDate :execresult
+UPDATE processes
+SET start_date = sqlc.arg(start_date),
+	end_date = sqlc.arg(end_date),
+	start_block = 0,
+	end_block = 0,
+	block_count = 0
 WHERE id = sqlc.arg(id);
 
 -- name: UpdateProcessEndDate :execresult

--- a/vochain/start.go
+++ b/vochain/start.go
@@ -79,9 +79,11 @@ func newTendermint(app *BaseApplication,
 
 	if len(localConfig.Peers) > 0 {
 		tconfig.P2P.PersistentPeers = strings.Trim(strings.Join(localConfig.Peers, ","), "[]\"")
+		tconfig.P2P.MaxNumInboundPeers = 0
+		tconfig.P2P.MaxNumOutboundPeers = 0
 	}
 	if len(tconfig.P2P.PersistentPeers) > 0 {
-		log.Infof("persistent peers: %s", tconfig.P2P.PersistentPeers)
+		log.Warnf("this node will only connect to these peers: %s", tconfig.P2P.PersistentPeers)
 	}
 
 	// consensus config


### PR DESCRIPTION
- **indexer: migrate legacy start_block, end_block, block_count fields**

this branch is to be deployed right after upgrade, on nodes that were running release-lts-ss
it's not intended to be merged into `main`, this commit is ephemereal

afterwards, release-lts-3 should be deployed and merged into main
