### PR TITLE
indexer: revert migration 10 changes and add dummy migration 11

### DIFF
--- a/vochain/indexer/migrations/0010_processes_manually_ended.sql
+++ b/vochain/indexer/migrations/0010_processes_manually_ended.sql
@@ -4,3 +4,7 @@ ADD COLUMN manually_ended BOOLEAN NOT NULL DEFAULT FALSE;
 
 UPDATE processes
 SET manually_ended = end_block < (start_block+block_count);
+
+ALTER TABLE processes DROP COLUMN start_block;
+ALTER TABLE processes DROP COLUMN end_block;
+ALTER TABLE processes DROP COLUMN block_count;

--- a/vochain/indexer/migrations/0011_drop_deprecated_columns.sql
+++ b/vochain/indexer/migrations/0011_drop_deprecated_columns.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+-- intentionally does nothing, columns were already dropped in migration 10
+
+-- This is a no-op command in SQLite, used just to have a valid SQL statement.
+SELECT 1;


### PR DESCRIPTION
Revert "indexer: don't drop start_block, end_block, block_count in migration 10"

This reverts commit c97e244c98e66823f35fce36572d6e12e82a4523.
