### PR TITLE
indexer: backups are now a deterministic set of SQL statements

### DIFF
--- a/data/compressor/compression.go
+++ b/data/compressor/compression.go
@@ -1,11 +1,23 @@
 package compressor
 
 import (
+	"io"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
 	"go.vocdoni.io/dvote/log"
 )
+
+// NewWriter creates a new writer that uses zstd
+func NewWriter(w io.Writer) (io.WriteCloser, error) {
+	return zstd.NewWriter(w)
+}
+
+// NewReader creates a new reader that uses zstd
+func NewReader(r io.Reader) (io.ReadCloser, error) {
+	zr, err := zstd.NewReader(r)
+	return zr.IOReadCloser(), err
+}
 
 // Compressor is a data compressor that uses zstd.
 type Compressor struct {

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.11.0
 	github.com/libp2p/go-reuseport v0.4.0
 	github.com/manifoldco/promptui v0.9.0
-	github.com/mattn/go-sqlite3 v1.14.23
 	github.com/multiformats/go-multiaddr v0.12.4
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -970,8 +970,6 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-sqlite3 v1.14.23 h1:gbShiuAP1W5j9UOksQ06aiiqPMxYecovVGwmTxWtuw0=
-github.com/mattn/go-sqlite3 v1.14.23/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -2,13 +2,11 @@ package indexer
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
 	stdlog "log"
 	"math/big"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -89,8 +87,8 @@ func TestBackup(t *testing.T) {
 	wantTotalVotes(10)
 
 	// Back up the database.
-	backupPath := filepath.Join(t.TempDir(), "backup")
-	err = idx.SaveBackup(context.TODO(), backupPath)
+	var bkp bytes.Buffer
+	err = idx.ExportBackup(&bkp)
 	qt.Assert(t, err, qt.IsNil)
 
 	// Add another 5 votes which aren't in the backup.
@@ -111,7 +109,7 @@ func TestBackup(t *testing.T) {
 	idx.Close()
 	idx, err = New(app, Options{DataDir: t.TempDir(), ExpectBackupRestore: true})
 	qt.Assert(t, err, qt.IsNil)
-	err = idx.RestoreBackup(backupPath)
+	err = idx.ImportBackup(&bkp)
 	qt.Assert(t, err, qt.IsNil)
 	wantTotalVotes(10)
 


### PR DESCRIPTION
this is much less performant that simply exporting/importing the raw binary database, but makes the backup deterministic, allowing StateSync to pull the snapshot from many nodes at the same time