### PR TITLE
vochain: add set_process_duration transaction

### DIFF
--- a/test/testcommon/api.go
+++ b/test/testcommon/api.go
@@ -65,7 +65,8 @@ func (d *APIserver) Start(t testing.TB, apis ...string) {
 	// create and add balance for the pre-created Account
 	err = d.VochainAPP.State.CreateAccount(d.Account.Address(), "", nil, 1000000)
 	qt.Assert(t, err, qt.IsNil)
-	d.VochainAPP.CommitState()
+	_, err = d.VochainAPP.CommitState()
+	qt.Assert(t, err, qt.IsNil)
 
 	// create vochain info (we do not start since it is not required)
 	d.VochainInfo = vochaininfo.NewVochainInfo(d.VochainAPP)

--- a/vochain/apptest.go
+++ b/vochain/apptest.go
@@ -49,6 +49,8 @@ func TestBaseApplicationWithChainID(tb testing.TB, chainID string) *BaseApplicat
 	if err != nil {
 		tb.Fatal(err)
 	}
+	app.State.ElectionPriceCalc.SetBasePrice(1)
+	app.State.ElectionPriceCalc.SetCapacity(10000)
 	// TODO: should this be a Close on the entire BaseApplication?
 	tb.Cleanup(func() {
 		if err := app.State.Close(); err != nil {

--- a/vochain/apputils.go
+++ b/vochain/apputils.go
@@ -134,7 +134,7 @@ func NewTemplateGenesisFile(dir string, validators int) (*genesis.Doc, error) {
 				Balance: 100000,
 			},
 		},
-		TxCost: genesis.TransactionCosts{},
+		TxCost: genesis.DefaultTransactionCosts(),
 	}
 	appState.MaxElectionSize = 100000
 

--- a/vochain/genesis/genesis.go
+++ b/vochain/genesis/genesis.go
@@ -179,22 +179,7 @@ var initialAppStateForTest = AppState{
 			Balance: 1000000000000,
 		},
 	},
-	TxCost: TransactionCosts{
-		SetProcessStatus:        1,
-		SetProcessCensus:        1,
-		SetProcessQuestionIndex: 1,
-		RegisterKey:             1,
-		NewProcess:              10,
-		SendTokens:              2,
-		SetAccountInfoURI:       2,
-		CreateAccount:           2,
-		AddDelegateForAccount:   2,
-		DelDelegateForAccount:   2,
-		CollectFaucet:           1,
-		SetAccountSIK:           1,
-		DelAccountSIK:           1,
-		SetAccountValidator:     100,
-	},
+	TxCost: DefaultTransactionCosts(),
 }
 
 var initialAppStateForDev = AppState{
@@ -244,22 +229,7 @@ var initialAppStateForDev = AppState{
 			Balance: 100000000,
 		},
 	},
-	TxCost: TransactionCosts{
-		SetProcessStatus:        2,
-		SetProcessCensus:        2,
-		SetProcessQuestionIndex: 1,
-		RegisterKey:             1,
-		NewProcess:              5,
-		SendTokens:              1,
-		SetAccountInfoURI:       1,
-		CreateAccount:           1,
-		AddDelegateForAccount:   1,
-		DelDelegateForAccount:   1,
-		CollectFaucet:           1,
-		SetAccountSIK:           1,
-		DelAccountSIK:           1,
-		SetAccountValidator:     10000,
-	},
+	TxCost: DefaultTransactionCosts(),
 }
 
 var initialAppStateForStage = AppState{
@@ -321,6 +291,7 @@ var initialAppStateForStage = AppState{
 	TxCost: TransactionCosts{
 		SetProcessStatus:        2,
 		SetProcessCensus:        1,
+		SetProcessDuration:      2,
 		SetProcessQuestionIndex: 1,
 		RegisterKey:             1,
 		NewProcess:              5,
@@ -412,6 +383,7 @@ var initialAppStateForLTS = AppState{
 	TxCost: TransactionCosts{
 		SetProcessStatus:        1,
 		SetProcessCensus:        5,
+		SetProcessDuration:      5,
 		SetProcessQuestionIndex: 1,
 		RegisterKey:             1,
 		NewProcess:              10,
@@ -459,6 +431,27 @@ func DefaultBlockParams() comettypes.BlockParams {
 func DefaultValidatorParams() comettypes.ValidatorParams {
 	return comettypes.ValidatorParams{
 		PubKeyTypes: []string{comettypes.ABCIPubKeyTypeSecp256k1},
+	}
+}
+
+// DefaultTransactionCosts returns a default set of transaction costs to use as template.
+func DefaultTransactionCosts() TransactionCosts {
+	return TransactionCosts{
+		SetProcessStatus:        2,
+		SetProcessCensus:        2,
+		SetProcessDuration:      2,
+		SetProcessQuestionIndex: 1,
+		RegisterKey:             1,
+		NewProcess:              5,
+		SendTokens:              1,
+		SetAccountInfoURI:       1,
+		CreateAccount:           1,
+		AddDelegateForAccount:   1,
+		DelDelegateForAccount:   1,
+		CollectFaucet:           1,
+		SetAccountSIK:           1,
+		DelAccountSIK:           1,
+		SetAccountValidator:     10000,
 	}
 }
 

--- a/vochain/genesis/txcost.go
+++ b/vochain/genesis/txcost.go
@@ -10,6 +10,7 @@ import (
 type TransactionCosts struct {
 	SetProcessStatus        uint32 `json:"Tx_SetProcessStatus"`
 	SetProcessCensus        uint32 `json:"Tx_SetProcessCensus"`
+	SetProcessDuration      uint32 `json:"Tx_SetProcessDuration"`
 	SetProcessQuestionIndex uint32 `json:"Tx_SetProcessQuestionIndex"`
 	RegisterKey             uint32 `json:"Tx_RegisterKey"`
 	NewProcess              uint32 `json:"Tx_NewProcess"`
@@ -43,6 +44,7 @@ func (t *TransactionCosts) AsMap() map[models.TxType]uint64 {
 var TxCostNameToTxTypeMap = map[string]models.TxType{
 	"SetProcessStatus":        models.TxType_SET_PROCESS_STATUS,
 	"SetProcessCensus":        models.TxType_SET_PROCESS_CENSUS,
+	"SetProcessDuration":      models.TxType_SET_PROCESS_DURATION,
 	"SetProcessQuestionIndex": models.TxType_SET_PROCESS_QUESTION_INDEX,
 	"SendTokens":              models.TxType_SEND_TOKENS,
 	"SetAccountInfoURI":       models.TxType_SET_ACCOUNT_INFO_URI,
@@ -69,6 +71,7 @@ func TxCostNameToTxType(key string) models.TxType {
 var TxTypeToCostNameMap = map[models.TxType]string{
 	models.TxType_SET_PROCESS_STATUS:         "SetProcessStatus",
 	models.TxType_SET_PROCESS_CENSUS:         "SetProcessCensus",
+	models.TxType_SET_PROCESS_DURATION:       "SetProcessDuration",
 	models.TxType_SET_PROCESS_QUESTION_INDEX: "SetProcessQuestionIndex",
 	models.TxType_SEND_TOKENS:                "SendTokens",
 	models.TxType_SET_ACCOUNT_INFO_URI:       "SetAccountInfoURI",

--- a/vochain/indexer/db/processes.sql.go
+++ b/vochain/indexer/db/processes.sql.go
@@ -391,8 +391,9 @@ SET census_root         = ?1,
 	public_keys         = ?4,
 	metadata            = ?5,
 	status              = ?6,
-	max_census_size	 	= ?7
-WHERE id = ?8
+	max_census_size	 	= ?7,
+	end_date 			= ?8
+WHERE id = ?9
 `
 
 type UpdateProcessFromStateParams struct {
@@ -403,6 +404,7 @@ type UpdateProcessFromStateParams struct {
 	Metadata      string
 	Status        int64
 	MaxCensusSize int64
+	EndDate       time.Time
 	ID            types.ProcessID
 }
 
@@ -415,6 +417,7 @@ func (q *Queries) UpdateProcessFromState(ctx context.Context, arg UpdateProcessF
 		arg.Metadata,
 		arg.Status,
 		arg.MaxCensusSize,
+		arg.EndDate,
 		arg.ID,
 	)
 }

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -631,6 +631,13 @@ func (idx *Indexer) OnProcessStatusChange(pid []byte, _ models.ProcessStatus, _ 
 	idx.blockUpdateProcs[string(pid)] = true
 }
 
+// OnProcessDurationChange adds the process to blockUpdateProcs and, if ended, the resultsPool
+func (idx *Indexer) OnProcessDurationChange(pid []byte, _ uint32, _ int32) {
+	idx.blockMu.Lock()
+	defer idx.blockMu.Unlock()
+	idx.blockUpdateProcs[string(pid)] = true
+}
+
 // OnRevealKeys checks if all keys have been revealed and in such case add the
 // process to the results queue
 func (idx *Indexer) OnRevealKeys(pid []byte, _ string, _ int32) {

--- a/vochain/indexer/process.go
+++ b/vochain/indexer/process.go
@@ -209,6 +209,7 @@ func (idx *Indexer) updateProcess(ctx context.Context, queries *indexerdb.Querie
 		Metadata:      p.GetMetadata(),
 		Status:        int64(p.Status),
 		MaxCensusSize: int64(p.GetMaxCensusSize()),
+		EndDate:       time.Unix(int64(p.StartTime+p.Duration), 0),
 	}); err != nil {
 		return err
 	}

--- a/vochain/indexer/queries/processes.sql
+++ b/vochain/indexer/queries/processes.sql
@@ -52,7 +52,8 @@ SET census_root         = sqlc.arg(census_root),
 	public_keys         = sqlc.arg(public_keys),
 	metadata            = sqlc.arg(metadata),
 	status              = sqlc.arg(status),
-	max_census_size	 	= sqlc.arg(max_census_size)
+	max_census_size	 	= sqlc.arg(max_census_size),
+	end_date 			= sqlc.arg(end_date)
 WHERE id = sqlc.arg(id);
 
 -- name: GetProcessStatus :one

--- a/vochain/keykeeper/keykeeper.go
+++ b/vochain/keykeeper/keykeeper.go
@@ -276,3 +276,6 @@ func (*KeyKeeper) OnCensusUpdate(_, _ []byte, _ string, _ uint64) {}
 
 // OnCancel does nothing
 func (k *KeyKeeper) OnCancel(_ []byte, _ int32) {}
+
+// OnProcessDurationChange does nothing
+func (k *KeyKeeper) OnProcessDurationChange(_ []byte, _ uint32, _ int32) {}

--- a/vochain/offchaindatahandler/offchaindatahandler.go
+++ b/vochain/offchaindatahandler/offchaindatahandler.go
@@ -173,3 +173,4 @@ func (*OffChainDataHandler) OnProcessStatusChange(_ []byte, _ models.ProcessStat
 func (*OffChainDataHandler) OnTransferTokens(_ *vochaintx.TokenTransfer)                     {}
 func (*OffChainDataHandler) OnProcessResults(_ []byte, _ *models.ProcessResult, _ int32)     {}
 func (*OffChainDataHandler) OnSpendTokens(_ []byte, _ models.TxType, _ uint64, _ string)     {}
+func (*OffChainDataHandler) OnProcessDurationChange(_ []byte, _ uint32, _ int32)             {}

--- a/vochain/state/balances.go
+++ b/vochain/state/balances.go
@@ -17,6 +17,7 @@ import (
 var (
 	TxTypeCostToStateKey = map[models.TxType]string{
 		models.TxType_SET_PROCESS_STATUS:         "c_setProcessStatus",
+		models.TxType_SET_PROCESS_DURATION:       "c_setProcessDuration",
 		models.TxType_SET_PROCESS_CENSUS:         "c_setProcessCensus",
 		models.TxType_SET_PROCESS_QUESTION_INDEX: "c_setProcessResults",
 		models.TxType_REGISTER_VOTER_KEY:         "c_registerKey",

--- a/vochain/state/eventlistener.go
+++ b/vochain/state/eventlistener.go
@@ -21,6 +21,7 @@ type EventListener interface {
 	OnNewTx(tx *vochaintx.Tx, blockHeight uint32, txIndex int32)
 	OnProcess(process *models.Process, txIndex int32)
 	OnProcessStatusChange(pid []byte, status models.ProcessStatus, txIndex int32)
+	OnProcessDurationChange(pid []byte, newDuration uint32, txIndex int32)
 	OnCancel(pid []byte, txIndex int32)
 	OnProcessKeys(pid []byte, encryptionPub string, txIndex int32)
 	OnRevealKeys(pid []byte, encryptionPriv string, txIndex int32)

--- a/vochain/state/state_test.go
+++ b/vochain/state/state_test.go
@@ -186,6 +186,7 @@ func (*Listener) OnNewTx(_ *vochaintx.Tx, _ uint32, _ int32)                    
 func (*Listener) OnBeginBlock(BeginBlock)                                         {}
 func (*Listener) OnProcess(_ *models.Process, _ int32)                            {}
 func (*Listener) OnProcessStatusChange(_ []byte, _ models.ProcessStatus, _ int32) {}
+func (*Listener) OnProcessDurationChange(_ []byte, _ uint32, _ int32)             {}
 func (*Listener) OnCancel(_ []byte, _ int32)                                      {}
 func (*Listener) OnProcessKeys(_ []byte, _ string, _ int32)                       {}
 func (*Listener) OnRevealKeys(_ []byte, _ string, _ int32)                        {}

--- a/vochain/transaction/election_tx.go
+++ b/vochain/transaction/election_tx.go
@@ -179,6 +179,9 @@ func (t *TransactionHandler) SetProcessTxCheck(vtx *vochaintx.Tx) (ethereum.Addr
 	if err != nil {
 		return ethereum.Address{}, err
 	}
+	if addr == nil || acc == nil {
+		return ethereum.Address{}, fmt.Errorf("cannot get account from signature")
+	}
 	// get process
 	process, err := t.state.Process(tx.ProcessId, false)
 	if err != nil {
@@ -229,7 +232,7 @@ func (t *TransactionHandler) SetProcessTxCheck(vtx *vochaintx.Tx) (ethereum.Addr
 			if err := t.checkMaxCensusSize(process); err != nil {
 				return ethereum.Address{}, err
 			}
-			// get Tx cost, since it is a new process, we should use the election price calculator
+			// get Tx cost, since it is a new census size, we should use the election price calculator
 			if acc.Balance < t.txCostIncreaseCensusSize(process, tx.GetCensusSize()) {
 				return ethereum.Address{}, fmt.Errorf("%w: required %d, got %d", vstate.ErrNotEnoughBalance, cost, acc.Balance)
 			}
@@ -241,6 +244,13 @@ func (t *TransactionHandler) SetProcessTxCheck(vtx *vochaintx.Tx) (ethereum.Addr
 			tx.GetCensusSize(),
 			false,
 		)
+	case models.TxType_SET_PROCESS_DURATION:
+		// get Tx cost, since it modifies the process duration, we should use the election price calculator
+		if acc.Balance < t.txCostIncreaseDuration(process, tx.GetDuration()) {
+			return ethereum.Address{}, fmt.Errorf("%w: required %d, got %d", vstate.ErrNotEnoughBalance, cost, acc.Balance)
+		}
+		return ethereum.Address(*addr), t.state.SetProcessDuration(process.ProcessId, tx.GetDuration(), false)
+
 	default:
 		return ethereum.Address{}, fmt.Errorf("unknown setProcess tx type: %s", tx.Txtype)
 	}
@@ -349,6 +359,25 @@ func (t *TransactionHandler) txCostIncreaseCensusSize(process *models.Process, n
 	}
 	if newCost < oldCost {
 		log.Warnw("txCostIncreaseCensusSize: new cost is lower than the old cost", "oldCost", oldCost, "newCost", newCost)
+		return baseCost
+	}
+	return baseCost + (newCost - oldCost)
+}
+
+// txCostIncreaseDuration calculates the cost increase of a process based on the new  duration.
+func (t *TransactionHandler) txCostIncreaseDuration(process *models.Process, newDuration uint32) uint64 {
+	oldCost := t.txElectionCostFromProcess(process)
+	oldDuration := process.GetDuration()
+	process.Duration = newDuration
+	newCost := t.txElectionCostFromProcess(process)
+	process.Duration = oldDuration
+
+	baseCost, err := t.state.TxBaseCost(models.TxType_SET_PROCESS_DURATION, false)
+	if err != nil {
+		log.Errorw(err, "txCostIncreaseDuration: cannot get transaction base cost")
+		return 0
+	}
+	if newCost < oldCost {
 		return baseCost
 	}
 	return baseCost + (newCost - oldCost)


### PR DESCRIPTION
With this transaction we can now modify the duration of an existing project (while in READY or PAUSE state).

If interruptible=false the duration can only be extended.

The cost of the transactions is computed dynamically by:
 max(nextPrice - previousPrice, txBaseCost)