### PR TITLE
vochain/indexer: lowercase hex search terms when querying

### DIFF
--- a/vochain/indexer/process.go
+++ b/vochain/indexer/process.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.vocdoni.io/proto/build/go/models"
@@ -72,7 +73,7 @@ func (idx *Indexer) ProcessList(entityID []byte, from, max int, searchTerm strin
 		Namespace:       int64(namespace),
 		Status:          int64(statusnum),
 		SourceNetworkID: int64(srcNetworkId),
-		IDSubstr:        searchTerm,
+		IDSubstr:        strings.ToLower(searchTerm), // we search in lowercase
 		Offset:          int64(from),
 		Limit:           int64(max),
 		WithResults:     withResults,
@@ -95,10 +96,10 @@ func (idx *Indexer) CountTotalProcesses() uint64 {
 
 // EntityList returns the list of entities indexed by the indexer
 // searchTerm is optional, if declared as zero-value
-// will be ignored. Searches against the ID field.
+// will be ignored. Searches against the ID field as lowercase hex.
 func (idx *Indexer) EntityList(max, from int, searchTerm string) []indexerdb.SearchEntitiesRow {
 	rows, err := idx.readOnlyQuery.SearchEntities(context.TODO(), indexerdb.SearchEntitiesParams{
-		EntityIDSubstr: searchTerm,
+		EntityIDSubstr: strings.ToLower(searchTerm), // we search in lowercase
 		Offset:         int64(from),
 		Limit:          int64(max),
 	})

--- a/vochain/indexer/vote.go
+++ b/vochain/indexer/vote.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"go.vocdoni.io/proto/build/go/models"
@@ -72,7 +73,7 @@ func (idx *Indexer) GetEnvelopes(processId []byte, max, from int,
 	envelopes := []*indexertypes.EnvelopeMetadata{}
 	txRefs, err := idx.readOnlyQuery.SearchVotes(context.TODO(), indexerdb.SearchVotesParams{
 		ProcessID:       processId,
-		NullifierSubstr: searchTerm,
+		NullifierSubstr: strings.ToLower(searchTerm), // we search in lowercase
 		Limit:           int64(max),
 		Offset:          int64(from),
 	})


### PR DESCRIPTION
(see commit message)

Fixes #1348.