### PR TITLE
api: implement pagination and query params for /chain/transfers

### DIFF
--- a/api/accounts.go
+++ b/api/accounts.go
@@ -534,6 +534,7 @@ func (a *API) accountListByPageHandler(_ *apirest.APIdata, ctx *httprouter.HTTPC
 	params, err := parseAccountParams(
 		ctx.URLParam(ParamPage),
 		"",
+		"",
 	)
 	if err != nil {
 		return err
@@ -548,14 +549,16 @@ func (a *API) accountListByPageHandler(_ *apirest.APIdata, ctx *httprouter.HTTPC
 //	@Tags			Accounts
 //	@Accept			json
 //	@Produce		json
-//	@Param			page	query		number	false	"Page"
-//	@Param			limit	query		number	false	"Items per page"
-//	@Success		200		{object}	AccountsList
+//	@Param			page		query		number	false	"Page"
+//	@Param			limit		query		number	false	"Items per page"
+//	@Param			accountId	query		string	false	"Filter by partial accountId"
+//	@Success		200			{object}	AccountsList
 //	@Router			/accounts [get]
 func (a *API) accountListHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	params, err := parseAccountParams(
 		ctx.QueryParam(ParamPage),
 		ctx.QueryParam(ParamLimit),
+		ctx.QueryParam(ParamAccountId),
 	)
 	if err != nil {
 		return err
@@ -571,6 +574,7 @@ func (a *API) sendAccountList(ctx *httprouter.HTTPContext, params *AccountParams
 	accounts, total, err := a.indexer.AccountList(
 		params.Limit,
 		params.Page*params.Limit,
+		params.AccountID,
 	)
 	if err != nil {
 		return ErrIndexerQueryFailed.WithErr(err)
@@ -589,7 +593,7 @@ func (a *API) sendAccountList(ctx *httprouter.HTTPContext, params *AccountParams
 }
 
 // parseAccountParams returns an AccountParams filled with the passed params
-func parseAccountParams(paramPage, paramLimit string) (*AccountParams, error) {
+func parseAccountParams(paramPage, paramLimit, paramAccountID string) (*AccountParams, error) {
 	pagination, err := parsePaginationParams(paramPage, paramLimit)
 	if err != nil {
 		return nil, err
@@ -597,5 +601,6 @@ func parseAccountParams(paramPage, paramLimit string) (*AccountParams, error) {
 
 	return &AccountParams{
 		PaginationParams: pagination,
+		AccountID:        util.TrimHex(paramAccountID),
 	}, nil
 }

--- a/api/accounts.go
+++ b/api/accounts.go
@@ -571,6 +571,10 @@ func (a *API) accountListHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext
 //
 // Errors returned are always of type APIerror.
 func (a *API) sendAccountList(ctx *httprouter.HTTPContext, params *AccountParams) error {
+	if params.AccountID != "" && !a.indexer.AccountExists(params.AccountID) {
+		return ErrAccountNotFound
+	}
+
 	accounts, total, err := a.indexer.AccountList(
 		params.Limit,
 		params.Page*params.Limit,

--- a/api/api.go
+++ b/api/api.go
@@ -74,6 +74,8 @@ const (
 	ParamHeight         = "height"
 	ParamReference      = "reference"
 	ParamType           = "type"
+	ParamAccountIdFrom  = "accountIdFrom"
+	ParamAccountIdTo    = "accountIdTo"
 )
 
 var (

--- a/api/api_types.go
+++ b/api/api_types.go
@@ -40,6 +40,7 @@ type OrganizationParams struct {
 // AccountParams allows the client to filter accounts
 type AccountParams struct {
 	PaginationParams
+	AccountID string `json:"accountId,omitempty"`
 }
 
 // TransactionParams allows the client to filter transactions

--- a/api/api_types.go
+++ b/api/api_types.go
@@ -57,6 +57,14 @@ type FeesParams struct {
 	AccountID string `json:"accountId,omitempty"`
 }
 
+// TransfersParams allows the client to filter transfers
+type TransfersParams struct {
+	PaginationParams
+	AccountID     string `json:"accountId,omitempty"`
+	AccountIDFrom string `json:"accountIdFrom,omitempty"`
+	AccountIDTo   string `json:"accountIdTo,omitempty"`
+}
+
 // VoteParams allows the client to filter votes
 type VoteParams struct {
 	PaginationParams
@@ -262,6 +270,12 @@ type TransactionsList struct {
 type FeesList struct {
 	Fees       []*indexertypes.TokenFeeMeta `json:"fees"`
 	Pagination *Pagination                  `json:"pagination"`
+}
+
+// TransfersList is used to return a paginated list to the client
+type TransfersList struct {
+	Transfers  []*indexertypes.TokenTransferMeta `json:"transfers"`
+	Pagination *Pagination                       `json:"pagination"`
 }
 
 type GenericTransactionWithInfo struct {

--- a/api/chain.go
+++ b/api/chain.go
@@ -332,6 +332,10 @@ func (a *API) organizationListByFilterAndPageHandler(msg *apirest.APIdata, ctx *
 //
 // Errors returned are always of type APIerror.
 func (a *API) sendOrganizationList(ctx *httprouter.HTTPContext, params *OrganizationParams) error {
+	if params.OrganizationID != "" && !a.indexer.EntityExists(params.OrganizationID) {
+		return ErrOrgNotFound
+	}
+
 	orgs, total, err := a.indexer.EntityList(
 		params.Limit,
 		params.Page*params.Limit,
@@ -1061,6 +1065,10 @@ func (a *API) chainFeesListByTypeAndPageHandler(_ *apirest.APIdata, ctx *httprou
 //
 // Errors returned are always of type APIerror.
 func (a *API) sendFeesList(ctx *httprouter.HTTPContext, params *FeesParams) error {
+	if params.AccountID != "" && !a.indexer.AccountExists(params.AccountID) {
+		return ErrAccountNotFound
+	}
+
 	fees, total, err := a.indexer.TokenFeesList(
 		params.Limit,
 		params.Page*params.Limit,
@@ -1118,6 +1126,12 @@ func (a *API) chainTransfersListHandler(_ *apirest.APIdata, ctx *httprouter.HTTP
 //
 // Errors returned are always of type APIerror.
 func (a *API) sendTransfersList(ctx *httprouter.HTTPContext, params *TransfersParams) error {
+	for _, param := range []string{params.AccountID, params.AccountIDFrom, params.AccountIDTo} {
+		if param != "" && !a.indexer.AccountExists(param) {
+			return ErrAccountNotFound.With(param)
+		}
+	}
+
 	transfers, total, err := a.indexer.TokenTransfersList(
 		params.Limit,
 		params.Page*params.Limit,

--- a/api/elections.go
+++ b/api/elections.go
@@ -262,6 +262,14 @@ func (a *API) electionListHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContex
 //
 // Errors returned are always of type APIerror.
 func (a *API) sendElectionList(ctx *httprouter.HTTPContext, params *ElectionParams) error {
+	if params.ElectionID != "" && !a.indexer.ProcessExists(params.ElectionID) {
+		return ErrElectionNotFound
+	}
+
+	if params.OrganizationID != "" && !a.indexer.EntityExists(params.OrganizationID) {
+		return ErrOrgNotFound
+	}
+
 	status, err := parseStatus(params.Status)
 	if err != nil {
 		return err

--- a/api/vote.go
+++ b/api/vote.go
@@ -226,6 +226,10 @@ func (a *API) votesListHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) 
 //
 // Errors returned are always of type APIerror.
 func (a *API) sendVotesList(ctx *httprouter.HTTPContext, params *VoteParams) error {
+	if params.ElectionID != "" && !a.indexer.ProcessExists(params.ElectionID) {
+		return ErrElectionNotFound
+	}
+
 	votes, total, err := a.indexer.VoteList(
 		params.Limit,
 		params.Page*params.Limit,

--- a/apiclient/account.go
+++ b/apiclient/account.go
@@ -290,21 +290,19 @@ func (c *HTTPclient) AccountSetMetadata(metadata *api.AccountMetadata) (types.He
 }
 
 // ListTokenTransfers returns the list of sent and received token transfers associated with an account
-func (c *HTTPclient) ListTokenTransfers(account common.Address, page int) (indexertypes.TokenTransfersAccount, error) {
+func (c *HTTPclient) ListTokenTransfers(account common.Address, page int) (*api.TransfersList, error) {
 	resp, code, err := c.Request(HTTPGET, nil, "accounts", account.Hex(), "transfers", "page", strconv.Itoa(page))
 	if err != nil {
-		return indexertypes.TokenTransfersAccount{}, err
+		return nil, err
 	}
 	if code != apirest.HTTPstatusOK {
-		return indexertypes.TokenTransfersAccount{}, fmt.Errorf("%s: %d (%s)", errCodeNot200, code, resp)
+		return nil, fmt.Errorf("%s: %d (%s)", errCodeNot200, code, resp)
 	}
-	tokenTxs := new(struct {
-		Transfers indexertypes.TokenTransfersAccount `json:"transfers"`
-	})
-	if err := json.Unmarshal(resp, &tokenTxs); err != nil {
-		return indexertypes.TokenTransfersAccount{}, err
+	tokenTxs := &api.TransfersList{}
+	if err := json.Unmarshal(resp, tokenTxs); err != nil {
+		return nil, err
 	}
-	return tokenTxs.Transfers, nil
+	return tokenTxs, nil
 }
 
 // SetSIK function allows to update the Secret Identity Key for the current

--- a/cmd/end2endtest/account.go
+++ b/cmd/end2endtest/account.go
@@ -329,14 +329,12 @@ func checkTokenTransfersCount(api *apiclient.HTTPclient, address common.Address)
 	if err != nil {
 		return err
 	}
-	countTokenTxs := uint64(len(tokenTxs.Received) + len(tokenTxs.Sent))
-
 	count, err := api.CountTokenTransfers(address)
 	if err != nil {
 		return err
 	}
-	if count != countTokenTxs {
-		return fmt.Errorf("expected %s to match transfers count %d and %d", address, count, countTokenTxs)
+	if count != tokenTxs.Pagination.TotalItems {
+		return fmt.Errorf("expected %s to match transfers count %d and %d", address, count, tokenTxs.Pagination.TotalItems)
 	}
 
 	log.Infow("current transfers count", "account", address.String(), "count", count)

--- a/test/api_test.go
+++ b/test/api_test.go
@@ -391,9 +391,7 @@ func TestAPIAccountTokentxs(t *testing.T) {
 	resp, code = c.Request("GET", nil, "accounts", signer.Address().Hex(), "transfers", "page", "0")
 	qt.Assert(t, code, qt.Equals, 200, qt.Commentf("response: %s", resp))
 
-	tokenTxs := new(struct {
-		Transfers indexertypes.TokenTransfersAccount `json:"transfers"`
-	})
+	tokenTxs := &api.TransfersList{}
 	err := json.Unmarshal(resp, tokenTxs)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -407,18 +405,14 @@ func TestAPIAccountTokentxs(t *testing.T) {
 	err = json.Unmarshal(resp, &countTnsAcc)
 	qt.Assert(t, err, qt.IsNil)
 
-	totalTokenTxs := uint64(len(tokenTxs.Transfers.Received) + len(tokenTxs.Transfers.Sent))
-
 	// compare count of total token transfers for the account 1 using the two response
-	qt.Assert(t, totalTokenTxs, qt.Equals, countTnsAcc.Count)
+	qt.Assert(t, tokenTxs.Pagination.TotalItems, qt.Equals, countTnsAcc.Count)
 
 	// get the token transfers received and sent for account 2
 	resp, code = c.Request("GET", nil, "accounts", signer2.Address().Hex(), "transfers", "page", "0")
 	qt.Assert(t, code, qt.Equals, 200, qt.Commentf("response: %s", resp))
 
-	tokenTxs2 := new(struct {
-		Transfers indexertypes.TokenTransfersAccount `json:"transfers"`
-	})
+	tokenTxs2 := &api.TransfersList{}
 	err = json.Unmarshal(resp, tokenTxs2)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -432,9 +426,8 @@ func TestAPIAccountTokentxs(t *testing.T) {
 	err = json.Unmarshal(resp, &countTnsAcc2)
 	qt.Assert(t, err, qt.IsNil)
 
-	totalTokenTxs2 := uint64(len(tokenTxs2.Transfers.Received) + len(tokenTxs2.Transfers.Sent))
 	// compare count of total token transfers for the account 2 using the two response
-	qt.Assert(t, totalTokenTxs2, qt.Equals, countTnsAcc2.Count)
+	qt.Assert(t, tokenTxs2.Pagination.TotalItems, qt.Equals, countTnsAcc2.Count)
 
 	resp, code = c.Request("GET", nil, "accounts", "page", "0")
 	qt.Assert(t, code, qt.Equals, 200, qt.Commentf("response: %s", resp))

--- a/test/apierror_test.go
+++ b/test/apierror_test.go
@@ -64,10 +64,6 @@ func TestAPIerror(t *testing.T) {
 			want: api.ErrFileSizeTooBig,
 		},
 		{
-			args: args{"GET", nil, []string{"accounts", "totallyWrong!@#$", "transfers", "page", "0"}},
-			want: api.ErrCantParseAccountID,
-		},
-		{
 			args: args{"GET", nil, []string{
 				"votes", "verify",
 				"0123456789012345678901234567890123456789012345678901234567890123",

--- a/test/apierror_test.go
+++ b/test/apierror_test.go
@@ -56,6 +56,18 @@ func TestAPIerror(t *testing.T) {
 			want: api.ErrOrgNotFound,
 		},
 		{
+			args: args{"GET", nil, []string{"accounts", "0123456789012345678901234567890123456789", "elections", "page", "0"}},
+			want: api.ErrOrgNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts", "0123456789012345678901234567890123456789", "transfers", "page", "0"}},
+			want: api.ErrAccountNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts", "0123456789012345678901234567890123456789", "fees", "page", "0"}},
+			want: api.ErrAccountNotFound,
+		},
+		{
 			args: args{"GET", nil, []string{"chain", "blocks", "1234"}},
 			want: api.ErrBlockNotFound,
 		},
@@ -116,10 +128,142 @@ func TestAPIerror(t *testing.T) {
 			args: args{"GET", nil, []string{"elections", "page", "-1"}},
 			want: api.ErrPageNotFound,
 		},
+		{
+			args: args{"GET", nil, []string{"elections", "0123456789012345678901234567890123456789", "votes", "page", "0"}},
+			want: api.ErrElectionNotFound,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want.Error(), func(t *testing.T) {
 			resp, code := c.Request(tt.args.method, tt.args.jsonBody, tt.args.urlPath...)
+			t.Logf("httpstatus=%d body=%s", code, resp)
+			qt.Assert(t, code, qt.Equals, tt.want.HTTPstatus)
+			apierr := &apirest.APIerror{}
+			qt.Assert(t, json.Unmarshal(resp, apierr), qt.IsNil)
+			qt.Assert(t, apierr.Code, qt.Equals, tt.want.Code)
+		})
+	}
+}
+
+func TestAPIerrorWithQuery(t *testing.T) {
+	server := testcommon.APIserver{}
+	server.Start(t,
+		api.ChainHandler,
+		api.CensusHandler,
+		api.VoteHandler,
+		api.AccountHandler,
+		api.ElectionHandler,
+		api.WalletHandler,
+	)
+	// Block 1
+	server.VochainAPP.AdvanceTestBlock()
+
+	token1 := uuid.New()
+	c := testutil.NewTestHTTPclient(t, server.ListenAddr, &token1)
+
+	type args struct {
+		method   string
+		jsonBody any
+		urlPath  []string
+		query    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want apirest.APIerror
+	}{
+		{
+			args: args{"GET", nil, []string{"accounts"}, "page=1234"},
+			want: api.ErrPageNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts"}, "accountId=0123456789"},
+			want: api.ErrAccountNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"accounts"}, "accountId=0123456789&page=1234"},
+			want: api.ErrAccountNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"elections"}, "electionId=0123456789"},
+			want: api.ErrElectionNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"elections"}, "electionId=0123456789&page=1234"},
+			want: api.ErrElectionNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"elections"}, "organizationId=0123456789"},
+			want: api.ErrOrgNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"elections"}, "organizationId=0123456789&page=1234"},
+			want: api.ErrOrgNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"elections"}, "status=FOOBAR"},
+			want: api.ErrParamStatusInvalid,
+		},
+		{
+			args: args{"GET", nil, []string{"elections"}, "manuallyEnded=FOOBAR"},
+			want: api.ErrCantParseBoolean,
+		},
+		{
+			args: args{"GET", nil, []string{"chain", "transactions"}, "page=1234"},
+			want: api.ErrPageNotFound,
+		},
+		// TODO: not yet implemented
+		// {
+		// 	args: args{"GET", nil, []string{"chain", "transactions"}, "height=1234"},
+		// 	want: api.ErrBlockNotFound,
+		// },
+		{
+			args: args{"GET", nil, []string{"chain", "transactions"}, "height=FOOBAR"},
+			want: api.ErrCantParseNumber,
+		},
+		// TODO: should this endpoint check `type` is a sane value?
+		// {
+		// 	args: args{"GET", nil, []string{"chain", "transactions"}, "type=FOOBAR"},
+		// 	want: api.ErrParamTypeInvalid,
+		// },
+		{
+			args: args{"GET", nil, []string{"chain", "organizations"}, "organizationId=0123456789"},
+			want: api.ErrOrgNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"chain", "fees"}, "accountId=0123456789"},
+			want: api.ErrAccountNotFound,
+		},
+		// TODO: should this endpoint check `reference` matches something?
+		// {
+		// 	args: args{"GET", nil, []string{"chain", "fees"}, "reference=0123456789"},
+		// 	want: api.ErrTransactionNotFound,
+		// },
+		// TODO: should this endpoint check `type` is a sane value?
+		// {
+		// 	args: args{"GET", nil, []string{"chain", "fees"}, "type=FOOBAR"},
+		// 	want: api.ErrParamTypeInvalid,
+		// },
+		{
+			args: args{"GET", nil, []string{"votes"}, "electionId=0123456789"},
+			want: api.ErrElectionNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"chain", "transfers"}, "accountId=0123456789"},
+			want: api.ErrAccountNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"chain", "transfers"}, "accountIdFrom=0123456789"},
+			want: api.ErrAccountNotFound,
+		},
+		{
+			args: args{"GET", nil, []string{"chain", "transfers"}, "accountIdTo=0123456789"},
+			want: api.ErrAccountNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want.Error(), func(t *testing.T) {
+			resp, code := c.RequestWithQuery(tt.args.method, tt.args.jsonBody, tt.args.query, tt.args.urlPath...)
 			t.Logf("httpstatus=%d body=%s", code, resp)
 			qt.Assert(t, code, qt.Equals, tt.want.HTTPstatus)
 			apierr := &apirest.APIerror{}

--- a/vochain/indexer/db/db.go
+++ b/vochain/indexer/db/db.go
@@ -66,9 +66,6 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getEntityCountStmt, err = db.PrepareContext(ctx, getEntityCount); err != nil {
 		return nil, fmt.Errorf("error preparing query GetEntityCount: %w", err)
 	}
-	if q.getListAccountsStmt, err = db.PrepareContext(ctx, getListAccounts); err != nil {
-		return nil, fmt.Errorf("error preparing query GetListAccounts: %w", err)
-	}
 	if q.getProcessStmt, err = db.PrepareContext(ctx, getProcess); err != nil {
 		return nil, fmt.Errorf("error preparing query GetProcess: %w", err)
 	}
@@ -95,6 +92,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getVoteStmt, err = db.PrepareContext(ctx, getVote); err != nil {
 		return nil, fmt.Errorf("error preparing query GetVote: %w", err)
+	}
+	if q.searchAccountsStmt, err = db.PrepareContext(ctx, searchAccounts); err != nil {
+		return nil, fmt.Errorf("error preparing query SearchAccounts: %w", err)
 	}
 	if q.searchEntitiesStmt, err = db.PrepareContext(ctx, searchEntities); err != nil {
 		return nil, fmt.Errorf("error preparing query SearchEntities: %w", err)
@@ -207,11 +207,6 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getEntityCountStmt: %w", cerr)
 		}
 	}
-	if q.getListAccountsStmt != nil {
-		if cerr := q.getListAccountsStmt.Close(); cerr != nil {
-			err = fmt.Errorf("error closing getListAccountsStmt: %w", cerr)
-		}
-	}
 	if q.getProcessStmt != nil {
 		if cerr := q.getProcessStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getProcessStmt: %w", cerr)
@@ -255,6 +250,11 @@ func (q *Queries) Close() error {
 	if q.getVoteStmt != nil {
 		if cerr := q.getVoteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getVoteStmt: %w", cerr)
+		}
+	}
+	if q.searchAccountsStmt != nil {
+		if cerr := q.searchAccountsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing searchAccountsStmt: %w", cerr)
 		}
 	}
 	if q.searchEntitiesStmt != nil {
@@ -370,7 +370,6 @@ type Queries struct {
 	createVoteStmt                               *sql.Stmt
 	getBlockStmt                                 *sql.Stmt
 	getEntityCountStmt                           *sql.Stmt
-	getListAccountsStmt                          *sql.Stmt
 	getProcessStmt                               *sql.Stmt
 	getProcessCountStmt                          *sql.Stmt
 	getProcessIDsByFinalResultsStmt              *sql.Stmt
@@ -380,6 +379,7 @@ type Queries struct {
 	getTransactionByHashStmt                     *sql.Stmt
 	getTxReferenceByBlockHeightAndBlockIndexStmt *sql.Stmt
 	getVoteStmt                                  *sql.Stmt
+	searchAccountsStmt                           *sql.Stmt
 	searchEntitiesStmt                           *sql.Stmt
 	searchProcessesStmt                          *sql.Stmt
 	searchTokenFeesStmt                          *sql.Stmt
@@ -412,7 +412,6 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		createVoteStmt:                   q.createVoteStmt,
 		getBlockStmt:                     q.getBlockStmt,
 		getEntityCountStmt:               q.getEntityCountStmt,
-		getListAccountsStmt:              q.getListAccountsStmt,
 		getProcessStmt:                   q.getProcessStmt,
 		getProcessCountStmt:              q.getProcessCountStmt,
 		getProcessIDsByFinalResultsStmt:  q.getProcessIDsByFinalResultsStmt,
@@ -422,6 +421,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getTransactionByHashStmt:         q.getTransactionByHashStmt,
 		getTxReferenceByBlockHeightAndBlockIndexStmt: q.getTxReferenceByBlockHeightAndBlockIndexStmt,
 		getVoteStmt:                    q.getVoteStmt,
+		searchAccountsStmt:             q.searchAccountsStmt,
 		searchEntitiesStmt:             q.searchEntitiesStmt,
 		searchProcessesStmt:            q.searchProcessesStmt,
 		searchTokenFeesStmt:            q.searchTokenFeesStmt,

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -814,17 +814,19 @@ func (idx *Indexer) CountTotalAccounts() (uint64, error) {
 	return uint64(count), err
 }
 
-// AccountList retrieves all accounts.
-func (idx *Indexer) AccountList(limit, offset int) ([]*indexertypes.Account, uint64, error) {
+// AccountList returns a list of accounts, accountID is a partial or full hex string,
+// and is optional (declared as zero-value will be ignored).
+func (idx *Indexer) AccountList(limit, offset int, accountID string) ([]*indexertypes.Account, uint64, error) {
 	if offset < 0 {
 		return nil, 0, fmt.Errorf("invalid value: offset cannot be %d", offset)
 	}
 	if limit <= 0 {
 		return nil, 0, fmt.Errorf("invalid value: limit cannot be %d", limit)
 	}
-	results, err := idx.readOnlyQuery.GetListAccounts(context.TODO(), indexerdb.GetListAccountsParams{
-		Limit:  int64(limit),
-		Offset: int64(offset),
+	results, err := idx.readOnlyQuery.SearchAccounts(context.TODO(), indexerdb.SearchAccountsParams{
+		Limit:           int64(limit),
+		Offset:          int64(offset),
+		AccountIDSubstr: accountID,
 	})
 	if err != nil {
 		return nil, 0, err

--- a/vochain/indexer/indexer.go
+++ b/vochain/indexer/indexer.go
@@ -844,3 +844,13 @@ func (idx *Indexer) AccountList(limit, offset int, accountID string) ([]*indexer
 	}
 	return list, uint64(results[0].TotalCount), nil
 }
+
+// AccountExists returns whether the passed accountID matches at least one row in the db.
+// accountID is a partial or full hex string.
+func (idx *Indexer) AccountExists(accountID string) bool {
+	_, count, err := idx.AccountList(1, 0, accountID)
+	if err != nil {
+		log.Errorw(err, "indexer query failed")
+	}
+	return count > 0
+}

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -1564,7 +1564,7 @@ func TestAccountsList(t *testing.T) {
 
 	last := 0
 	for i := 0; i < int(totalAccs); i++ {
-		accts, _, err := idx.AccountList(10, last)
+		accts, _, err := idx.AccountList(10, last, "")
 		qt.Assert(t, err, qt.IsNil)
 
 		for j, acc := range accts {
@@ -1587,7 +1587,7 @@ func TestAccountsList(t *testing.T) {
 	app.AdvanceTestBlock()
 
 	// verify the updated balance and nonce
-	accts, _, err := idx.AccountList(5, 0)
+	accts, _, err := idx.AccountList(5, 0, "")
 	qt.Assert(t, err, qt.IsNil)
 	// the account in the position 0 must be the updated account balance due it has the major balance
 	// indexer query has order BY balance DESC

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -1650,22 +1650,29 @@ func TestTokenTransfers(t *testing.T) {
 	app.AdvanceTestBlock()
 
 	// acct 1 must have only one token transfer received
-	acc1Tokentx, err := idx.GetTokenTransfersByToAccount(keys[1].Address().Bytes(), 0, 10)
+	acc1Tokentx, _, err := idx.TokenTransfersList(10, 0, "", "", hex.EncodeToString(keys[1].Address().Bytes()))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, len(acc1Tokentx), qt.Equals, 1)
 	qt.Assert(t, acc1Tokentx[0].Amount, qt.Equals, uint64(5))
 
 	// acct 2 must two token transfers received
-	acc2Tokentx, err := idx.GetTokenTransfersByToAccount(keys[2].Address().Bytes(), 0, 10)
+	acc2Tokentx, _, err := idx.TokenTransfersList(10, 0, "", "", hex.EncodeToString(keys[2].Address().Bytes()))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, len(acc2Tokentx), qt.Equals, 2)
 	qt.Assert(t, acc2Tokentx[0].Amount, qt.Equals, uint64(95))
 	qt.Assert(t, acc2Tokentx[1].Amount, qt.Equals, uint64(18))
 
 	// acct 0 must zero token transfers received
-	acc0Tokentx, err := idx.GetTokenTransfersByToAccount(keys[0].Address().Bytes(), 0, 10)
+	acc0Tokentx, _, err := idx.TokenTransfersList(10, 0, "", "", hex.EncodeToString(keys[0].Address().Bytes()))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, len(acc0Tokentx), qt.Equals, 0)
+
+	// acct 1 must have two token transfer received or sent
+	acc1TokentxFromOrTo, _, err := idx.TokenTransfersList(10, 0, hex.EncodeToString(keys[1].Address().Bytes()), "", "")
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, len(acc1TokentxFromOrTo), qt.Equals, 2)
+	qt.Assert(t, acc1TokentxFromOrTo[0].Amount, qt.Equals, uint64(5))
+	qt.Assert(t, acc1TokentxFromOrTo[1].Amount, qt.Equals, uint64(95))
 }
 
 // friendlyResults translates votes into a matrix of strings

--- a/vochain/indexer/indexertypes/types.go
+++ b/vochain/indexer/indexertypes/types.go
@@ -209,7 +209,7 @@ type TokenTransferMeta struct {
 	Amount    uint64          `json:"amount"`
 	From      types.AccountID `json:"from"`
 	Height    uint64          `json:"height"`
-	TxHash    types.Hash      `json:"txHash"`
+	TxHash    types.HexBytes  `json:"txHash"`
 	Timestamp time.Time       `json:"timestamp"`
 	To        types.AccountID `json:"to"`
 }

--- a/vochain/indexer/process.go
+++ b/vochain/indexer/process.go
@@ -87,6 +87,16 @@ func (idx *Indexer) ProcessList(limit, offset int, entityID string, processID st
 	return list, uint64(results[0].TotalCount), nil
 }
 
+// ProcessExists returns whether the passed processID matches at least one row in the db.
+// processID is a partial or full hex string.
+func (idx *Indexer) ProcessExists(processID string) bool {
+	_, count, err := idx.ProcessList(1, 0, "", processID, 0, 0, 0, nil, nil, nil)
+	if err != nil {
+		log.Errorw(err, "indexer query failed")
+	}
+	return count > 0
+}
+
 // CountTotalProcesses returns the total number of processes indexed.
 func (idx *Indexer) CountTotalProcesses() uint64 {
 	count, err := idx.readOnlyQuery.GetProcessCount(context.TODO())
@@ -126,6 +136,16 @@ func (idx *Indexer) EntityList(limit, offset int, entityID string) ([]indexertyp
 		return list, 0, nil
 	}
 	return list, uint64(results[0].TotalCount), nil
+}
+
+// EntityExists returns whether the passed entityID matches at least one row in the db.
+// entityID is a partial or full hex string.
+func (idx *Indexer) EntityExists(entityID string) bool {
+	_, count, err := idx.EntityList(1, 0, entityID)
+	if err != nil {
+		log.Errorw(err, "indexer query failed")
+	}
+	return count > 0
 }
 
 // CountTotalEntities return the total number of entities indexed by the indexer

--- a/vochain/indexer/queries/account.sql
+++ b/vochain/indexer/queries/account.sql
@@ -3,12 +3,24 @@ REPLACE INTO accounts (
     account, balance, nonce
 ) VALUES (?, ?, ?);
 
--- name: GetListAccounts :many
-SELECT *,
-       COUNT(*) OVER() AS total_count
-FROM accounts
+-- name: SearchAccounts :many
+WITH results AS (
+  SELECT *
+  FROM accounts
+  WHERE (
+    (
+    sqlc.arg(account_id_substr) = ''
+    OR (LENGTH(sqlc.arg(account_id_substr)) = 40 AND LOWER(HEX(account)) = LOWER(sqlc.arg(account_id_substr)))
+    OR (LENGTH(sqlc.arg(account_id_substr)) < 40 AND INSTR(LOWER(HEX(account)), LOWER(sqlc.arg(account_id_substr))) > 0)
+    -- TODO: consider keeping an account_hex column for faster searches
+    )
+  )
+)
+SELECT *, COUNT(*) OVER() AS total_count
+FROM results
 ORDER BY balance DESC
-LIMIT ? OFFSET ?;
+LIMIT sqlc.arg(limit)
+OFFSET sqlc.arg(offset);
 
 -- name: CountAccounts :one
 SELECT COUNT(*) FROM accounts;


### PR DESCRIPTION
add a new endpoint, that includes `pagination` field in reply, and accepts QueryParams:
 * GET /chain/transfers
   * page
   * limit
   * accountId
   * accountIdFrom
   * accountIdTo

* mark all of these endpoints as deprecated on swagger docs:
  * /accounts/{accountId}/transfers/page/{page}
  * /accounts/{accountId}/fees/page/{page}

* api: add TransfersList struct

* indexer: replace GetTokenTransfersBy*Account methods with a new TokenTransfersList
