### PR TITLE
api: hotfix legacy endpoints, return an empty list like they always did

### DIFF
--- a/api/legacy.go
+++ b/api/legacy.go
@@ -1,0 +1,61 @@
+package api
+
+//
+// Legacy lists used to return an empty list (instead of null or an error)
+//
+
+func emptyElectionsList() any {
+	return struct {
+		List []any `json:"elections"`
+	}{
+		List: []any{},
+	}
+}
+
+func emptyOrganizationsList() any {
+	return struct {
+		List []any `json:"organizations"`
+	}{
+		List: []any{},
+	}
+}
+
+func emptyVotesList() any {
+	return struct {
+		List []any `json:"votes"`
+	}{
+		List: []any{},
+	}
+}
+
+func emptyTransactionsList() any {
+	return struct {
+		List []any `json:"transactions"`
+	}{
+		List: []any{},
+	}
+}
+
+func emptyFeesList() any {
+	return struct {
+		List []any `json:"fees"`
+	}{
+		List: []any{},
+	}
+}
+
+func emptyTransfersList() any {
+	return struct {
+		List []any `json:"transfers"`
+	}{
+		List: []any{},
+	}
+}
+
+func emptyAccountsList() any {
+	return struct {
+		List []any `json:"accounts"`
+	}{
+		List: []any{},
+	}
+}

--- a/test/apierror_test.go
+++ b/test/apierror_test.go
@@ -121,10 +121,6 @@ func TestAPIerror(t *testing.T) {
 			want: api.ErrCantParseNumber,
 		},
 		{
-			args: args{"GET", nil, []string{"elections", "page", "1"}},
-			want: api.ErrPageNotFound,
-		},
-		{
 			args: args{"GET", nil, []string{"elections", "page", "-1"}},
 			want: api.ErrPageNotFound,
 		},


### PR DESCRIPTION
    rather than a "404 page not found" all the legacy endpoints had different behaviours
    
    endpoints that return an empty list
      * GET /accounts/{accountId}/fees/page/{page}
      * GET /accounts/page/{page}
      * GET /chain/organizations/page/{page}
      * POST /chain/organizations/filter/page/{page}
      * GET /chain/transactions/page/{page}
      * GET /chain/blocks/{height}/transactions/page/{page}
      * GET /chain/fees/page/{page}
      * GET /chain/fees/reference/{reference}/page/{page}
      * GET /chain/fees/type/{type}/page/{page}
      * POST /elections/filter/page/{page}
      * POST /elections/filter
      * GET /elections/page/{page}
      * GET /elections/{electionId}/votes/page/{page}
    
    odd endpoints that return {}
      * GET /accounts/{organizationId}/elections/page/{page}
      * GET /accounts/{organizationId}/elections/status/{status}/page/{page}
    
    odd endpoint that returns {"transfers":{"received":[],"sent":[]}}
      * GET /accounts/{accountId}/transfers/page/{page}
    
    the new endpoints are of course unaffected, they still return "page not found":
      * GET /accounts
      * GET /chain/organizations
      * GET /chain/transactions
      * GET /chain/fees
      * GET /chain/transfers
      * GET /elections
      * GET /votes
