### PR TITLE
fix: fix slice init length

### DIFF
--- a/vochain/state/utils.go
+++ b/vochain/state/utils.go
@@ -52,7 +52,7 @@ func CheckDuplicateDelegates(delegates [][]byte, addr *ethcommon.Address) error 
 }
 
 func printPrettierDelegates(delegates [][]byte) []string {
-	prettierDelegates := make([]string, len(delegates))
+	prettierDelegates := make([]string, 0, len(delegates))
 	for _, delegate := range delegates {
 		prettierDelegates = append(prettierDelegates, ethcommon.BytesToAddress(delegate).String())
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of   `len(delegates)` rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW