### PR TITLE
vochain: reschedule ISTC action on set duration tx

### DIFF
--- a/vochain/ist/store.go
+++ b/vochain/ist/store.go
@@ -14,7 +14,8 @@ func (c *Controller) removeAction(id []byte) error {
 	return c.state.NoState(true).Delete(addPrefix(id))
 }
 
-// addAction adds an action to the pending actions list.
+// addAction adds an action to the pending actions list. If the action already exists,
+// it will be replaced with the new one.
 func (c *Controller) addAction(act *Action) error {
 	if act.ID == nil {
 		return fmt.Errorf("action ID is nil")


### PR DESCRIPTION
In order to compute the results at the correct time after SET_DURATION is executed, we need to reschedule the ISTC action.

Add an end2end test to verify the correct behavior.

Add a soft-fork to don't break LTS chain (just in case).