### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0 # the push step needs a full repo, not shallow
     - name: Push main branch to dev branch

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           echo github.head_ref: ${{ github.head_ref }}
           echo github.base_ref: ${{ github.base_ref }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go environment
         uses: actions/setup-go@v5
         with:
@@ -77,7 +77,7 @@ jobs:
     env:
       LOG_PANIC_ON_INVALIDCHARS: true # check that log lines contains no invalid chars (evidence of format mismatch)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
       - uses: actions/setup-go@v5
         with:
@@ -109,7 +109,7 @@ jobs:
   job_compose_test:
     runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
       - name: Run compose script
         env:
@@ -146,7 +146,7 @@ jobs:
     needs: [job_go_test, job_compose_test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
       - uses: actions/download-artifact@v4
       - uses: actions/setup-go@v5
@@ -183,7 +183,7 @@ jobs:
     needs: [job_gocoverage_textfmt]
     continue-on-error: true # never mark the whole CI as failed because of this job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
       - name: Checkout developer-portal repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: vocdoni/developer-portal
           ref: main


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0