### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/vochain/tmdb_cleveldb.go
+++ b/vochain/tmdb_cleveldb.go
@@ -1,5 +1,4 @@
 //go:build cleveldb
-// +build cleveldb
 
 package vochain
 

--- a/vochain/tmdb_default.go
+++ b/vochain/tmdb_default.go
@@ -1,5 +1,4 @@
 //go:build !cleveldb
-// +build !cleveldb
 
 // If -tags=cleveldb is not used, we must fall back to something included by
 // tm-db by default. goleveldb is an OK choice, since it's pure Go and it's also


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild