### PR TITLE
feat: batch transaction endpoint (POST /chain/transactions/batch)

### DIFF
--- a/api/api_types.go
+++ b/api/api_types.go
@@ -290,11 +290,14 @@ type TransactionBatch struct {
 // NewProcess transaction, ProcessID is the predicted election id. Error is set
 // only on the item that failed to be submitted.
 type TransactionBatchItem struct {
-	Hash        types.HexBytes `json:"hash,omitempty" extensions:"x-omitempty"`
-	ProcessID   types.HexBytes `json:"processId,omitempty" extensions:"x-omitempty"`
-	Code        *uint32        `json:"code,omitempty" extensions:"x-omitempty"`
-	Error       string         `json:"error,omitempty" extensions:"x-omitempty"`
-	MetadataURL string         `json:"metadataURL,omitempty" extensions:"x-omitempty"`
+	Hash      types.HexBytes `json:"hash,omitempty" extensions:"x-omitempty"`
+	ProcessID types.HexBytes `json:"processId,omitempty" extensions:"x-omitempty"`
+	// Code is the mempool CheckTx response code. For submitted items it is always
+	// 0: a non-zero CheckTx code is turned into a submit error, so the item lands
+	// in Failed instead. The field is kept for parity with the single-tx endpoint.
+	Code        *uint32 `json:"code,omitempty" extensions:"x-omitempty"`
+	Error       string  `json:"error,omitempty" extensions:"x-omitempty"`
+	MetadataURL string  `json:"metadataURL,omitempty" extensions:"x-omitempty"`
 }
 
 // TransactionBatchResult groups every input transaction of a batch by its

--- a/api/api_types.go
+++ b/api/api_types.go
@@ -275,6 +275,10 @@ type Transaction struct {
 // in a batch request.
 type TransactionPayload struct {
 	Payload []byte `json:"payload" swaggertype:"string" format:"base64"`
+	// Metadata is the optional raw election metadata for a NewProcess payload. When
+	// provided, its CID must match the metadata URI in the transaction, and it is
+	// pinned to IPFS on submission (same as POST /elections).
+	Metadata []byte `json:"metadata,omitempty" swaggertype:"string" format:"base64"`
 }
 
 // TransactionBatch is a request to submit multiple transactions at once, in order.
@@ -286,10 +290,11 @@ type TransactionBatch struct {
 // NewProcess transaction, ProcessID is the predicted election id. Error is set
 // only on the item that failed to be submitted.
 type TransactionBatchItem struct {
-	Hash      types.HexBytes `json:"hash,omitempty" extensions:"x-omitempty"`
-	ProcessID types.HexBytes `json:"processId,omitempty" extensions:"x-omitempty"`
-	Code      *uint32        `json:"code,omitempty" extensions:"x-omitempty"`
-	Error     string         `json:"error,omitempty" extensions:"x-omitempty"`
+	Hash        types.HexBytes `json:"hash,omitempty" extensions:"x-omitempty"`
+	ProcessID   types.HexBytes `json:"processId,omitempty" extensions:"x-omitempty"`
+	Code        *uint32        `json:"code,omitempty" extensions:"x-omitempty"`
+	Error       string         `json:"error,omitempty" extensions:"x-omitempty"`
+	MetadataURL string         `json:"metadataURL,omitempty" extensions:"x-omitempty"`
 }
 
 // TransactionBatchResult groups every input transaction of a batch by its

--- a/api/api_types.go
+++ b/api/api_types.go
@@ -269,13 +269,27 @@ type Transaction struct {
 	Costs     map[string]uint64 `json:"costs,omitempty" extensions:"x-omitempty" swaggerignore:"true"`
 	Address   types.HexBytes    `json:"address,omitempty" extensions:"x-omitempty" swaggerignore:"true" `
 	ProcessID types.HexBytes    `json:"processId,omitempty" extensions:"x-omitempty" `
-	// Error is set on a batch item that failed to be submitted.
-	Error string `json:"error,omitempty" extensions:"x-omitempty"`
+}
+
+// TransactionPayload is one pre-signed transaction (base64-encoded models.SignedTx)
+// in a batch request.
+type TransactionPayload struct {
+	Payload []byte `json:"payload" swaggertype:"string" format:"base64"`
 }
 
 // TransactionBatch is a request to submit multiple transactions at once, in order.
 type TransactionBatch struct {
-	Transactions []Transaction `json:"transactions"`
+	Transactions []TransactionPayload `json:"transactions"`
+}
+
+// TransactionBatchItem is the outcome of a single transaction in a batch. For a
+// NewProcess transaction, ProcessID is the predicted election id. Error is set
+// only on the item that failed to be submitted.
+type TransactionBatchItem struct {
+	Hash      types.HexBytes `json:"hash,omitempty" extensions:"x-omitempty"`
+	ProcessID types.HexBytes `json:"processId,omitempty" extensions:"x-omitempty"`
+	Code      *uint32        `json:"code,omitempty" extensions:"x-omitempty"`
+	Error     string         `json:"error,omitempty" extensions:"x-omitempty"`
 }
 
 // TransactionBatchResult groups every input transaction of a batch by its
@@ -286,12 +300,12 @@ type TransactionBatch struct {
 // resubmit any that did not land, together with the failed and pending items.
 type TransactionBatchResult struct {
 	// Submitted are the transactions accepted by the mempool, in order.
-	Submitted []Transaction `json:"submitted"`
+	Submitted []TransactionBatchItem `json:"submitted"`
 	// Failed holds the first transaction that failed to be submitted (Error set);
 	// submission stops there.
-	Failed []Transaction `json:"failed"`
+	Failed []TransactionBatchItem `json:"failed"`
 	// Pending are the transactions after the failed one that were not sent.
-	Pending []Transaction `json:"pending"`
+	Pending []TransactionBatchItem `json:"pending"`
 }
 
 type TransactionReference struct {

--- a/api/api_types.go
+++ b/api/api_types.go
@@ -268,7 +268,30 @@ type Transaction struct {
 	Code      *uint32           `json:"code,omitempty" extensions:"x-omitempty"`
 	Costs     map[string]uint64 `json:"costs,omitempty" extensions:"x-omitempty" swaggerignore:"true"`
 	Address   types.HexBytes    `json:"address,omitempty" extensions:"x-omitempty" swaggerignore:"true" `
-	ProcessID types.HexBytes    `json:"processId,omitempty" extensions:"x-omitempty" swaggerignore:"true" `
+	ProcessID types.HexBytes    `json:"processId,omitempty" extensions:"x-omitempty" `
+	// Error is set on a batch item that failed to be submitted.
+	Error string `json:"error,omitempty" extensions:"x-omitempty"`
+}
+
+// TransactionBatch is a request to submit multiple transactions at once, in order.
+type TransactionBatch struct {
+	Transactions []Transaction `json:"transactions"`
+}
+
+// TransactionBatchResult groups every input transaction of a batch by its
+// submission outcome. Note: "submitted" means the mempool accepted the broadcast,
+// NOT that the transaction is block-confirmed — a mempool-accepted transaction can
+// still be discarded at commit (e.g. a stale/contended nonce, which is not checked
+// at mempool admission). The caller must confirm each submitted item on-chain and
+// resubmit any that did not land, together with the failed and pending items.
+type TransactionBatchResult struct {
+	// Submitted are the transactions accepted by the mempool, in order.
+	Submitted []Transaction `json:"submitted"`
+	// Failed holds the first transaction that failed to be submitted (Error set);
+	// submission stops there.
+	Failed []Transaction `json:"failed"`
+	// Pending are the transactions after the failed one that were not sent.
+	Pending []Transaction `json:"pending"`
 }
 
 type TransactionReference struct {

--- a/api/chain.go
+++ b/api/chain.go
@@ -676,8 +676,11 @@ func (a *API) chainSendTxBatchHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 		},
 	)
 
-	// Pin the metadata of the transactions that were actually submitted (the
-	// ordered prefix), best-effort, exactly like POST /elections.
+	// Pin the metadata of the transactions that were actually submitted, best-effort,
+	// exactly like POST /elections. This relies on the fail-fast invariant of
+	// classifyTransactionBatch: submitted items are always the leading prefix of the
+	// input in order, so result.Submitted[i] corresponds to req.Transactions[i]. If
+	// that strategy ever changes, this index correspondence must be revisited.
 	for i := range result.Submitted {
 		md := req.Transactions[i].Metadata
 		if a.storage == nil || len(md) == 0 {

--- a/api/chain.go
+++ b/api/chain.go
@@ -7,13 +7,16 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	comettypes "github.com/cometbft/cometbft/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/zk/circuit"
+	"go.vocdoni.io/dvote/data/ipfs"
 	"go.vocdoni.io/dvote/httprouter"
 	"go.vocdoni.io/dvote/httprouter/apirest"
+	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain/genesis"
 	"go.vocdoni.io/dvote/vochain/indexer"
@@ -649,6 +652,15 @@ func (a *API) chainSendTxBatchHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 		return ErrTransactionBatchTooLarge.Withf("%d, max is %d", len(req.Transactions), maxTransactionBatchSize)
 	}
 
+	// Validate election metadata up front (same checks as POST /elections): a
+	// client-side metadata mistake rejects the whole batch before anything is
+	// submitted, so no transaction lands on-chain because of it.
+	for i := range req.Transactions {
+		if err := a.checkBatchItemMetadata(req.Transactions[i]); err != nil {
+			return err
+		}
+	}
+
 	// per-creator (EntityId) running process-index delta, advanced for every
 	// NewProcess item regardless of send outcome, so each item gets the exact
 	// processId the chain will assign in ordered commit.
@@ -663,6 +675,26 @@ func (a *API) chainSendTxBatchHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 			return res.Hash.Bytes(), res.Code, nil
 		},
 	)
+
+	// Pin the metadata of the transactions that were actually submitted (the
+	// ordered prefix), best-effort, exactly like POST /elections.
+	for i := range result.Submitted {
+		md := req.Transactions[i].Metadata
+		if a.storage == nil || len(md) == 0 {
+			continue
+		}
+		sctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		cid, err := a.storage.Publish(sctx, md)
+		cancel()
+		if err != nil {
+			log.Errorf("could not publish batch metadata to storage: %v", err)
+			continue
+		}
+		result.Submitted[i].MetadataURL = a.storage.URIprefix() + cid
+		if strings.TrimPrefix(cid, "ipfs://") != strings.TrimPrefix(ipfs.CalculateCIDv1json(md), "ipfs://") {
+			log.Errorf("%s (%s != %s)", ErrVochainReturnedWrongMetadataCID, cid, ipfs.CalculateCIDv1json(md))
+		}
+	}
 
 	data, err := json.Marshal(result)
 	if err != nil {
@@ -747,6 +779,39 @@ func (a *API) batchProcessID(payload []byte, deltas map[string]int32) []byte {
 		return nil
 	}
 	return pid.Marshal()
+}
+
+// checkBatchItemMetadata validates a batch item's optional raw election metadata,
+// mirroring POST /elections: only when raw metadata is provided, the NewProcess tx
+// must carry a matching metadata URI. Returns nil when there is nothing to check.
+func (a *API) checkBatchItemMetadata(item TransactionPayload) error {
+	if len(item.Metadata) == 0 {
+		return nil
+	}
+	// Extract the metadata URI (and encrypted flag) from the NewProcess payload.
+	metadataURI, encryptedMetadata := "", false
+	stx := &models.SignedTx{}
+	if err := proto.Unmarshal(item.Payload, stx); err == nil {
+		tx := &models.Tx{}
+		if err := proto.Unmarshal(stx.GetTx(), tx); err == nil {
+			if p := tx.GetNewProcess().GetProcess(); p != nil {
+				metadataURI = p.GetMetadata()
+				encryptedMetadata = p.GetMode() != nil && p.GetMode().EncryptedMetaData
+			}
+		}
+	}
+	if metadataURI == "" {
+		return ErrMetadataProvidedButNoURI
+	}
+	if !encryptedMetadata {
+		if err := json.Unmarshal(item.Metadata, &ElectionMetadata{}); err != nil {
+			return ErrCantParseMetadataAsJSON.WithErr(err)
+		}
+	}
+	if !ipfs.CIDequals(ipfs.CalculateCIDv1json(item.Metadata), metadataURI) {
+		return ErrMetadataURINotMatchContent
+	}
+	return nil
 }
 
 // chainTxCostHandler

--- a/api/chain.go
+++ b/api/chain.go
@@ -16,8 +16,14 @@ import (
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain/genesis"
 	"go.vocdoni.io/dvote/vochain/indexer"
+	"go.vocdoni.io/dvote/vochain/processid"
 	"go.vocdoni.io/dvote/vochain/state"
+	"go.vocdoni.io/proto/build/go/models"
+	"google.golang.org/protobuf/proto"
 )
+
+// maxTransactionBatchSize bounds how many transactions POST /chain/transactions/batch accepts.
+const maxTransactionBatchSize = 100
 
 const (
 	ChainHandler = "chain"
@@ -125,6 +131,14 @@ func (a *API) enableChainHandlers() error {
 		"POST",
 		apirest.MethodAccessTypePublic,
 		a.chainSendTxHandler,
+	); err != nil {
+		return err
+	}
+	if err := a.Endpoint.RegisterMethod(
+		"/chain/transactions/batch",
+		"POST",
+		apirest.MethodAccessTypePublic,
+		a.chainSendTxBatchHandler,
 	); err != nil {
 		return err
 	}
@@ -602,6 +616,122 @@ func (a *API) chainSendTxHandler(msg *apirest.APIdata, ctx *httprouter.HTTPConte
 		return err
 	}
 	return ctx.Send(data, apirest.HTTPstatusOK)
+}
+
+// chainSendTxBatchHandler
+//
+//	@Summary				Submit a batch of transactions
+//	@Description.markdown	chainSendTxBatchHandler
+//	@Tags					Chain
+//	@Accept					json
+//	@Produce				json
+//	@Param					transactions	body		TransactionBatch		true	"List of base64 transaction payloads, submitted in order"
+//	@Success				200				{object}	TransactionBatchResult	"Every input transaction grouped as submitted / failed / pending"
+//	@Router					/chain/transactions/batch [post]
+//
+// The transactions are submitted in order and fail-fast: the first one that fails
+// to be submitted goes to `failed` and submission stops, leaving the rest in
+// `pending`. "submitted" means the mempool accepted the broadcast, NOT that the
+// transaction is block-confirmed — the caller must confirm each submitted item
+// on-chain and resubmit any that did not land, together with failed and pending.
+// For NewProcess transactions each item carries its predicted `processId`.
+func (a *API) chainSendTxBatchHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
+	req := &TransactionBatch{}
+	if err := json.Unmarshal(msg.Data, req); err != nil {
+		return ErrCantParseDataAsJSON.WithErr(err)
+	}
+	if len(req.Transactions) == 0 {
+		return ErrCantParseDataAsJSON.With("empty transaction batch")
+	}
+	if len(req.Transactions) > maxTransactionBatchSize {
+		return ErrTransactionBatchTooLarge.Withf("%d, max is %d", len(req.Transactions), maxTransactionBatchSize)
+	}
+
+	// per-creator (EntityId) running process-index delta, advanced for every
+	// NewProcess item regardless of send outcome, so each item gets the exact
+	// processId the chain will assign in ordered commit.
+	deltas := map[string]int32{}
+	result := classifyTransactionBatch(req.Transactions,
+		func(payload []byte) []byte { return a.batchProcessID(payload, deltas) },
+		func(payload []byte) (hash, response []byte, code uint32, err error) {
+			res, err := a.sendTx(payload)
+			if err != nil {
+				return nil, nil, 0, err
+			}
+			return res.Hash.Bytes(), res.Data.Bytes(), res.Code, nil
+		},
+	)
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return ErrMarshalingServerJSONFailed.WithErr(err)
+	}
+	return ctx.Send(data, apirest.HTTPstatusOK)
+}
+
+// classifyTransactionBatch submits the transactions in order and groups every
+// input item into submitted / failed / pending. It is fail-fast: the first send
+// error goes to `failed` and no further items are sent (they share the sender's
+// now-broken nonce sequence and cannot commit), so the rest land in `pending`.
+// `processID` supplies each item's predicted processId (nil if not applicable);
+// it is called for every item, including the unsent ones. Injecting `processID`
+// and `send` keeps the grouping logic testable without a live chain.
+func classifyTransactionBatch(
+	txs []Transaction,
+	processID func(payload []byte) []byte,
+	send func(payload []byte) (hash, response []byte, code uint32, err error),
+) *TransactionBatchResult {
+	result := &TransactionBatchResult{
+		Submitted: []Transaction{},
+		Failed:    []Transaction{},
+		Pending:   []Transaction{},
+	}
+	stopped := false
+	for i := range txs {
+		item := Transaction{ProcessID: processID(txs[i].Payload)}
+		if stopped {
+			result.Pending = append(result.Pending, item)
+			continue
+		}
+		hash, response, code, err := send(txs[i].Payload)
+		if err != nil {
+			item.Error = err.Error()
+			result.Failed = append(result.Failed, item)
+			stopped = true
+			continue
+		}
+		item.Hash = hash
+		item.Response = response
+		item.Code = &code
+		result.Submitted = append(result.Submitted, item)
+	}
+	return result
+}
+
+// batchProcessID returns the predicted processId for a NewProcess payload and
+// advances the per-creator positional delta. Returns nil for non-NewProcess or
+// undecodable payloads (the tx is still submitted; only the predicted id is absent).
+func (a *API) batchProcessID(payload []byte, deltas map[string]int32) []byte {
+	stx := &models.SignedTx{}
+	if err := proto.Unmarshal(payload, stx); err != nil {
+		return nil
+	}
+	tx := &models.Tx{}
+	if err := proto.Unmarshal(stx.GetTx(), tx); err != nil {
+		return nil
+	}
+	proc := tx.GetNewProcess().GetProcess()
+	if proc == nil {
+		return nil
+	}
+	key := string(proc.GetEntityId())
+	delta := deltas[key]
+	deltas[key] = delta + 1
+	pid, err := processid.BuildProcessID(proc, a.vocapp.State, delta)
+	if err != nil {
+		return nil
+	}
+	return pid.Marshal()
 }
 
 // chainTxCostHandler

--- a/api/chain.go
+++ b/api/chain.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	comettypes "github.com/cometbft/cometbft/types"
+	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/zk/circuit"
 	"go.vocdoni.io/dvote/httprouter"
 	"go.vocdoni.io/dvote/httprouter/apirest"
@@ -715,15 +716,29 @@ func (a *API) batchProcessID(payload []byte, deltas map[string]int32) []byte {
 	if err := proto.Unmarshal(payload, stx); err != nil {
 		return nil
 	}
-	tx := &models.Tx{}
-	if err := proto.Unmarshal(stx.GetTx(), tx); err != nil {
+	// Decode the inner Tx and build the signed body (also used to recover the signer).
+	signedBody, tx, err := ethereum.BuildVocdoniTransaction(stx.GetTx(), a.vocapp.ChainID())
+	if err != nil {
 		return nil
 	}
 	proc := tx.GetNewProcess().GetProcess()
 	if proc == nil {
 		return nil
 	}
-	key := string(proc.GetEntityId())
+	// Resolve the organization exactly as NewProcessTxCheck does: when EntityId is
+	// unset, it defaults to the tx signer's address (vochain/transaction/election_tx.go).
+	// Both the delta key and BuildProcessID must use the resolved entity, otherwise
+	// the predicted id would be dropped and the deltas would collide on the empty key.
+	entity := proc.GetEntityId()
+	if len(entity) == 0 {
+		addr, err := ethereum.AddrFromSignature(signedBody, stx.GetSignature())
+		if err != nil {
+			return nil
+		}
+		entity = addr.Bytes()
+		proc.EntityId = entity
+	}
+	key := string(entity)
 	delta := deltas[key]
 	deltas[key] = delta + 1
 	pid, err := processid.BuildProcessID(proc, a.vocapp.State, delta)

--- a/api/chain.go
+++ b/api/chain.go
@@ -641,7 +641,7 @@ func (a *API) chainSendTxBatchHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 		return ErrCantParseDataAsJSON.WithErr(err)
 	}
 	if len(req.Transactions) == 0 {
-		return ErrCantParseDataAsJSON.With("empty transaction batch")
+		return ErrTransactionBatchEmpty
 	}
 	if len(req.Transactions) > maxTransactionBatchSize {
 		return ErrTransactionBatchTooLarge.Withf("%d, max is %d", len(req.Transactions), maxTransactionBatchSize)
@@ -653,12 +653,12 @@ func (a *API) chainSendTxBatchHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 	deltas := map[string]int32{}
 	result := classifyTransactionBatch(req.Transactions,
 		func(payload []byte) []byte { return a.batchProcessID(payload, deltas) },
-		func(payload []byte) (hash, response []byte, code uint32, err error) {
+		func(payload []byte) (hash []byte, code uint32, err error) {
 			res, err := a.sendTx(payload)
 			if err != nil {
-				return nil, nil, 0, err
+				return nil, 0, err
 			}
-			return res.Hash.Bytes(), res.Data.Bytes(), res.Code, nil
+			return res.Hash.Bytes(), res.Code, nil
 		},
 	)
 
@@ -677,23 +677,23 @@ func (a *API) chainSendTxBatchHandler(msg *apirest.APIdata, ctx *httprouter.HTTP
 // it is called for every item, including the unsent ones. Injecting `processID`
 // and `send` keeps the grouping logic testable without a live chain.
 func classifyTransactionBatch(
-	txs []Transaction,
+	txs []TransactionPayload,
 	processID func(payload []byte) []byte,
-	send func(payload []byte) (hash, response []byte, code uint32, err error),
+	send func(payload []byte) (hash []byte, code uint32, err error),
 ) *TransactionBatchResult {
 	result := &TransactionBatchResult{
-		Submitted: []Transaction{},
-		Failed:    []Transaction{},
-		Pending:   []Transaction{},
+		Submitted: []TransactionBatchItem{},
+		Failed:    []TransactionBatchItem{},
+		Pending:   []TransactionBatchItem{},
 	}
 	stopped := false
 	for i := range txs {
-		item := Transaction{ProcessID: processID(txs[i].Payload)}
+		item := TransactionBatchItem{ProcessID: processID(txs[i].Payload)}
 		if stopped {
 			result.Pending = append(result.Pending, item)
 			continue
 		}
-		hash, response, code, err := send(txs[i].Payload)
+		hash, code, err := send(txs[i].Payload)
 		if err != nil {
 			item.Error = err.Error()
 			result.Failed = append(result.Failed, item)
@@ -701,7 +701,6 @@ func classifyTransactionBatch(
 			continue
 		}
 		item.Hash = hash
-		item.Response = response
 		item.Code = &code
 		result.Submitted = append(result.Submitted, item)
 	}

--- a/api/chain.go
+++ b/api/chain.go
@@ -628,7 +628,6 @@ func (a *API) chainSendTxHandler(msg *apirest.APIdata, ctx *httprouter.HTTPConte
 //	@Produce				json
 //	@Param					transactions	body		TransactionBatch		true	"List of base64 transaction payloads, submitted in order"
 //	@Success				200				{object}	TransactionBatchResult	"Every input transaction grouped as submitted / failed / pending"
-//	@Router					/chain/transactions/batch [post]
 //
 // The transactions are submitted in order and fail-fast: the first one that fails
 // to be submitted goes to `failed` and submission stops, leaving the rest in
@@ -636,6 +635,8 @@ func (a *API) chainSendTxHandler(msg *apirest.APIdata, ctx *httprouter.HTTPConte
 // transaction is block-confirmed — the caller must confirm each submitted item
 // on-chain and resubmit any that did not land, together with failed and pending.
 // For NewProcess transactions each item carries its predicted `processId`.
+//
+//	@Router					/chain/transactions/batch [post]
 func (a *API) chainSendTxBatchHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	req := &TransactionBatch{}
 	if err := json.Unmarshal(msg.Data, req); err != nil {

--- a/api/chain_batch_test.go
+++ b/api/chain_batch_test.go
@@ -12,6 +12,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/google/uuid"
 	"go.vocdoni.io/dvote/api/censusdb"
+	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/data/ipfs"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/metadb"
@@ -21,6 +22,9 @@ import (
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/vochain"
 	"go.vocdoni.io/dvote/vochain/indexer"
+	"go.vocdoni.io/dvote/vochain/processid"
+	"go.vocdoni.io/proto/build/go/models"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestClassifyTransactionBatch checks the fail-fast grouping: submission stops at
@@ -122,4 +126,66 @@ func TestChainSendTxBatchHandler(t *testing.T) {
 	// empty batch -> dedicated 400 error
 	_, code = cl.Request("POST", &TransactionBatch{Transactions: []TransactionPayload{}}, "transactions", "batch")
 	c.Assert(code, qt.Equals, ErrTransactionBatchEmpty.HTTPstatus)
+}
+
+// signedNewProcessPayload builds a signed NewProcess transaction (as the
+// marshaled models.SignedTx the endpoint receives). entityID may be nil to
+// exercise the EntityId-unset path.
+func signedNewProcessPayload(t *testing.T, signer *ethereum.SignKeys, chainID string, entityID []byte) []byte {
+	tx := &models.Tx{Payload: &models.Tx_NewProcess{NewProcess: &models.NewProcessTx{
+		Txtype: models.TxType_NEW_PROCESS,
+		Process: &models.Process{
+			EntityId:     entityID,
+			CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
+			EnvelopeType: &models.EnvelopeType{},
+		},
+	}}}
+	txBytes, err := proto.Marshal(tx)
+	qt.Assert(t, err, qt.IsNil)
+	sig, err := signer.SignVocdoniTx(txBytes, chainID)
+	qt.Assert(t, err, qt.IsNil)
+	payload, err := proto.Marshal(&models.SignedTx{Tx: txBytes, Signature: sig})
+	qt.Assert(t, err, qt.IsNil)
+	return payload
+}
+
+// TestBatchProcessID covers the real decode + per-EntityId delta + BuildProcessID
+// path, including the EntityId-unset case where the organization must default to
+// the tx signer (mirroring NewProcessTxCheck).
+func TestBatchProcessID(t *testing.T) {
+	c := qt.New(t)
+	app := vochain.TestBaseApplication(t)
+	a := &API{vocapp: app}
+
+	signer := &ethereum.SignKeys{}
+	c.Assert(signer.Generate(), qt.IsNil)
+	entity := signer.Address().Bytes()
+	c.Assert(app.State.CreateAccount(signer.Address(), "", nil, 100), qt.IsNil)
+
+	// expected id for a given delta, computed the same way the chain does.
+	expected := func(delta int32) []byte {
+		pid, err := processid.BuildProcessID(&models.Process{
+			EntityId:     entity,
+			CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
+			EnvelopeType: &models.EnvelopeType{},
+		}, app.State, delta)
+		c.Assert(err, qt.IsNil)
+		return pid.Marshal()
+	}
+
+	// EntityId set: two txs for the same entity advance the delta (0, then 1).
+	deltas := map[string]int32{}
+	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), entity), deltas),
+		qt.DeepEquals, expected(0))
+	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), entity), deltas),
+		qt.DeepEquals, expected(1))
+	c.Assert(deltas[string(entity)], qt.Equals, int32(2))
+
+	// EntityId unset: the signer is recovered and used, so the id is NOT dropped
+	// and the delta is keyed on the resolved entity (not the empty string).
+	deltas2 := map[string]int32{}
+	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), nil), deltas2),
+		qt.DeepEquals, expected(0))
+	c.Assert(deltas2[string(entity)], qt.Equals, int32(1))
+	c.Assert(deltas2[""], qt.Equals, int32(0))
 }

--- a/api/chain_batch_test.go
+++ b/api/chain_batch_test.go
@@ -1,11 +1,26 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"path"
 	"testing"
 
+	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
+	cometcoretypes "github.com/cometbft/cometbft/rpc/core/types"
 	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
+	"go.vocdoni.io/dvote/api/censusdb"
+	"go.vocdoni.io/dvote/data/ipfs"
+	"go.vocdoni.io/dvote/db"
+	"go.vocdoni.io/dvote/db/metadb"
+	"go.vocdoni.io/dvote/httprouter"
+	"go.vocdoni.io/dvote/httprouter/apirest"
+	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/dvote/vochain"
+	"go.vocdoni.io/dvote/vochain/indexer"
 )
 
 // TestClassifyTransactionBatch checks the fail-fast grouping: submission stops at
@@ -14,7 +29,7 @@ import (
 func TestClassifyTransactionBatch(t *testing.T) {
 	c := qt.New(t)
 
-	txs := []Transaction{
+	txs := []TransactionPayload{
 		{Payload: []byte("a")},
 		{Payload: []byte("b")},
 		{Payload: []byte("bad")}, // fails to submit
@@ -25,12 +40,12 @@ func TestClassifyTransactionBatch(t *testing.T) {
 	processID := func(p []byte) []byte { return append([]byte("pid-"), p...) }
 
 	var sent [][]byte
-	send := func(p []byte) (hash, response []byte, code uint32, err error) {
+	send := func(p []byte) (hash []byte, code uint32, err error) {
 		sent = append(sent, p)
 		if string(p) == "bad" {
-			return nil, nil, 0, fmt.Errorf("boom")
+			return nil, 0, fmt.Errorf("boom")
 		}
-		return append([]byte("hash-"), p...), nil, 0, nil
+		return append([]byte("hash-"), p...), 0, nil
 	}
 
 	res := classifyTransactionBatch(txs, processID, send)
@@ -54,4 +69,57 @@ func TestClassifyTransactionBatch(t *testing.T) {
 	c.Assert(res.Pending[0].Hash, qt.IsNil)
 	// submitted items carry their hash
 	c.Assert(res.Submitted[0].Hash, qt.DeepEquals, types.HexBytes("hash-a"))
+}
+
+// TestChainSendTxBatchHandler exercises the HTTP handler end to end against a test
+// app whose mempool is stubbed: a payload equal to "bad" fails to submit.
+func TestChainSendTxBatchHandler(t *testing.T) {
+	c := qt.New(t)
+
+	router := httprouter.HTTProuter{}
+	router.Init("127.0.0.1", 0)
+	addr, err := url.Parse("http://" + path.Join(router.Address().String(), "chain"))
+	c.Assert(err, qt.IsNil)
+
+	api, err := NewAPI(&router, "/", t.TempDir(), db.TypePebble)
+	c.Assert(err, qt.IsNil)
+	kv, err := metadb.New(db.TypePebble, t.TempDir())
+	c.Assert(err, qt.IsNil)
+	censusDB := censusdb.NewCensusDB(kv)
+	storage := ipfs.MockIPFS(t)
+	app := vochain.TestBaseApplication(t)
+	// stub the mempool: a tx whose raw payload is "bad" is rejected at submit.
+	app.SetFnSendTx(func(tx []byte) (*cometcoretypes.ResultBroadcastTx, error) {
+		if string(tx) == "bad" {
+			return nil, fmt.Errorf("rejected")
+		}
+		return &cometcoretypes.ResultBroadcastTx{Hash: cmtbytes.HexBytes("hash"), Code: 0}, nil
+	})
+	idx, err := indexer.New(app, indexer.Options{DataDir: t.TempDir()})
+	c.Assert(err, qt.IsNil)
+	api.Attach(app, nil, idx, storage, censusDB)
+	c.Assert(api.EnableHandlers(ChainHandler), qt.IsNil)
+
+	token := uuid.New()
+	cl := testutil.NewTestHTTPclient(t, addr, &token)
+
+	// ok, bad, ok -> submitted:1, failed:1 (fail-fast), pending:1
+	body := &TransactionBatch{Transactions: []TransactionPayload{
+		{Payload: []byte("ok1")},
+		{Payload: []byte("bad")},
+		{Payload: []byte("ok2")},
+	}}
+	resp, code := cl.Request("POST", body, "transactions", "batch")
+	c.Assert(code, qt.Equals, apirest.HTTPstatusOK)
+	result := &TransactionBatchResult{}
+	c.Assert(json.Unmarshal(resp, result), qt.IsNil)
+	c.Assert(result.Submitted, qt.HasLen, 1)
+	c.Assert(result.Failed, qt.HasLen, 1)
+	c.Assert(result.Pending, qt.HasLen, 1)
+	c.Assert(result.Failed[0].Error, qt.Not(qt.Equals), "")
+	c.Assert(result.Submitted[0].Hash, qt.Not(qt.IsNil))
+
+	// empty batch -> dedicated 400 error
+	_, code = cl.Request("POST", &TransactionBatch{Transactions: []TransactionPayload{}}, "transactions", "batch")
+	c.Assert(code, qt.Equals, ErrTransactionBatchEmpty.HTTPstatus)
 }

--- a/api/chain_batch_test.go
+++ b/api/chain_batch_test.go
@@ -131,13 +131,14 @@ func TestChainSendTxBatchHandler(t *testing.T) {
 // signedNewProcessPayload builds a signed NewProcess transaction (as the
 // marshaled models.SignedTx the endpoint receives). entityID may be nil to
 // exercise the EntityId-unset path.
-func signedNewProcessPayload(t *testing.T, signer *ethereum.SignKeys, chainID string, entityID []byte) []byte {
+func signedNewProcessPayload(t *testing.T, signer *ethereum.SignKeys, chainID string, entityID []byte, metadataURI string) []byte {
 	tx := &models.Tx{Payload: &models.Tx_NewProcess{NewProcess: &models.NewProcessTx{
 		Txtype: models.TxType_NEW_PROCESS,
 		Process: &models.Process{
 			EntityId:     entityID,
 			CensusOrigin: models.CensusOrigin_OFF_CHAIN_TREE,
 			EnvelopeType: &models.EnvelopeType{},
+			Metadata:     &metadataURI,
 		},
 	}}}
 	txBytes, err := proto.Marshal(tx)
@@ -175,17 +176,88 @@ func TestBatchProcessID(t *testing.T) {
 
 	// EntityId set: two txs for the same entity advance the delta (0, then 1).
 	deltas := map[string]int32{}
-	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), entity), deltas),
+	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), entity, ""), deltas),
 		qt.DeepEquals, expected(0))
-	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), entity), deltas),
+	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), entity, ""), deltas),
 		qt.DeepEquals, expected(1))
 	c.Assert(deltas[string(entity)], qt.Equals, int32(2))
 
 	// EntityId unset: the signer is recovered and used, so the id is NOT dropped
 	// and the delta is keyed on the resolved entity (not the empty string).
 	deltas2 := map[string]int32{}
-	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), nil), deltas2),
+	c.Assert(a.batchProcessID(signedNewProcessPayload(t, signer, app.ChainID(), nil, ""), deltas2),
 		qt.DeepEquals, expected(0))
 	c.Assert(deltas2[string(entity)], qt.Equals, int32(1))
 	c.Assert(deltas2[""], qt.Equals, int32(0))
+}
+
+// TestChainSendTxBatchMetadata covers the /elections-style metadata handling on
+// the batch endpoint: when raw metadata is provided it must match the tx's URI and
+// is pinned; a mismatch or a metadata-without-URI rejects the whole batch.
+func TestChainSendTxBatchMetadata(t *testing.T) {
+	c := qt.New(t)
+	router := httprouter.HTTProuter{}
+	router.Init("127.0.0.1", 0)
+	addr, err := url.Parse("http://" + path.Join(router.Address().String(), "chain"))
+	c.Assert(err, qt.IsNil)
+	api, err := NewAPI(&router, "/", t.TempDir(), db.TypePebble)
+	c.Assert(err, qt.IsNil)
+	kv, err := metadb.New(db.TypePebble, t.TempDir())
+	c.Assert(err, qt.IsNil)
+	app := vochain.TestBaseApplication(t)
+	app.SetFnSendTx(func(_ []byte) (*cometcoretypes.ResultBroadcastTx, error) {
+		return &cometcoretypes.ResultBroadcastTx{Hash: cmtbytes.HexBytes("hash"), Code: 0}, nil
+	})
+	idx, err := indexer.New(app, indexer.Options{DataDir: t.TempDir()})
+	c.Assert(err, qt.IsNil)
+	api.Attach(app, nil, idx, ipfs.MockIPFS(t), censusdb.NewCensusDB(kv))
+	c.Assert(api.EnableHandlers(ChainHandler), qt.IsNil)
+	token := uuid.New()
+	cl := testutil.NewTestHTTPclient(t, addr, &token)
+
+	signer := &ethereum.SignKeys{}
+	c.Assert(signer.Generate(), qt.IsNil)
+	entity := signer.Address().Bytes()
+	raw := []byte(`{"title":{"default":"batch"}}`)
+	uri := ipfs.CalculateCIDv1json(raw)
+
+	post := func(items ...TransactionPayload) (int, *TransactionBatchResult) {
+		resp, code := cl.Request("POST", &TransactionBatch{Transactions: items}, "transactions", "batch")
+		res := &TransactionBatchResult{}
+		if code == apirest.HTTPstatusOK {
+			c.Assert(json.Unmarshal(resp, res), qt.IsNil)
+		}
+		return code, res
+	}
+
+	// URI + matching metadata -> submitted and pinned (MetadataURL set).
+	code, res := post(TransactionPayload{
+		Payload:  signedNewProcessPayload(t, signer, app.ChainID(), entity, uri),
+		Metadata: raw,
+	})
+	c.Assert(code, qt.Equals, apirest.HTTPstatusOK)
+	c.Assert(res.Submitted, qt.HasLen, 1)
+	c.Assert(res.Submitted[0].MetadataURL, qt.Not(qt.Equals), "")
+
+	// URI + mismatching metadata -> whole batch rejected, nothing submitted.
+	code, _ = post(TransactionPayload{
+		Payload:  signedNewProcessPayload(t, signer, app.ChainID(), entity, uri),
+		Metadata: []byte(`{"title":{"default":"different"}}`),
+	})
+	c.Assert(code, qt.Equals, ErrMetadataURINotMatchContent.HTTPstatus)
+
+	// URI + no raw metadata -> submitted, not pinned (elections-style optional).
+	code, res = post(TransactionPayload{
+		Payload: signedNewProcessPayload(t, signer, app.ChainID(), entity, uri),
+	})
+	c.Assert(code, qt.Equals, apirest.HTTPstatusOK)
+	c.Assert(res.Submitted, qt.HasLen, 1)
+	c.Assert(res.Submitted[0].MetadataURL, qt.Equals, "")
+
+	// raw metadata + no URI -> whole batch rejected.
+	code, _ = post(TransactionPayload{
+		Payload:  signedNewProcessPayload(t, signer, app.ChainID(), entity, ""),
+		Metadata: raw,
+	})
+	c.Assert(code, qt.Equals, ErrMetadataProvidedButNoURI.HTTPstatus)
 }

--- a/api/chain_batch_test.go
+++ b/api/chain_batch_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/types"
+)
+
+// TestClassifyTransactionBatch checks the fail-fast grouping: submission stops at
+// the first failure, every input item lands in exactly one group, and each item
+// carries its predicted processId (including the unsent pending ones).
+func TestClassifyTransactionBatch(t *testing.T) {
+	c := qt.New(t)
+
+	txs := []Transaction{
+		{Payload: []byte("a")},
+		{Payload: []byte("b")},
+		{Payload: []byte("bad")}, // fails to submit
+		{Payload: []byte("d")},   // must never be submitted (fail-fast)
+	}
+
+	// predicted processId = "pid-" + payload, for every item.
+	processID := func(p []byte) []byte { return append([]byte("pid-"), p...) }
+
+	var sent [][]byte
+	send := func(p []byte) (hash, response []byte, code uint32, err error) {
+		sent = append(sent, p)
+		if string(p) == "bad" {
+			return nil, nil, 0, fmt.Errorf("boom")
+		}
+		return append([]byte("hash-"), p...), nil, 0, nil
+	}
+
+	res := classifyTransactionBatch(txs, processID, send)
+
+	// grouping
+	c.Assert(res.Submitted, qt.HasLen, 2)
+	c.Assert(res.Failed, qt.HasLen, 1)
+	c.Assert(res.Pending, qt.HasLen, 1)
+	// every input item appears exactly once
+	c.Assert(len(res.Submitted)+len(res.Failed)+len(res.Pending), qt.Equals, len(txs))
+
+	// fail-fast: only "a", "b", "bad" were ever submitted; "d" was not.
+	c.Assert(sent, qt.HasLen, 3)
+	c.Assert(sent[2], qt.DeepEquals, []byte("bad"))
+
+	// the failed item carries its error and predicted id
+	c.Assert(res.Failed[0].Error, qt.Equals, "boom")
+	c.Assert(res.Failed[0].ProcessID, qt.DeepEquals, types.HexBytes("pid-bad"))
+	// the pending (unsent) item still carries its predicted id and no hash
+	c.Assert(res.Pending[0].ProcessID, qt.DeepEquals, types.HexBytes("pid-d"))
+	c.Assert(res.Pending[0].Hash, qt.IsNil)
+	// submitted items carry their hash
+	c.Assert(res.Submitted[0].Hash, qt.DeepEquals, types.HexBytes("hash-a"))
+}

--- a/api/docs/descriptions/chainSendTxBatchHandler.md
+++ b/api/docs/descriptions/chainSendTxBatchHandler.md
@@ -1,0 +1,13 @@
+Submits several pre-signed transactions in a single request, **in order**.
+
+The transactions are submitted sequentially and **fail-fast**: the first one that fails to be submitted is placed in `failed` and submission stops, leaving the remaining transactions in `pending`. Every input transaction is returned in exactly one group:
+
+- `submitted`: accepted by the mempool (broadcast).
+- `failed`: the first transaction that failed to be submitted (its `error` is set).
+- `pending`: the transactions after the failed one, which were not sent.
+
+For a `NewProcess` (create election) transaction, each item includes its predicted `processId`.
+
+> **Note:** `submitted` means the mempool accepted the broadcast, **not** that the transaction is included in a block. A mempool-accepted transaction can still be discarded at commit (for example, a stale or contended account nonce, which is not checked at mempool admission). The caller must confirm each `submitted` item on-chain (e.g. via [`chain/transactions/reference/{hash}`](transaction-by-reference)) and resubmit any that did not land, together with the `failed` and `pending` items, reusing the same account nonces.
+
+Intended for creating multiple dependent processes at once: build and sign all transactions up front with contiguous account nonces (and, for elections, predicted `processId`s), then submit them together so they land in the same block in order.

--- a/api/errors.go
+++ b/api/errors.go
@@ -85,6 +85,7 @@ var (
 	ErrPageNotFound                     = apirest.APIerror{Code: 4057, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("page not found")}
 	ErrCantParseDate                    = apirest.APIerror{Code: 4058, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse date")}
 	ErrTransactionBatchTooLarge         = apirest.APIerror{Code: 4059, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("transaction batch too large")}
+	ErrTransactionBatchEmpty            = apirest.APIerror{Code: 4060, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("transaction batch is empty")}
 	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
 	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
 	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}

--- a/api/errors.go
+++ b/api/errors.go
@@ -84,6 +84,7 @@ var (
 	ErrCantParseHexString               = apirest.APIerror{Code: 4056, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse string into hex bytes")}
 	ErrPageNotFound                     = apirest.APIerror{Code: 4057, HTTPstatus: apirest.HTTPstatusNotFound, Err: fmt.Errorf("page not found")}
 	ErrCantParseDate                    = apirest.APIerror{Code: 4058, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("cannot parse date")}
+	ErrTransactionBatchTooLarge         = apirest.APIerror{Code: 4059, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("transaction batch too large")}
 	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
 	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
 	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}

--- a/apiclient/helpers.go
+++ b/apiclient/helpers.go
@@ -95,21 +95,20 @@ func (c *HTTPclient) SendTx(marshaledSignedTx []byte) (types.HexBytes, []byte, e
 	return tx.Hash, tx.Response, nil
 }
 
-// SendTxBatch submits several protobuf-marshaled models.SignedTx at once, in
-// order, to POST /chain/transactions/batch. The transactions must carry
-// contiguous account nonces; the caller is responsible for building/signing them
-// with predicted nonces (and, for NewProcess, predicted processIds).
+// SendTxBatch submits several transactions at once, in order, to
+// POST /chain/transactions/batch. Each item carries a protobuf-marshaled
+// models.SignedTx in Payload and, for a NewProcess, may carry the raw election
+// Metadata (which is validated against the tx's metadata URI and pinned to IPFS,
+// same as POST /elections). The transactions must carry contiguous account nonces;
+// the caller is responsible for building/signing them with predicted nonces (and,
+// for NewProcess, predicted processIds).
 //
 // The result groups every input transaction into submitted / failed / pending.
 // "submitted" means the mempool accepted it, NOT that it is block-confirmed — the
 // caller must confirm each submitted item on-chain (e.g. WaitUntilTxIsMined) and
 // resubmit any that did not land together with the failed and pending items.
-func (c *HTTPclient) SendTxBatch(marshaledSignedTxs [][]byte) (*api.TransactionBatchResult, error) {
-	batch := &api.TransactionBatch{Transactions: make([]api.TransactionPayload, len(marshaledSignedTxs))}
-	for i, tx := range marshaledSignedTxs {
-		batch.Transactions[i] = api.TransactionPayload{Payload: tx}
-	}
-	resp, code, err := c.Request(HTTPPOST, batch, "chain", "transactions", "batch")
+func (c *HTTPclient) SendTxBatch(txs []api.TransactionPayload) (*api.TransactionBatchResult, error) {
+	resp, code, err := c.Request(HTTPPOST, &api.TransactionBatch{Transactions: txs}, "chain", "transactions", "batch")
 	if err != nil {
 		return nil, err
 	}

--- a/apiclient/helpers.go
+++ b/apiclient/helpers.go
@@ -95,6 +95,34 @@ func (c *HTTPclient) SendTx(marshaledSignedTx []byte) (types.HexBytes, []byte, e
 	return tx.Hash, tx.Response, nil
 }
 
+// SendTxBatch submits several protobuf-marshaled models.SignedTx at once, in
+// order, to POST /chain/transactions/batch. The transactions must carry
+// contiguous account nonces; the caller is responsible for building/signing them
+// with predicted nonces (and, for NewProcess, predicted processIds).
+//
+// The result groups every input transaction into submitted / failed / pending.
+// "submitted" means the mempool accepted it, NOT that it is block-confirmed — the
+// caller must confirm each submitted item on-chain (e.g. WaitUntilTxIsMined) and
+// resubmit any that did not land together with the failed and pending items.
+func (c *HTTPclient) SendTxBatch(marshaledSignedTxs [][]byte) (*api.TransactionBatchResult, error) {
+	batch := &api.TransactionBatch{Transactions: make([]api.Transaction, len(marshaledSignedTxs))}
+	for i, tx := range marshaledSignedTxs {
+		batch.Transactions[i] = api.Transaction{Payload: tx}
+	}
+	resp, code, err := c.Request(HTTPPOST, batch, "chain", "transactions", "batch")
+	if err != nil {
+		return nil, err
+	}
+	if code != apirest.HTTPstatusOK {
+		return nil, fmt.Errorf("%s: %d (%s)", errCodeNot200, code, resp)
+	}
+	result := &api.TransactionBatchResult{}
+	if err := json.Unmarshal(resp, result); err != nil {
+		return nil, fmt.Errorf("could not decode response: %w", err)
+	}
+	return result, nil
+}
+
 // WaitUntilNextBlock waits until next block, and returns nil
 //
 // It uses a context.WithTimeout(24s) before giving up and returning ctx.Err()

--- a/apiclient/helpers.go
+++ b/apiclient/helpers.go
@@ -105,9 +105,9 @@ func (c *HTTPclient) SendTx(marshaledSignedTx []byte) (types.HexBytes, []byte, e
 // caller must confirm each submitted item on-chain (e.g. WaitUntilTxIsMined) and
 // resubmit any that did not land together with the failed and pending items.
 func (c *HTTPclient) SendTxBatch(marshaledSignedTxs [][]byte) (*api.TransactionBatchResult, error) {
-	batch := &api.TransactionBatch{Transactions: make([]api.Transaction, len(marshaledSignedTxs))}
+	batch := &api.TransactionBatch{Transactions: make([]api.TransactionPayload, len(marshaledSignedTxs))}
 	for i, tx := range marshaledSignedTxs {
-		batch.Transactions[i] = api.Transaction{Payload: tx}
+		batch.Transactions[i] = api.TransactionPayload{Payload: tx}
 	}
 	resp, code, err := c.Request(HTTPPOST, batch, "chain", "transactions", "batch")
 	if err != nil {


### PR DESCRIPTION
Adds a generic endpoint to submit **multiple pre-signed transactions in one call, in order** — aimed at creating several dependent processes (e.g. elections) reliably.

## Problem
Creating N elections back-to-back is error-prone. A `NewProcessTx` carries two per-account counters that only advance **on commit**: the account `Nonce` (exact-match) and the `ProcessIndex` that derives the deterministic `electionID`. Submission is fire-and-forget (`BroadcastTxSync` returns before the block) and the nonce isn't checked at mempool. So today a client must wait for A to commit before it can build B with the right nonce/id; fire two back-to-back and the second gets a stale nonce → accepted at submit (HTTP 200) → **silently discarded** at block proposal.

## What this adds
`POST /chain/transactions/batch` — accepts `{ transactions: [{payload, metadata?}, ...] }` where `payload` is a pre-signed `models.SignedTx` and `metadata` is optional raw election metadata. It submits them **in order** and returns **every** input item grouped by submission outcome:

- **submitted** — accepted by the mempool (sent),
- **failed** — the first item that failed to submit (with `error`); submission **stops** here (fail-fast),
- **pending** — the items after it that were **not sent**.

Each response item is `{hash, processId, code, error, metadataURL}`. For a `NewProcess`, `processId` is the **predicted** id, computed server-side via `processid.BuildProcessID` with a per-creator positional delta — the exact id the chain assigns in ordered commit (the submit response's `res.Data` can't be used: it repeats the first id for the whole batch). When `EntityId` is unset the organization is defaulted to the recovered tx signer, mirroring `NewProcessTxCheck`.

Why fail-fast: the account nonce is strictly sequential and a failed `NewProcess` consumes no nonce, so everything after a failure is un-committable anyway — continuing would only return misleading "accepted" statuses for doomed txs. The batch commits a prefix; predicted ids are stable, so the caller retries the `failed`+`pending` items in the same nonce slots and each lands on its original id.

## Metadata (same as POST /elections)
For a `NewProcess` item that provides raw `metadata`: the tx must carry a matching metadata URI (else `ErrMetadataProvidedButNoURI`), the recomputed CID must equal the URI (else `ErrMetadataURINotMatchContent`), and the metadata is **pinned to IPFS** after the item is submitted (best-effort), returned as `metadataURL`. Raw metadata is optional (a URI-only tx is submitted, just not pinned). Metadata is validated **up front for the whole batch** — a metadata mistake returns 400 and nothing is submitted.

## Robustness (important)
**`submitted` means broadcast-accepted, NOT block-confirmed.** A mempool-accepted tx can still be discarded at commit (stale/contended nonce, cumulative-balance shortfall). This is a thin, fast, no-consensus-change endpoint by design — **the caller confirms each `submitted` item on-chain and retries**. `code` on submitted items is always 0 (a non-zero CheckTx code turns the item into `failed`).

## Limits
Max **100** transactions per batch (`ErrTransactionBatchTooLarge`); empty batch → `ErrTransactionBatchEmpty`.

## Changes
- `api/chain.go` — `chainSendTxBatchHandler` (metadata validation → `classifyTransactionBatch` fail-fast grouping → best-effort IPFS pin of submitted items), `batchProcessID` (decode + per-`EntityId` delta + signer-recovery fallback), `checkBatchItemMetadata`, route registration. Reuses `a.sendTx`, `processid.BuildProcessID`, `ipfs.*`; no consensus code.
- `api/api_types.go` — `TransactionPayload` (request item: `payload` + optional `metadata`), `TransactionBatchItem` (`hash`/`processId`/`code`/`error`/`metadataURL`), `TransactionBatch`, `TransactionBatchResult`.
- `api/errors.go` — `ErrTransactionBatchTooLarge`, `ErrTransactionBatchEmpty`.
- `api/docs/descriptions/chainSendTxBatchHandler.md` — endpoint docs for swagger.
- `apiclient/helpers.go` — `SendTxBatch([]api.TransactionPayload)` (supports per-item metadata).
- `api/chain_batch_test.go` — tests.

## Verification
- `go build ./...`, `go vet`, `gofumpt`, `go generate` clean.
- `go test ./api/ -run Batch`: `TestClassifyTransactionBatch` (fail-fast grouping), `TestChainSendTxBatchHandler` (HTTP grouping + empty-batch), `TestBatchProcessID` (decode/delta/BuildProcessID incl. EntityId-unset), `TestChainSendTxBatchMetadata` (match/mismatch/URI-without-metadata/metadata-without-URI).

## Follow-ups (out of scope)
- `apiclient.NewElectionBatch` — a build-and-sign helper that pre-computes nonces/ids for N elections; pairs with an e2e test against `voconed`.
- Stronger guarantees if ever needed: a server-confirmed (blocking) variant, or an **atomic** multi-process tx (one nonce, all-or-nothing) — the latter a height-gated consensus change.
- Request body-size hardening (unbounded `io.ReadAll`) — API-wide concern, tracked separately.