### PR TITLE
ci: fix swagger docs action on Go 1.26

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -27,10 +27,14 @@ jobs:
           go-version: '1.26'
           cache: false
       - name: Install swag
+        # Build swag from source with the job's Go toolchain so its go/parser
+        # matches the stdlib syntax that --parseDependency/--parseInternal walk.
+        # A prebuilt binary embeds an older parser and fails on Go 1.26 stdlib.
         run: |
-          curl -L https://github.com/swaggo/swag/releases/download/v1.16.3/swag_1.16.3_Linux_amd64.tar.gz | tar -xzf -
+          go install github.com/swaggo/swag/cmd/swag@v1.16.6
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Run swag
-        run: ./swag init --parseDependency --parseDepth 1 --parseInternal --md api/docs/descriptions --overridesFile api/docs/.swaggo -g api.go -d api/,api/docs/models/ -o api/docs --ot yaml
+        run: swag init --parseDependency --parseDepth 1 --parseInternal --md api/docs/descriptions --overridesFile api/docs/.swaggo -g api.go -d api/,api/docs/models/ -o api/docs --ot yaml
       - name: Install api-spec-converter
         run: npm install -g api-spec-converter
       - name: Convert the Swagger file to OAS3 format


### PR DESCRIPTION
The **API Swagger Docs** workflow (`Generate vocdoni-api.yaml`) has failed on `main` since the Go 1.26 upgrade.

## Root cause

The `Install swag` step downloads the **prebuilt `swag v1.16.3` binary**. A prebuilt swag embeds the `go/parser` of the older Go it was compiled with. Because `swag init` runs with `--parseDependency --parseInternal`, it walks the **Go 1.26 standard library**, and that old parser chokes on newer generics syntax:

```
failed to parse file .../go/1.26.4/.../crypto/x509/constraints.go:67:46: unexpected comma; expecting ]
```

It's a parser-version mismatch, not an annotation bug — and it's unrelated to any given PR's changes (it fails on `main` too). Bumping to a newer *prebuilt* binary wouldn't reliably help either (v1.16.6's binary was built before Go 1.26).

## Fix

Build swag **from source with the job's Go 1.26 toolchain** (the job already runs `actions/setup-go@v5` with `go-version: '1.26'`), so its parser matches the stdlib it parses. Pinned to **v1.16.6** (latest stable v1) for reproducibility, and called from `PATH`:

```yaml
- name: Install swag
  run: |
    go install github.com/swaggo/swag/cmd/swag@v1.16.6
    echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
- name: Run swag
  run: swag init --parseDependency ... (unchanged)
```

Only `.github/workflows/swagger.yml` changes; everything downstream (api-spec-converter, yq, the developer-portal diff/PR) is untouched. Stayed on swag v1 (the workflow emits Swagger 2.0 → OAS3; v2 has a different CLI/output).

## Verified locally

With Go 1.26.4: `go install github.com/swaggo/swag/cmd/swag@v1.16.6` then the **exact** `swag init …` command → **exit 0**, produces `api/docs/swagger.yaml`, **no `constraints.go` parse error**.

## Expected side effect

On the first green run, the workflow regenerates `vocdoni-api.yaml`; the v1.16.3→v1.16.6 output differences plus the API drift accumulated while the job was broken will show up as a (possibly large) auto-PR to `vocdoni/developer-portal` (reviewed there). On `pull_request` events it only posts a diff comment.

Sources: swaggo/swag [#1162](https://github.com/swaggo/swag/issues/1162), [#1213](https://github.com/swaggo/swag/issues/1213), [releases](https://github.com/swaggo/swag/releases).