### PR TITLE
vochain: fix CSP salted-proof salt derivation (cross-election reuse + weight binding)

### DIFF
--- a/api/census_test.go
+++ b/api/census_test.go
@@ -15,10 +15,12 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/saltedkey"
 	"go.vocdoni.io/dvote/data/ipfs"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/metadb"
 	"go.vocdoni.io/dvote/httprouter"
+	"go.vocdoni.io/dvote/test/testcommon/testcsp"
 	"go.vocdoni.io/dvote/test/testcommon/testutil"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/vochain"
@@ -221,6 +223,7 @@ func TestCensusProofVerifierArbo(t *testing.T) {
 	// verify the proof
 	electionID := rnd.RandomBytes(32)
 	valid, weight, err := transaction.VerifyProof(
+		app.ChainID(),
 		&models.Process{
 			ProcessId:    electionID,
 			CensusRoot:   censusData.CensusID,
@@ -332,6 +335,7 @@ func TestCensusZk(t *testing.T) {
 	// verify the proof
 	electionID := util.RandomBytes(32)
 	valid, newWeight, err := transaction.VerifyProof(
+		app.ChainID(),
 		&models.Process{
 			ProcessId:    electionID,
 			CensusRoot:   censusData.CensusID,
@@ -413,6 +417,7 @@ func TestCensusProofVerifierCSP(t *testing.T) {
 
 	// verify the proof
 	valid, weight, err := transaction.VerifyProof(
+		app.ChainID(),
 		process,
 		&models.VoteEnvelope{
 			Nonce:     util.RandomBytes(32),
@@ -488,6 +493,7 @@ func TestCensusProofVerifierCSPLegacy(t *testing.T) {
 
 	// verify the proof
 	valid, weight, err := transaction.VerifyProof(
+		app.ChainID(),
 		process,
 		&models.VoteEnvelope{
 			Nonce:     util.RandomBytes(32),
@@ -508,4 +514,66 @@ func TestCensusProofVerifierCSPLegacy(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, valid, qt.IsTrue)
 	qt.Assert(t, weight.Int64(), qt.Equals, int64(1))
+}
+
+// TestCensusProofVerifierCSPSalted covers the salted CSP proof types through the
+// transaction.VerifyProof dispatch, on a chain where the fixed salt derivation
+// (issue #1424) is active: the weight travels bound inside the salt.
+func TestCensusProofVerifierCSPSalted(t *testing.T) {
+	app := vochain.TestBaseApplicationWithChainID(t, "vocdoni/TEST/1")
+
+	signer, err := testcsp.NewSigner()
+	qt.Assert(t, err, qt.IsNil)
+
+	vp, err := state.NewVotePackage([]int{1, 2, 3, 4}).Encode()
+	qt.Assert(t, err, qt.IsNil)
+
+	for _, proofType := range []models.ProofCA_Type{
+		models.ProofCA_ECDSA_PIDSALTED,
+		models.ProofCA_ECDSA_BLIND_PIDSALTED,
+	} {
+		t.Run(proofType.String(), func(t *testing.T) {
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+
+			pid := util.RandomBytes(types.ProcessIDsize)
+			process := &models.Process{
+				ProcessId:     pid,
+				StartTime:     0,
+				EnvelopeType:  &models.EnvelopeType{EncryptedVotes: false},
+				Mode:          new(models.ProcessMode),
+				Status:        models.ProcessStatus_READY,
+				EntityId:      util.RandomBytes(types.EthereumAddressSize),
+				CensusRoot:    root,
+				CensusOrigin:  models.CensusOrigin_OFF_CHAIN_CA,
+				BlockCount:    1024,
+				MaxCensusSize: 1000,
+			}
+			qt.Assert(t, app.State.AddProcess(process), qt.IsNil)
+
+			k := ethereum.NewSignKeys()
+			qt.Assert(t, k.Generate(), qt.IsNil)
+			weight := big.NewInt(testParticipantWeight)
+			salt, err := saltedkey.Salt(pid, weight.Bytes())
+			qt.Assert(t, err, qt.IsNil)
+			proof, err := signer.SignProof(proofType,
+				testcsp.Bundle(pid, k.Address().Bytes(), weight), salt)
+			qt.Assert(t, err, qt.IsNil)
+
+			valid, gotWeight, err := transaction.VerifyProof(
+				app.ChainID(),
+				process,
+				&models.VoteEnvelope{
+					Nonce:       util.RandomBytes(32),
+					ProcessId:   pid,
+					Proof:       proof,
+					VotePackage: vp,
+				},
+				state.NewVoterID(state.VoterIDTypeECDSA, k.PublicKey()),
+			)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, valid, qt.IsTrue)
+			qt.Assert(t, gotWeight.Int64(), qt.Equals, testParticipantWeight)
+		})
+	}
 }

--- a/cmd/end2endtest/csp.go
+++ b/cmd/end2endtest/csp.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"fmt"
+	"math/big"
 	"os"
 	"time"
 
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/test/testcommon/testcsp"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
@@ -17,6 +19,13 @@ func init() {
 		},
 		description: "csp election",
 		example:     os.Args[0] + " --operation=cspelection --votes=1000",
+	}
+	ops["cspelectionblindsalted"] = operation{
+		testFunc: func() VochainTest {
+			return &E2ECSPBlindSaltedElection{}
+		},
+		description: "csp election with weighted blind pid-salted proofs (issue #1424 derivation)",
+		example:     os.Args[0] + " --operation=cspelectionblindsalted --votes=1000",
 	}
 }
 
@@ -86,4 +95,24 @@ func (t *E2ECSPElection) Run() error {
 	log.Infof("election results: %v", elres.Results)
 
 	return nil
+}
+
+var _ VochainTest = (*E2ECSPBlindSaltedElection)(nil)
+
+// E2ECSPBlindSaltedElection runs a CSP election where every proof is
+// ECDSA_BLIND_PIDSALTED with a CSP-authorized weight, exercising end to end the
+// salt derivation of issue #1424 on chains where it is active.
+type E2ECSPBlindSaltedElection struct {
+	E2ECSPElection
+}
+
+func (t *E2ECSPBlindSaltedElection) Setup(api *apiclient.HTTPclient, c *config) error {
+	signer, err := testcsp.NewSigner()
+	if err != nil {
+		return err
+	}
+	t.cspSigner = signer
+	t.cspProofType = models.ProofCA_ECDSA_BLIND_PIDSALTED
+	t.cspVoteWeight = big.NewInt(10)
+	return t.E2ECSPElection.Setup(api, c)
 }

--- a/cmd/end2endtest/helpers.go
+++ b/cmd/end2endtest/helpers.go
@@ -15,9 +15,12 @@ import (
 	vapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/saltedkey"
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/test/testcommon/testcsp"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
+	"go.vocdoni.io/dvote/vochain/genesis"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )
@@ -203,6 +206,9 @@ func (t *e2eElection) generateProofs(csp *ethereum.SignKeys, voterAccts []*ether
 		for _, acc := range accounts {
 			voterKey := acc.Address().Bytes()
 			proof, err := func() (*apiclient.CensusProof, error) {
+				if t.cspSigner != nil {
+					return t.cspGenProofSalted(voterKey)
+				}
 				if csp != nil {
 					return cspGenProof(t.election.ElectionID, voterKey, csp)
 				}
@@ -438,6 +444,14 @@ func (t *e2eElection) setupElectionRaw(prc *models.Process) error {
 	case models.CensusOrigin_OFF_CHAIN_CA:
 		voterAccounts = ethereum.NewSignKeysBatch(t.config.nvotes)
 
+		if t.cspSigner != nil {
+			censusRoot, err := t.cspSigner.CensusRoot(t.cspProofType)
+			if err != nil {
+				return err
+			}
+			prc.CensusRoot = censusRoot
+			break
+		}
 		if err := csp.Generate(); err != nil {
 			return err
 		}
@@ -643,6 +657,37 @@ func votesToBigInt(votes ...uint64) []*types.BigInt {
 		vBigInt[i] = new(types.BigInt).SetUint64(v)
 	}
 	return vBigInt
+}
+
+// cspGenProofSalted issues a t.cspProofType proof for the running election,
+// signed by t.cspSigner with the salt derivation the chain expects. It evaluates
+// the same public predicate an external CSP service uses to pick the
+// derivation: election startDate versus the per-chain fork table.
+func (t *e2eElection) cspGenProofSalted(voterKey []byte) (*apiclient.CensusProof, error) {
+	pid := t.election.ElectionID
+	bundle := testcsp.Bundle(pid, voterKey, t.cspVoteWeight)
+
+	salt := []byte(pid) // legacy derivation: the raw processID
+	if genesis.CSPSaltedProofV2Active(t.api.ChainID(), uint32(t.election.StartDate.Unix())) {
+		var weightBytes []byte
+		if t.cspVoteWeight != nil {
+			weightBytes = t.cspVoteWeight.Bytes()
+		}
+		var err error
+		if salt, err = saltedkey.Salt(pid, weightBytes); err != nil {
+			return nil, err
+		}
+	}
+
+	caProof, err := t.cspSigner.Sign(t.cspProofType, bundle, salt)
+	if err != nil {
+		return nil, err
+	}
+	caProofBytes, err := proto.Marshal(caProof)
+	if err != nil {
+		return nil, err
+	}
+	return &apiclient.CensusProof{Proof: caProofBytes}, nil
 }
 
 func cspGenProof(pid, voterKey []byte, csp *ethereum.SignKeys) (*apiclient.CensusProof, error) {

--- a/cmd/end2endtest/main.go
+++ b/cmd/end2endtest/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"sync"
@@ -14,7 +15,9 @@ import (
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/internal"
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/test/testcommon/testcsp"
 	"go.vocdoni.io/dvote/util"
+	"go.vocdoni.io/proto/build/go/models"
 )
 
 // how many times to retry flaky transactions
@@ -43,6 +46,12 @@ type e2eElection struct {
 	config   *config
 	election *vapi.Election
 	voters   *sync.Map // key:acc.Public, value: acctProof struct {account, proof, proofSik}
+
+	// cspSigner, when set on an OFF_CHAIN_CA election, issues the CSP proofs
+	// as cspProofType with cspVoteWeight, instead of the default plain ECDSA
+	cspSigner     *testcsp.Signer
+	cspProofType  models.ProofCA_Type
+	cspVoteWeight *big.Int
 }
 
 type operation struct {

--- a/crypto/saltedkey/saltedkey.go
+++ b/crypto/saltedkey/saltedkey.go
@@ -1,8 +1,17 @@
+// Package saltedkey derives the salted CSP keys used by the salted vote proofs
+// (models.ProofCA_ECDSA_PIDSALTED and models.ProofCA_ECDSA_BLIND_PIDSALTED).
+//
+// A salted proof binds a CSP authorization to one election: the CSP signs with
+// the private key d' = (d + salt) mod n, and the chain verifies against the
+// public key Q' = Q + salt*G, where both sides derive salt independently from
+// the election. See Salt for the derivation and its rationale.
 package saltedkey
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
+	"math/big"
 
 	blind "github.com/arnaucube/go-blindsecp256k1"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -10,6 +19,83 @@ import (
 
 // SaltSize is the size (in bytes) of the salt word
 const SaltSize = 20
+
+// MaxVoteWeightBits is the maximum bit length accepted for a CSP-authorized
+// vote weight by Salt.
+const MaxVoteWeightBits = SaltSize * 8
+
+// ErrVoteWeightOverflow is returned by Salt when the vote weight does not fit
+// in MaxVoteWeightBits bits.
+var ErrVoteWeightOverflow = errors.New("vote weight exceeds the maximum salt size")
+
+// weightEncodingBytes is the fixed width the vote weight is rendered to before
+// hashing, so every byte encoding of the same integer yields the same salt.
+const weightEncodingBytes = 32
+
+// Salt derives the salt applied to the CSP key for a salted proof
+// (models.ProofCA_ECDSA_PIDSALTED and models.ProofCA_ECDSA_BLIND_PIDSALTED) of
+// the given election and CSP-authorized vote weight.
+//
+//	w    = big-endian unsigned integer of voteWeight; 1 when voteWeight is absent
+//	         reject if w >= 2^160
+//	salt = keccak256( processID || w-as-32-big-endian-bytes )[:20]
+//
+// The signer derives the matching private key as d' = (d + uint(salt)) mod n
+// (SaltECDSAPrivKey, SaltBlindPrivKey); the verifier derives the matching public
+// key as Q' = Q + uint(salt)*G (SaltECDSAPubKey, SaltBlindPubKey).
+//
+// Why the whole processID and the weight go through the hash: the processID
+// layout is chainID[6] + orgAddr[20] + censusOrigin[1] + envType[1] + nonce[4],
+// so its first 20 bytes — all the salting primitives consume — are chainID[6] +
+// orgAddr[:14]. Passing the raw processID meant every election of the same
+// organization on the same chain derived one salt, hence one salted keypair;
+// because the CSP signs a message it cannot read in the blind flow, a voter
+// authorized for one election could have a bundle for a sibling election
+// blind-signed and it would verify. Hashing spreads all 32 bytes, including the
+// nonce, over the salt, and binds the CSP-authorized weight into it too — a
+// voter who alters bundle.voteWeight derives a different salt, so the signature
+// no longer verifies.
+//
+// Why hash both inputs rather than add them. An earlier version used
+// salt = keccak256(pid)[:20] + w mod 2^160. That is additively malleable: the
+// verifier re-derives the salt from the voter-chosen w, so a voter holding a
+// blind signature valid for saltA = keccak256(pidA)[:20] + 1 can present a
+// bundle for election B declaring w' = (saltA - keccak256(pidB)[:20]) mod 2^160,
+// making election B derive the identical salt. Both the cross-election and the
+// weight binding collapse, with no crypto — the attacker just chooses the
+// verifier's salt input. Hashing both inputs removes that handle: hitting a
+// target salt needs a keccak preimage collision.
+//
+// Why a fixed 32-byte weight: bundle.voteWeight is variable-length, and 0x05 and
+// 0x0005 both decode to (and are recorded on-chain as) the integer 5. Hashing
+// the raw bytes would give two salts for one recorded weight — a malleability
+// seam. Rendering the parsed integer to a fixed width collapses every encoding
+// to one preimage, so the salt binds exactly the integer the chain records.
+//
+// Why an absent weight is treated as 1: an absent voteWeight and a voteWeight of
+// 1 already yield the same on-chain weight, so they must yield the same salt.
+//
+// The MaxVoteWeightBits guard is a sane cap and keeps FillBytes safe (it would
+// panic if w did not fit in weightEncodingBytes); it is not otherwise
+// load-bearing. SaltSize stays 20, so the salting primitives and every
+// already-deployed CSP keep working unchanged — only the hash preimage changes.
+//
+// There is no domain-separation tag: this is the only derivation, and the salt
+// is only ever consumed by the key-salting primitives in this package.
+//
+// Mirrored by vocdoni/blind-csp, vocdoni/saas-backend (csp/sign.go,
+// csp/sign_blind.go) and vocdoni/vocdoni-sdk. Activation is per-election, see
+// vochain/genesis.CSPSaltedProofV2Active.
+func Salt(processID, voteWeight []byte) ([]byte, error) {
+	weight := big.NewInt(1)
+	if voteWeight != nil {
+		weight = new(big.Int).SetBytes(voteWeight)
+	}
+	if weight.BitLen() > MaxVoteWeightBits {
+		return nil, ErrVoteWeightOverflow
+	}
+	return ethcrypto.Keccak256(processID, weight.FillBytes(make([]byte, weightEncodingBytes)))[:SaltSize], nil
+}
 
 // SaltBlindPubKey returns the salted blind public key of pubKey applying the salt.
 func SaltBlindPubKey(pubKey *blind.PublicKey, salt []byte) (*blind.PublicKey, error) {
@@ -40,6 +126,43 @@ func SaltECDSAPubKey(pubKey *ecdsa.PublicKey, salt []byte) (*ecdsa.PublicKey, er
 	var salt2 [SaltSize]byte
 	copy(salt2[:], salt[:SaltSize])
 	x, y := pubKey.Curve.ScalarBaseMult(salt2[:])
-	pubKey.X, pubKey.Y = pubKey.Curve.Add(pubKey.X, pubKey.Y, x, y)
-	return pubKey, nil
+	saltedX, saltedY := pubKey.Curve.Add(pubKey.X, pubKey.Y, x, y)
+	return &ecdsa.PublicKey{Curve: pubKey.Curve, X: saltedX, Y: saltedY}, nil
+}
+
+// SaltBlindPrivKey returns the salted blind private key of privKey applying the
+// salt. It is the signer-side counterpart of SaltBlindPubKey.
+func SaltBlindPrivKey(privKey *blind.PrivateKey, salt []byte) (*blind.PrivateKey, error) {
+	if privKey == nil {
+		return nil, fmt.Errorf("private key is nil")
+	}
+	d, err := saltScalar(privKey.BigInt(), salt)
+	if err != nil {
+		return nil, err
+	}
+	return (*blind.PrivateKey)(d), nil
+}
+
+// SaltECDSAPrivKey returns the salted plain private key of privKey applying the
+// salt. It is the signer-side counterpart of SaltECDSAPubKey.
+func SaltECDSAPrivKey(privKey *ecdsa.PrivateKey, salt []byte) (*ecdsa.PrivateKey, error) {
+	if privKey == nil {
+		return nil, fmt.Errorf("private key is nil")
+	}
+	d, err := saltScalar(privKey.D, salt)
+	if err != nil {
+		return nil, err
+	}
+	return ethcrypto.ToECDSA(d.FillBytes(make([]byte, 32)))
+}
+
+// saltScalar returns (d + salt) mod n, the private-key tweak matching the
+// Q + salt*G applied by the public-key salting functions. As they do, it
+// consumes the first SaltSize bytes of salt.
+func saltScalar(d *big.Int, salt []byte) (*big.Int, error) {
+	if len(salt) < SaltSize {
+		return nil, fmt.Errorf("provided salt is not large enough (need %d bytes)", SaltSize)
+	}
+	s := new(big.Int).SetBytes(salt[:SaltSize])
+	return s.Add(s, d).Mod(s, ethcrypto.S256().Params().N), nil
 }

--- a/crypto/saltedkey/saltedkey_test.go
+++ b/crypto/saltedkey/saltedkey_test.go
@@ -1,0 +1,224 @@
+package saltedkey
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	blind "github.com/arnaucube/go-blindsecp256k1"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	qt "github.com/frankban/quicktest"
+)
+
+// testProcessID builds a 32 byte processID with the real layout:
+// chainID[6] + orgAddr[20] + censusOrigin[1] + envType[1] + nonce[4].
+// Two elections of the same organization on the same chain differ only in the
+// nonce, which lives in the last 4 bytes.
+func testProcessID(nonce uint32) []byte {
+	pid := make([]byte, 32)
+	copy(pid[0:6], []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}) // chainID
+	for i := 6; i < 26; i++ {
+		pid[i] = byte(i) // organization address
+	}
+	pid[26] = 0x03 // census origin
+	pid[27] = 0x00 // envelope type
+	pid[28] = byte(nonce >> 24)
+	pid[29] = byte(nonce >> 16)
+	pid[30] = byte(nonce >> 8)
+	pid[31] = byte(nonce)
+	return pid
+}
+
+func TestSaltDeterministic(t *testing.T) {
+	pid := testProcessID(1)
+	first, err := Salt(pid, big.NewInt(42).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+	second, err := Salt(pid, big.NewInt(42).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+
+	qt.Assert(t, first, qt.DeepEquals, second)
+	qt.Assert(t, len(first), qt.Equals, SaltSize)
+}
+
+// TestSaltDiffersPerProcessID is the regression test for issue #1424: two
+// elections of the same organization on the same chain, differing only in the
+// nonce, must derive different salts. It also pins the legacy behaviour that
+// made them collide, so the fork's two sides stay documented in one place.
+func TestSaltDiffersPerProcessID(t *testing.T) {
+	pidA, pidB := testProcessID(1), testProcessID(2)
+	qt.Assert(t, pidA, qt.Not(qt.DeepEquals), pidB)
+
+	// legacy derivation: the raw processID cropped to SaltSize. The nonce lives
+	// past byte 20, so both elections collide.
+	qt.Assert(t, pidA[:SaltSize], qt.DeepEquals, pidB[:SaltSize])
+
+	saltA, err := Salt(pidA, nil)
+	qt.Assert(t, err, qt.IsNil)
+	saltB, err := Salt(pidB, nil)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, saltA, qt.Not(qt.DeepEquals), saltB)
+
+	// and the new derivation must not accidentally reproduce the legacy one
+	qt.Assert(t, saltA, qt.Not(qt.DeepEquals), pidA[:SaltSize])
+}
+
+func TestSaltDiffersPerWeight(t *testing.T) {
+	pid := testProcessID(1)
+	low, err := Salt(pid, big.NewInt(5).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+	high, err := Salt(pid, big.NewInt(1000).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, low, qt.Not(qt.DeepEquals), high)
+
+	// adjacent weights must differ too
+	next, err := Salt(pid, big.NewInt(6).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, low, qt.Not(qt.DeepEquals), next)
+}
+
+// TestSaltAbsentWeightIsOne checks that an absent voteWeight and a voteWeight of
+// 1 derive the same salt: they already yield the same on-chain weight.
+func TestSaltAbsentWeightIsOne(t *testing.T) {
+	pid := testProcessID(1)
+	absent, err := Salt(pid, nil)
+	qt.Assert(t, err, qt.IsNil)
+	one, err := Salt(pid, big.NewInt(1).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, absent, qt.DeepEquals, one)
+}
+
+// TestSaltRejectsOverflow covers the MaxVoteWeightBits cap: a weight that does
+// not fit is rejected rather than panicking FillBytes.
+func TestSaltRejectsOverflow(t *testing.T) {
+	pid := testProcessID(1)
+	twoTo160 := new(big.Int).Lsh(big.NewInt(1), MaxVoteWeightBits)
+
+	// the largest representable weight is accepted
+	max := new(big.Int).Sub(twoTo160, big.NewInt(1))
+	_, err := Salt(pid, max.Bytes())
+	qt.Assert(t, err, qt.IsNil)
+
+	// exactly 2^160 is rejected (161 bits)
+	_, err = Salt(pid, twoTo160.Bytes())
+	qt.Assert(t, err, qt.Equals, ErrVoteWeightOverflow)
+
+	// and anything larger
+	_, err = Salt(pid, new(big.Int).Add(big.NewInt(5), twoTo160).Bytes())
+	qt.Assert(t, err, qt.Equals, ErrVoteWeightOverflow)
+}
+
+// TestSaltCanonicalWeight pins the fixed-width canonicalization: every byte
+// encoding of the same integer must derive the same salt, so a voter cannot
+// re-encode a weight to shift the salt while the chain records the same value.
+func TestSaltCanonicalWeight(t *testing.T) {
+	pid := testProcessID(1)
+
+	oneByte, err := Salt(pid, []byte{0x05})
+	qt.Assert(t, err, qt.IsNil)
+	padded, err := Salt(pid, []byte{0x00, 0x00, 0x05})
+	qt.Assert(t, err, qt.IsNil)
+	fromInt, err := Salt(pid, big.NewInt(5).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+
+	qt.Assert(t, padded, qt.DeepEquals, oneByte)
+	qt.Assert(t, fromInt, qt.DeepEquals, oneByte)
+
+	// a genuinely different integer still differs
+	other, err := Salt(pid, []byte{0x06})
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, other, qt.Not(qt.DeepEquals), oneByte)
+}
+
+func TestSaltECDSAKeyPairRoundtrip(t *testing.T) {
+	key, err := ethcrypto.GenerateKey()
+	qt.Assert(t, err, qt.IsNil)
+	salt, err := Salt(testProcessID(1), big.NewInt(42).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+
+	saltedPriv, err := SaltECDSAPrivKey(key, salt)
+	qt.Assert(t, err, qt.IsNil)
+	saltedPub, err := SaltECDSAPubKey(&key.PublicKey, salt)
+	qt.Assert(t, err, qt.IsNil)
+
+	qt.Assert(t, saltedPriv.PublicKey.X.String(), qt.Equals, saltedPub.X.String())
+	qt.Assert(t, saltedPriv.PublicKey.Y.String(), qt.Equals, saltedPub.Y.String())
+}
+
+func TestSaltBlindKeyPairRoundtrip(t *testing.T) {
+	key, err := blind.NewPrivateKey()
+	qt.Assert(t, err, qt.IsNil)
+	salt, err := Salt(testProcessID(1), big.NewInt(42).Bytes())
+	qt.Assert(t, err, qt.IsNil)
+
+	saltedPriv, err := SaltBlindPrivKey(key, salt)
+	qt.Assert(t, err, qt.IsNil)
+	saltedPub, err := SaltBlindPubKey(key.Public(), salt)
+	qt.Assert(t, err, qt.IsNil)
+
+	qt.Assert(t, saltedPriv.Public().X.String(), qt.Equals, saltedPub.X.String())
+	qt.Assert(t, saltedPriv.Public().Y.String(), qt.Equals, saltedPub.Y.String())
+}
+
+func TestSaltECDSAPubKeyDoesNotMutateInput(t *testing.T) {
+	key, err := ethcrypto.GenerateKey()
+	qt.Assert(t, err, qt.IsNil)
+	wantX, wantY := key.PublicKey.X.String(), key.PublicKey.Y.String()
+
+	_, err = SaltECDSAPubKey(&key.PublicKey, testProcessID(1))
+	qt.Assert(t, err, qt.IsNil)
+
+	qt.Assert(t, key.PublicKey.X.String(), qt.Equals, wantX)
+	qt.Assert(t, key.PublicKey.Y.String(), qt.Equals, wantY)
+}
+
+// TestSaltPubKeyLegacyTruncation pins the pre-fork behaviour: the salting
+// primitives consume only the first SaltSize bytes, so passing a full 32 byte
+// processID is identical to passing its first 20. Elections that started before
+// the fork rely on this staying exactly as it is.
+func TestSaltPubKeyLegacyTruncation(t *testing.T) {
+	key, err := ethcrypto.GenerateKey()
+	qt.Assert(t, err, qt.IsNil)
+	pid := testProcessID(1)
+
+	full, err := SaltECDSAPubKey(&key.PublicKey, pid)
+	qt.Assert(t, err, qt.IsNil)
+	cropped, err := SaltECDSAPubKey(&key.PublicKey, pid[:SaltSize])
+	qt.Assert(t, err, qt.IsNil)
+
+	qt.Assert(t, full.X.String(), qt.Equals, cropped.X.String())
+	qt.Assert(t, full.Y.String(), qt.Equals, cropped.Y.String())
+}
+
+func TestSaltRejectsShortSalt(t *testing.T) {
+	key, err := ethcrypto.GenerateKey()
+	qt.Assert(t, err, qt.IsNil)
+	short := make([]byte, SaltSize-1)
+
+	_, err = SaltECDSAPubKey(&key.PublicKey, short)
+	qt.Assert(t, err, qt.IsNotNil)
+	_, err = SaltECDSAPrivKey(key, short)
+	qt.Assert(t, err, qt.IsNotNil)
+
+	blindKey, err := blind.NewPrivateKey()
+	qt.Assert(t, err, qt.IsNil)
+	_, err = SaltBlindPubKey(blindKey.Public(), short)
+	qt.Assert(t, err, qt.IsNotNil)
+	_, err = SaltBlindPrivKey(blindKey, short)
+	qt.Assert(t, err, qt.IsNotNil)
+}
+
+// TestSaltNilKeys guards the nil paths, which the salted proof verifier reaches
+// when a census root fails to parse.
+func TestSaltNilKeys(t *testing.T) {
+	salt, err := Salt(testProcessID(1), nil)
+	qt.Assert(t, err, qt.IsNil)
+
+	_, err = SaltECDSAPubKey(nil, salt)
+	qt.Assert(t, err, qt.IsNotNil)
+	_, err = SaltBlindPubKey(nil, salt)
+	qt.Assert(t, err, qt.IsNotNil)
+	_, err = SaltECDSAPrivKey((*ecdsa.PrivateKey)(nil), salt)
+	qt.Assert(t, err, qt.IsNotNil)
+	_, err = SaltBlindPrivKey(nil, salt)
+	qt.Assert(t, err, qt.IsNotNil)
+}

--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -11,6 +11,7 @@
 #  e2etest_ballotelection: run ballot test
 #  e2etest_lifecyclelection: run lifecycle test
 #  e2etest_cspelection: run csp test
+#  e2etest_cspelectionblindsalted: run csp test with weighted blind pid-salted proofs
 #  e2etest_dynamicensuselection: run dynamic census test
 #  e2etest_electiontimebounds: run election time bounds test
 
@@ -57,6 +58,7 @@ tests_to_run=(
   	"e2etest_tokentxs"
   	"e2etest_lifecyclelection"
   	"e2etest_cspelection"
+  	"e2etest_cspelectionblindsalted"
   	"e2etest_dynamicensuselection"
   	"e2etest_electiontimebounds"
 	"test_statesync"
@@ -146,6 +148,10 @@ e2etest_lifecyclelection() {
 
 e2etest_cspelection() {
   e2etest cspelection
+}
+
+e2etest_cspelectionblindsalted() {
+  e2etest cspelectionblindsalted
 }
 
 e2etest_dynamicensuselection() {

--- a/test/testcommon/testcsp/testcsp.go
+++ b/test/testcommon/testcsp/testcsp.go
@@ -1,0 +1,190 @@
+// Package testcsp provides a CSP (Credential Service Provider) signer able to
+// produce all four models.ProofCA types, including the salted variants.
+//
+// This repository only ever verifies CSP proofs (see
+// vochain/transaction/proofs/cspproof); the real signer lives in
+// vocdoni/blind-csp and vocdoni/saas-backend. This package is the signer side
+// needed to test the verifier, and doubles as executable documentation of the
+// derivation those services must mirror.
+//
+// Sign takes the salt explicitly rather than deriving it, so a test states which
+// salt it uses: saltedkey.Salt(pid, weight) for the post-fork rule, the raw
+// processID for the legacy one, or a deliberately mismatched value to build the
+// cross-election and weight-tampering proofs that must be rejected.
+package testcsp
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+
+	blind "github.com/arnaucube/go-blindsecp256k1"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/saltedkey"
+	"go.vocdoni.io/dvote/types"
+	"go.vocdoni.io/proto/build/go/models"
+	"google.golang.org/protobuf/proto"
+)
+
+// blindSignAttempts bounds the retry loop in blindSign. blind.BlindSign rejects
+// a k or a blinded message that does not serialize to exactly 32 bytes, each
+// failing with probability ~1/256, so a single attempt is flaky.
+const blindSignAttempts = 32
+
+// Signer holds the CSP keys: an ECDSA one for the plain proof types and a blind
+// secp256k1 one for the blind types.
+type Signer struct {
+	ECDSA *ethereum.SignKeys
+	Blind *blind.PrivateKey
+}
+
+// NewSigner returns a Signer with freshly generated keys.
+func NewSigner() (*Signer, error) {
+	ecdsaKey := ethereum.NewSignKeys()
+	if err := ecdsaKey.Generate(); err != nil {
+		return nil, fmt.Errorf("cannot generate CSP ECDSA key: %w", err)
+	}
+	blindKey, err := blind.NewPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate CSP blind key: %w", err)
+	}
+	return &Signer{ECDSA: ecdsaKey, Blind: blindKey}, nil
+}
+
+// CensusRoot returns the value to store in process.CensusRoot for proofType.
+//
+// Note the root is always the *unsalted* public key: for the salted types the
+// verifier applies the salt to the root itself.
+func (s *Signer) CensusRoot(proofType models.ProofCA_Type) (types.HexBytes, error) {
+	switch proofType {
+	case models.ProofCA_ECDSA, models.ProofCA_ECDSA_PIDSALTED:
+		return s.ECDSA.PublicKey(), nil
+	case models.ProofCA_ECDSA_BLIND, models.ProofCA_ECDSA_BLIND_PIDSALTED:
+		// the verifier feeds the root through ethereum.DecompressPubKey and then
+		// blind.NewPublicKeyFromECDSA, so it must be an ethereum-serialized key,
+		// not blind.PublicKey.Bytes() (which is little-endian and will not parse)
+		return ethcrypto.CompressPubkey(blindPubToECDSA(s.Blind.Public())), nil
+	default:
+		return nil, fmt.Errorf("unsupported CSP proof type %s", proofType)
+	}
+}
+
+// Bundle builds the CA bundle a voter presents. A nil weight leaves voteWeight
+// absent, which the chain reads as a weight of 1.
+func Bundle(pid, voterAddr []byte, weight *big.Int) *models.CAbundle {
+	bundle := &models.CAbundle{
+		ProcessId: pid,
+		Address:   voterAddr,
+	}
+	if weight != nil {
+		bundle.VoteWeight = weight.Bytes()
+	}
+	return bundle
+}
+
+// Sign issues a CSP proof over bundle, signing with the key salted by salt.
+//
+// salt is ignored for the unsalted proof types. For the salted ones it must be
+// what the verifier will derive for this election, otherwise the proof is
+// expected to fail: that is precisely what the negative tests assert.
+func (s *Signer) Sign(proofType models.ProofCA_Type, bundle *models.CAbundle, salt []byte) (*models.ProofCA, error) {
+	bundleBytes, err := proto.Marshal(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal CSP bundle: %w", err)
+	}
+
+	var signature []byte
+	switch proofType {
+	case models.ProofCA_ECDSA:
+		if signature, err = s.ECDSA.SignEthereum(bundleBytes); err != nil {
+			return nil, fmt.Errorf("cannot sign CSP bundle: %w", err)
+		}
+	case models.ProofCA_ECDSA_PIDSALTED:
+		saltedKey, err := s.saltedECDSA(salt)
+		if err != nil {
+			return nil, err
+		}
+		if signature, err = saltedKey.SignEthereum(bundleBytes); err != nil {
+			return nil, fmt.Errorf("cannot sign CSP bundle with salted key: %w", err)
+		}
+	case models.ProofCA_ECDSA_BLIND:
+		sig, err := blindSign(s.Blind, bundleBytes)
+		if err != nil {
+			return nil, err
+		}
+		signature = sig.BytesUncompressed()
+	case models.ProofCA_ECDSA_BLIND_PIDSALTED:
+		saltedKey, err := saltedkey.SaltBlindPrivKey(s.Blind, salt)
+		if err != nil {
+			return nil, fmt.Errorf("cannot salt CSP blind key: %w", err)
+		}
+		sig, err := blindSign(saltedKey, bundleBytes)
+		if err != nil {
+			return nil, err
+		}
+		signature = sig.BytesUncompressed()
+	default:
+		return nil, fmt.Errorf("unsupported CSP proof type %s", proofType)
+	}
+
+	return &models.ProofCA{
+		Type:      proofType,
+		Bundle:    bundle,
+		Signature: signature,
+	}, nil
+}
+
+// SignProof is Sign wrapped into the marshalled models.Proof a VoteEnvelope
+// carries.
+func (s *Signer) SignProof(proofType models.ProofCA_Type, bundle *models.CAbundle, salt []byte) (*models.Proof, error) {
+	caProof, err := s.Sign(proofType, bundle, salt)
+	if err != nil {
+		return nil, err
+	}
+	return &models.Proof{Payload: &models.Proof_Ca{Ca: caProof}}, nil
+}
+
+// saltedECDSA returns a SignKeys holding the salted ECDSA private key.
+func (s *Signer) saltedECDSA(salt []byte) (*ethereum.SignKeys, error) {
+	saltedPriv, err := saltedkey.SaltECDSAPrivKey(&s.ECDSA.Private, salt)
+	if err != nil {
+		return nil, fmt.Errorf("cannot salt CSP ECDSA key: %w", err)
+	}
+	saltedKey := ethereum.NewSignKeys()
+	if err := saltedKey.AddHexKey(hex.EncodeToString(ethcrypto.FromECDSA(saltedPriv))); err != nil {
+		return nil, fmt.Errorf("cannot load salted CSP ECDSA key: %w", err)
+	}
+	return saltedKey, nil
+}
+
+// blindSign runs the three-leg blind protocol locally, playing both the CSP and
+// the voter. The message is the raw keccak of the bundle, matching what
+// cspproof.Verify feeds to blind.Verify (note: no Ethereum signing prefix here,
+// unlike the plain ECDSA branch).
+func blindSign(sk *blind.PrivateKey, msg []byte) (*blind.Signature, error) {
+	m := new(big.Int).SetBytes(ethereum.HashRaw(msg))
+	for range blindSignAttempts {
+		k, r, err := blind.NewRequestParameters()
+		if err != nil {
+			return nil, fmt.Errorf("cannot create blind request parameters: %w", err)
+		}
+		mBlinded, userSecret, err := blind.Blind(m, r)
+		if err != nil {
+			continue // rejected draw, see blindSignAttempts
+		}
+		sBlind, err := sk.BlindSign(mBlinded, k)
+		if err != nil {
+			continue
+		}
+		return blind.Unblind(sBlind, userSecret), nil
+	}
+	return nil, fmt.Errorf("blind signature failed after %d attempts", blindSignAttempts)
+}
+
+// blindPubToECDSA reinterprets a blind public key as an ECDSA one on secp256k1,
+// so it can be serialized with the go-ethereum helpers the verifier uses.
+func blindPubToECDSA(pk *blind.PublicKey) *ecdsa.PublicKey {
+	return &ecdsa.PublicKey{Curve: ethcrypto.S256(), X: pk.X, Y: pk.Y}
+}

--- a/vochain/apptest.go
+++ b/vochain/apptest.go
@@ -36,6 +36,9 @@ func TestBaseApplicationWithChainID(tb testing.TB, chainID string) *BaseApplicat
 		tb.Fatal(err)
 	}
 	app.SetTestingMethods()
+	// propagate the chainID to the app and the state, as SetupVochain does on a
+	// real node; InitChain below only hands it to cometbft
+	app.SetChainID(chainID)
 	genesisDoc, err := NewTemplateGenesisFile(tb.TempDir(), 4)
 	if err != nil {
 		tb.Fatal(err)

--- a/vochain/genesis/forks.go
+++ b/vochain/genesis/forks.go
@@ -1,0 +1,104 @@
+package genesis
+
+import "math"
+
+/*
+Soft-fork activation via per-election gating.
+
+A soft fork here is a state-affecting protocol change activated per ChainID, so
+every validator switches behavior on the same elections. It is lighter than the
+EndOfChain hard fork documented in genesis.go (no new ChainID / AppHash /
+blockstore reset): the chain and its ChainID continue across the fork.
+
+Why the gate is keyed on the election and not on the block height. Before the
+activation point an upgraded node must produce byte-for-byte the same state as a
+not-yet-upgraded node, so mixed binary versions during the rollout window cannot
+diverge. Height gating cannot give that here, because a vote proof is verified at
+CheckTx and then NOT re-verified at DeliverTx when it is served from the vote
+cache (see vochain/transaction.VoteTxCheck). A vote checked at H-1 under the old
+rule and delivered at H under the new one would be accepted by the proposer,
+which skips re-verification, and rejected by every node that never saw it in its
+mempool: an AppHash divergence, i.e. a chain halt.
+
+Keying on immutable election data removes that class of bug entirely. The
+predicate depends only on the ChainID and on fields fixed when the election was
+created, so it returns the same value at CheckTx and at DeliverTx, on every node,
+regardless of height, wall clock or mempool timing. An election never changes
+rules mid-flight, and an off-chain signer (a CSP) can evaluate the same predicate
+from public election data without polling the chain height.
+
+### Runbook: activating a per-election soft fork on a network
+
+  1. Merge with every production chain set to forkNever. Behavior is identical to
+     the previous release, so the binary can be deployed at any time with zero
+     divergence risk. This decouples "deploy the binary" from "activate the rule".
+  2. Ship the mirrored change in every off-chain component that must agree on the
+     rule (for the CSP fork below: vocdoni/blind-csp, vocdoni/saas-backend,
+     vocdoni/vocdoni-sdk), behind the same predicate, with the activation point
+     still unset. Both sides must be deployable before either activates.
+  3. Confirm out-of-band that every validator AND gateway runs the new image;
+     there is no in-protocol version negotiation. Watchtower auto-pulls (~30s).
+  4. Pick the activation point comfortably after the last node upgrade, the last
+     off-chain upgrade, and the longest lead time with which that network's
+     organizers create elections ahead of their start date.
+  5. Set it for the target ChainID in the fork table below (replace forkNever);
+     one-line commit. Release the binary: merge to the network's release branch
+     (e.g. release-lts-1); CI (docker-release.yml) pushes the image.
+  6. Monitor the first election that activates the rule. Note the risk profile is
+     inverted versus a height fork: node divergence is impossible because the
+     predicate is election-local, but a stale off-chain signer issues proofs the
+     chain rejects. That surfaces as voter-visible failures on one election, not
+     as a chain halt. Watch the signer, not the AppHash.
+  7. Abort/rollback: BEFORE the activation point, ship a binary moving it later
+     (or to forkNever) to cancel. AFTER it, elections already running under the
+     new rule are committed consensus state and reverting needs a further
+     coordinated fork.
+  8. Removing the legacy branch: only once every election predating the fork has
+     ended on every chain in the table.
+
+Note there is one older, inline height-gated soft fork at
+vochain/transaction/transaction.go, guarding an ISTC reschedule on
+vocdoni/LTS/1.2. It is deliberately left where it is: it is slated for deletion
+once that chain forgets old blocks, not for migration into this table.
+*/
+
+// forkNever is used as an activation point for a soft-fork that has not been
+// scheduled yet on a given chain: the feature stays inactive for every election.
+const forkNever = uint32(math.MaxUint32)
+
+// cspSaltedProofV2Time holds, per ChainID, the unix timestamp from which an
+// election's StartTime activates the fixed CSP salted-proof derivation
+// (crypto/saltedkey.Salt). Elections that started before it keep the legacy
+// derivation, which cropped the processID to 20 bytes and so shared one salted
+// key across every election of an organization (issue #1424).
+//
+// StartTime is the right anchor because it is always set (NewProcessTxCheck
+// defaults it to the current block timestamp and rejects earlier values), it is
+// immutable after creation (SetProcessDuration moves the end, never the start),
+// it is part of the consensus state, and it is exposed off-chain as the
+// election's startDate so a CSP can evaluate the same predicate.
+//
+// It also makes the rollout window self-enforcing: votes with
+// currentTime < process.StartTime are rejected, so no vote governed by the new
+// rule can be cast before the activation timestamp in wall-clock terms.
+//
+// A value of 0 means active for every election. A ChainID absent from the map
+// (custom chains, vocone, and the "test" ChainID used by
+// vochain.TestBaseApplication) or set to forkNever never activates it.
+var cspSaltedProofV2Time = map[string]uint32{
+	"vocdoni/TEST/1":   0,         // always on for the testsuite chain
+	"vocdoni/DEV/36":   forkNever, // TODO: schedule
+	"vocdoni/STAGE/12": forkNever, // TODO: schedule
+	"vocdoni/LTS/1.2":  forkNever, // TODO: schedule (coordinated with the CSP operators)
+}
+
+// CSPSaltedProofV2Active reports whether the fixed salt derivation for
+// ECDSA_PIDSALTED and ECDSA_BLIND_PIDSALTED proofs is active for an election
+// with the given StartTime on the given chain.
+func CSPSaltedProofV2Active(chainID string, electionStartTime uint32) bool {
+	forkTime, ok := cspSaltedProofV2Time[chainID]
+	if !ok || forkTime == forkNever {
+		return false
+	}
+	return electionStartTime >= forkTime
+}

--- a/vochain/genesis/forks_test.go
+++ b/vochain/genesis/forks_test.go
@@ -1,0 +1,57 @@
+package genesis
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestCSPSaltedProofV2Active(t *testing.T) {
+	// a chain scheduled at a concrete timestamp, to exercise the boundary
+	const scheduled = "vocdoni/TEST/FORK"
+	cspSaltedProofV2Time[scheduled] = 1000
+	t.Cleanup(func() { delete(cspSaltedProofV2Time, scheduled) })
+
+	for _, tt := range []struct {
+		name      string
+		chainID   string
+		startTime uint32
+		want      bool
+	}{
+		// unknown chains (vocone, custom testsuites, the "test" chainID used by
+		// vochain.TestBaseApplication) must default to inactive
+		{"unknown chainID", "some/custom/chain", 999999, false},
+		{"empty chainID", "", 999999, false},
+		{"test chainID used by unit tests", "test", 999999, false},
+
+		// unscheduled chains stay inactive at every start time
+		{"forkNever, low startTime", "vocdoni/LTS/1.2", 0, false},
+		{"forkNever, high startTime", "vocdoni/LTS/1.2", 4294967294, false},
+
+		// a chain activated from genesis is active for every election
+		{"activated from zero", "vocdoni/TEST/1", 0, true},
+		{"activated from zero, later election", "vocdoni/TEST/1", 999999, true},
+
+		// the boundary is inclusive: an election starting exactly at the fork
+		// timestamp is governed by the new rule
+		{"one second before the fork", scheduled, 999, false},
+		{"exactly at the fork", scheduled, 1000, true},
+		{"one second after the fork", scheduled, 1001, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CSPSaltedProofV2Active(tt.chainID, tt.startTime)
+			qt.Assert(t, got, qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestCSPSaltedProofV2NotScheduledOnProductionChains guards against activating a
+// production chain by accident. Removing a chain from this list is a deliberate,
+// coordinated rollout step, never a drive-by edit.
+func TestCSPSaltedProofV2NotScheduledOnProductionChains(t *testing.T) {
+	for _, chainID := range []string{"vocdoni/DEV/36", "vocdoni/STAGE/12", "vocdoni/LTS/1.2"} {
+		qt.Assert(t, cspSaltedProofV2Time[chainID], qt.Equals, forkNever,
+			qt.Commentf("chain %s is scheduled; if that is intentional, update this test "+
+				"and follow the runbook in forks.go", chainID))
+	}
+}

--- a/vochain/proof_test.go
+++ b/vochain/proof_test.go
@@ -2,11 +2,14 @@ package vochain
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	cometabcitypes "github.com/cometbft/cometbft/abci/types"
 	qt "github.com/frankban/quicktest"
 	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/saltedkey"
+	"go.vocdoni.io/dvote/test/testcommon/testcsp"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain/state"
@@ -245,4 +248,187 @@ func testCSPsendVotes(t *testing.T, pid []byte, vp []byte, signer *ethereum.Sign
 	}
 	_, err = app.CommitState()
 	qt.Assert(t, err, qt.IsNil)
+}
+
+// cspSaltedTestProcess adds an OFF_CHAIN_CA process for the given CSP root and
+// returns its pid. StartTime 0 activates the salted-proof fork on chains that
+// schedule it at genesis (vocdoni/TEST/1) and is inert elsewhere.
+func cspSaltedTestProcess(t *testing.T, app *BaseApplication, censusRoot []byte) []byte {
+	pid := util.RandomBytes(types.ProcessIDsize)
+	process := &models.Process{
+		ProcessId:     pid,
+		StartBlock:    0,
+		StartTime:     0,
+		EnvelopeType:  &models.EnvelopeType{EncryptedVotes: false},
+		Mode:          new(models.ProcessMode),
+		Status:        models.ProcessStatus_READY,
+		EntityId:      util.RandomBytes(types.EthereumAddressSize),
+		CensusRoot:    censusRoot,
+		CensusOrigin:  models.CensusOrigin_OFF_CHAIN_CA,
+		BlockCount:    1024,
+		MaxCensusSize: 1000,
+	}
+	qt.Assert(t, app.State.AddProcess(process), qt.IsNil)
+	return pid
+}
+
+// TestCSPproofSalted drives the salted CSP proof types through the full
+// CheckTx -> deliverTx -> commit path on a chain where the fixed salt
+// derivation (issue #1424) is active.
+func TestCSPproofSalted(t *testing.T) {
+	app := TestBaseApplicationWithChainID(t, "vocdoni/TEST/1")
+	signer, err := testcsp.NewSigner()
+	qt.Assert(t, err, qt.IsNil)
+
+	vp, err := state.NewVotePackage([]int{1, 2, 3, 4}).Encode()
+	qt.Assert(t, err, qt.IsNil)
+
+	for _, proofType := range []models.ProofCA_Type{
+		models.ProofCA_ECDSA_PIDSALTED,
+		models.ProofCA_ECDSA_BLIND_PIDSALTED,
+	} {
+		t.Run(proofType.String(), func(t *testing.T) {
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+			pid := cspSaltedTestProcess(t, app, root)
+			weight := big.NewInt(42)
+
+			// a proof salted for this election and weight is accepted
+			k := ethereum.NewSignKeys()
+			qt.Assert(t, k.Generate(), qt.IsNil)
+			salt, err := saltedkey.Salt(pid, weight.Bytes())
+			qt.Assert(t, err, qt.IsNil)
+			proof, err := signer.Sign(proofType, testcsp.Bundle(pid, k.Address().Bytes(), weight), salt)
+			qt.Assert(t, err, qt.IsNil)
+			testCSPsendVotes(t, pid, vp, k, proof, app, true)
+
+			// a proof salted for a sibling election of the same organization
+			// (identical first 20 bytes, different nonce) is rejected: this is
+			// the cross-election reuse the fork closes
+			k2 := ethereum.NewSignKeys()
+			qt.Assert(t, k2.Generate(), qt.IsNil)
+			sibling := append([]byte{}, pid...)
+			sibling[31] ^= 0xff
+			siblingSalt, err := saltedkey.Salt(sibling, weight.Bytes())
+			qt.Assert(t, err, qt.IsNil)
+			proof, err = signer.Sign(proofType, testcsp.Bundle(pid, k2.Address().Bytes(), weight), siblingSalt)
+			qt.Assert(t, err, qt.IsNil)
+			testCSPsendVotes(t, pid, vp, k2, proof, app, false)
+
+			// a bundle declaring a weight the CSP did not salt for is rejected
+			k3 := ethereum.NewSignKeys()
+			qt.Assert(t, k3.Generate(), qt.IsNil)
+			authorizedSalt, err := saltedkey.Salt(pid, big.NewInt(5).Bytes())
+			qt.Assert(t, err, qt.IsNil)
+			proof, err = signer.Sign(proofType, testcsp.Bundle(pid, k3.Address().Bytes(), big.NewInt(1000)), authorizedSalt)
+			qt.Assert(t, err, qt.IsNil)
+			testCSPsendVotes(t, pid, vp, k3, proof, app, false)
+
+			// the adaptive forgery: the voter holds a signature the CSP made for
+			// another election at weight 1, and picks the weight that would make
+			// this election derive the same salt under an additive rule. The
+			// hashed derivation defeats it; an additive one would accept it.
+			k4 := ethereum.NewSignKeys()
+			qt.Assert(t, k4.Generate(), qt.IsNil)
+			otherPID := util.RandomBytes(types.ProcessIDsize)
+			saltOther, err := saltedkey.Salt(otherPID, big.NewInt(1).Bytes())
+			qt.Assert(t, err, qt.IsNil)
+			mod := new(big.Int).Lsh(big.NewInt(1), saltedkey.MaxVoteWeightBits)
+			hThis := new(big.Int).SetBytes(ethereum.HashRaw(pid)[:saltedkey.SaltSize])
+			forged := new(big.Int).Mod(new(big.Int).Sub(new(big.Int).SetBytes(saltOther), hThis), mod)
+			proof, err = signer.Sign(proofType, testcsp.Bundle(pid, k4.Address().Bytes(), forged), saltOther)
+			qt.Assert(t, err, qt.IsNil)
+			testCSPsendVotes(t, pid, vp, k4, proof, app, false)
+		})
+	}
+}
+
+// TestCSPproofSaltedPreFork checks the legacy derivation still governs chains
+// without the fork scheduled: the "test" chainID used by TestBaseApplication is
+// absent from the fork table, as any custom or vocone chain is.
+func TestCSPproofSaltedPreFork(t *testing.T) {
+	app := TestBaseApplication(t)
+	signer, err := testcsp.NewSigner()
+	qt.Assert(t, err, qt.IsNil)
+
+	vp, err := state.NewVotePackage([]int{1, 2, 3, 4}).Encode()
+	qt.Assert(t, err, qt.IsNil)
+
+	for _, proofType := range []models.ProofCA_Type{
+		models.ProofCA_ECDSA_PIDSALTED,
+		models.ProofCA_ECDSA_BLIND_PIDSALTED,
+	} {
+		t.Run(proofType.String(), func(t *testing.T) {
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+			pid := cspSaltedTestProcess(t, app, root)
+
+			// the legacy salt is the raw processID
+			k := ethereum.NewSignKeys()
+			qt.Assert(t, k.Generate(), qt.IsNil)
+			proof, err := signer.Sign(proofType, testcsp.Bundle(pid, k.Address().Bytes(), nil), pid)
+			qt.Assert(t, err, qt.IsNil)
+			testCSPsendVotes(t, pid, vp, k, proof, app, true)
+
+			// a proof salted with the post-fork derivation is rejected here
+			k2 := ethereum.NewSignKeys()
+			qt.Assert(t, k2.Generate(), qt.IsNil)
+			salt, err := saltedkey.Salt(pid, nil)
+			qt.Assert(t, err, qt.IsNil)
+			proof, err = signer.Sign(proofType, testcsp.Bundle(pid, k2.Address().Bytes(), nil), salt)
+			qt.Assert(t, err, qt.IsNil)
+			testCSPsendVotes(t, pid, vp, k2, proof, app, false)
+		})
+	}
+}
+
+// TestCSPproofSaltedNoCache delivers a salted vote without a prior CheckTx, so
+// the vote cache cannot serve it and the proof is fully re-verified at
+// delivery. The outcome must match the cached path exercised by
+// testCSPsendVotes: the fork gate depends only on immutable election data, so
+// the two paths cannot disagree.
+func TestCSPproofSaltedNoCache(t *testing.T) {
+	app := TestBaseApplicationWithChainID(t, "vocdoni/TEST/1")
+	signer, err := testcsp.NewSigner()
+	qt.Assert(t, err, qt.IsNil)
+	root, err := signer.CensusRoot(models.ProofCA_ECDSA_BLIND_PIDSALTED)
+	qt.Assert(t, err, qt.IsNil)
+	pid := cspSaltedTestProcess(t, app, root)
+
+	vp, err := state.NewVotePackage([]int{1, 2, 3, 4}).Encode()
+	qt.Assert(t, err, qt.IsNil)
+	weight := big.NewInt(42)
+	salt, err := saltedkey.Salt(pid, weight.Bytes())
+	qt.Assert(t, err, qt.IsNil)
+
+	buildVote := func(k *ethereum.SignKeys, salt []byte) []byte {
+		proof, err := signer.Sign(models.ProofCA_ECDSA_BLIND_PIDSALTED,
+			testcsp.Bundle(pid, k.Address().Bytes(), weight), salt)
+		qt.Assert(t, err, qt.IsNil)
+		var stx models.SignedTx
+		stx.Tx, err = proto.Marshal(&models.Tx{Payload: &models.Tx_Vote{Vote: &models.VoteEnvelope{
+			Nonce:       util.RandomBytes(32),
+			ProcessId:   pid,
+			Proof:       &models.Proof{Payload: &models.Proof_Ca{Ca: proof}},
+			VotePackage: vp,
+		}}})
+		qt.Assert(t, err, qt.IsNil)
+		stx.Signature, err = k.SignVocdoniTx(stx.Tx, app.chainID)
+		qt.Assert(t, err, qt.IsNil)
+		txb, err := proto.Marshal(&stx)
+		qt.Assert(t, err, qt.IsNil)
+		return txb
+	}
+
+	// a valid salted vote delivered straight to deliverTx is accepted
+	k := ethereum.NewSignKeys()
+	qt.Assert(t, k.Generate(), qt.IsNil)
+	resp := app.deliverTx(buildVote(k, salt))
+	qt.Assert(t, resp.Code, qt.Equals, uint32(0), qt.Commentf("%s", resp.Data))
+
+	// and a legacy-salted one is rejected, also without cache involvement
+	k2 := ethereum.NewSignKeys()
+	qt.Assert(t, k2.Generate(), qt.IsNil)
+	resp = app.deliverTx(buildVote(k2, pid))
+	qt.Assert(t, resp.Code, qt.Not(qt.Equals), uint32(0))
 }

--- a/vochain/transaction/account_tx.go
+++ b/vochain/transaction/account_tx.go
@@ -306,7 +306,7 @@ func (t *TransactionHandler) RegisterSIKTxCheck(vtx *vochaintx.Tx) (common.Addre
 		process.EnvelopeType.Anonymous = true
 	}()
 	// verify the proof for the transaction signer address
-	valid, _, err := VerifyProof(process, &models.VoteEnvelope{ProcessId: pid, Proof: censusProof}, vstate.NewVoterID(vstate.VoterIDTypeZkSnark, txAddress.Bytes()))
+	valid, _, err := VerifyProof(t.state.ChainID(), process, &models.VoteEnvelope{ProcessId: pid, Proof: censusProof}, vstate.NewVoterID(vstate.VoterIDTypeZkSnark, txAddress.Bytes()))
 	if err != nil {
 		return common.Address{}, nil, nil, false, fmt.Errorf("error verifying the proof: %w", err)
 	}

--- a/vochain/transaction/proof.go
+++ b/vochain/transaction/proof.go
@@ -23,7 +23,10 @@ type ProofVerifier interface {
 
 // VerifyProof is a wrapper over all VerifyProofFunc(s) available which uses the process.CensusOrigin
 // to execute the correct verification function.
-func VerifyProof(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
+//
+// chainID is needed to resolve per-election soft-fork activation; only the CSP
+// verifier consumes it today, so the ProofVerifier interface stays free of it.
+func VerifyProof(chainID string, process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
 	// sanity checks
 	if envelope == nil {
 		return false, nil, fmt.Errorf("envelope is nil")
@@ -59,7 +62,7 @@ func VerifyProof(process *models.Process, envelope *models.VoteEnvelope, vID sta
 			verifier = &arboproof.ProofVerifierArbo{}
 		}
 	case models.CensusOrigin_OFF_CHAIN_CA:
-		verifier = &cspproof.ProofVerifierCSP{}
+		verifier = &cspproof.ProofVerifierCSP{ChainID: chainID}
 	case models.CensusOrigin_ERC20, models.CensusOrigin_MINI_ME:
 		verifier = &ethereumproof.ProofVerifierEthereumStorage{}
 	case models.CensusOrigin_FARCASTER_FRAME:

--- a/vochain/transaction/proofs/cspproof/cspproof.go
+++ b/vochain/transaction/proofs/cspproof/cspproof.go
@@ -9,17 +9,41 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/crypto/saltedkey"
+	"go.vocdoni.io/dvote/vochain/genesis"
 	"go.vocdoni.io/dvote/vochain/state"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )
 
 // ProofVerifierCSP defines the interface for CSP (Credential Service Provider) proof verification systems.
-type ProofVerifierCSP struct{}
+type ProofVerifierCSP struct {
+	// ChainID of the vochain, used to resolve the per-election activation of the
+	// fixed salt derivation. An empty or unknown ChainID keeps the legacy one.
+	ChainID string
+}
+
+// salt returns the salt applied to the CSP census root for this election.
+//
+// Before the fork point the salt is the raw processID, of which the salting
+// primitives consume saltedkey.SaltSize (20) bytes: chainID[6] + orgAddr[:14].
+// The nonce is cropped, so every election of the same organization on the same
+// chain shares one salted key (issue #1424). Kept verbatim for elections that
+// started before the fork, so their in-flight proofs stay valid.
+//
+// After it, the salt covers the whole processID and the CSP-authorized vote
+// weight. See saltedkey.Salt.
+func (v *ProofVerifierCSP) salt(process *models.Process, envelope *models.VoteEnvelope,
+	bundle *models.CAbundle,
+) ([]byte, error) {
+	if !genesis.CSPSaltedProofV2Active(v.ChainID, process.StartTime) {
+		return envelope.ProcessId, nil
+	}
+	return saltedkey.Salt(envelope.ProcessId, bundle.GetVoteWeight())
+}
 
 // VerifyProof verifies a proof with census origin OFF_CHAIN_CA.
 // Returns verification result and weight.
-func (*ProofVerifierCSP) Verify(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
+func (v *ProofVerifierCSP) Verify(process *models.Process, envelope *models.VoteEnvelope, vID state.VoterID) (bool, *big.Int, error) {
 	key := vID.Address()
 	censusRoot := process.CensusRoot
 	p := envelope.Proof.GetCa()
@@ -54,7 +78,11 @@ func (*ProofVerifierCSP) Verify(process *models.Process, envelope *models.VoteEn
 			if err != nil {
 				return false, nil, fmt.Errorf("cannot unmarshal ECDSA CSP public key: %w", err)
 			}
-			rootPubSalted, err = saltedkey.SaltECDSAPubKey(rootPubSalted, envelope.ProcessId)
+			salt, err := v.salt(process, envelope, p.Bundle)
+			if err != nil {
+				return false, nil, err
+			}
+			rootPubSalted, err = saltedkey.SaltECDSAPubKey(rootPubSalted, salt)
 			if err != nil {
 				return false, nil, fmt.Errorf("cannot salt ECDSA public key: %w", err)
 			}
@@ -83,7 +111,11 @@ func (*ProofVerifierCSP) Verify(process *models.Process, envelope *models.VoteEn
 		}
 		// If pid salted, apply the salt (processId) to the censusRoot public key
 		if p.GetType() == models.ProofCA_ECDSA_BLIND_PIDSALTED {
-			rootPub, err = saltedkey.SaltBlindPubKey(rootPub, envelope.ProcessId)
+			salt, err := v.salt(process, envelope, p.Bundle)
+			if err != nil {
+				return false, nil, err
+			}
+			rootPub, err = saltedkey.SaltBlindPubKey(rootPub, salt)
 			if err != nil {
 				return false, nil, fmt.Errorf("cannot salt blind pubkey: %w", err)
 			}

--- a/vochain/transaction/proofs/cspproof/cspproof_test.go
+++ b/vochain/transaction/proofs/cspproof/cspproof_test.go
@@ -1,0 +1,381 @@
+package cspproof
+
+import (
+	"math/big"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/crypto/saltedkey"
+	"go.vocdoni.io/dvote/test/testcommon/testcsp"
+	"go.vocdoni.io/dvote/util"
+	"go.vocdoni.io/dvote/vochain/state"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+const (
+	// chainActive has the salted-proof fork scheduled at timestamp 0, so every
+	// election on it is governed by the new derivation.
+	chainActive = "vocdoni/TEST/1"
+	// chainInactive is absent from the fork table, which is how custom chains,
+	// vocone and vochain.TestBaseApplication behave: legacy derivation.
+	chainInactive = "test"
+)
+
+var saltedTypes = []models.ProofCA_Type{
+	models.ProofCA_ECDSA_PIDSALTED,
+	models.ProofCA_ECDSA_BLIND_PIDSALTED,
+}
+
+// siblingPIDs returns two processIDs of the same organization on the same chain,
+// differing only in the nonce. Their first 20 bytes — all the legacy salt
+// consumed — are identical, which is the root of issue #1424.
+func siblingPIDs(t *testing.T) (pidA, pidB []byte) {
+	t.Helper()
+	pidA = util.RandomBytes(32)
+	pidB = append([]byte{}, pidA...)
+	pidB[31] ^= 0xff // bump the nonce, which lives in bytes 28..31
+	qt.Assert(t, pidA[:saltedkey.SaltSize], qt.DeepEquals, pidB[:saltedkey.SaltSize])
+	return pidA, pidB
+}
+
+func newProcess(pid, censusRoot []byte) *models.Process {
+	return &models.Process{
+		ProcessId:    pid,
+		CensusRoot:   censusRoot,
+		CensusOrigin: models.CensusOrigin_OFF_CHAIN_CA,
+		EnvelopeType: &models.EnvelopeType{},
+		Status:       models.ProcessStatus_READY,
+		// StartTime drives the fork gate; 0 is at or after every scheduled
+		// activation, so chainActive is always post-fork here.
+		StartTime: 0,
+	}
+}
+
+// verify runs the CSP verifier for chainID over a proof built for pid.
+func verify(chainID string, process *models.Process, pid []byte,
+	proof *models.Proof, voter *ethereum.SignKeys,
+) (bool, *big.Int, error) {
+	verifier := &ProofVerifierCSP{ChainID: chainID}
+	return verifier.Verify(process,
+		&models.VoteEnvelope{ProcessId: pid, Proof: proof},
+		state.NewVoterID(state.VoterIDTypeECDSA, voter.PublicKey()))
+}
+
+// newVoter returns a fresh voter key.
+func newVoter(t *testing.T) *ethereum.SignKeys {
+	t.Helper()
+	k := ethereum.NewSignKeys()
+	qt.Assert(t, k.Generate(), qt.IsNil)
+	return k
+}
+
+// expectedSalt is the salt the verifier derives for pid/weight on chainID.
+func expectedSalt(t *testing.T, chainID string, pid []byte, weight *big.Int) []byte {
+	t.Helper()
+	if chainID == chainActive {
+		var weightBytes []byte
+		if weight != nil {
+			weightBytes = weight.Bytes()
+		}
+		salt, err := saltedkey.Salt(pid, weightBytes)
+		qt.Assert(t, err, qt.IsNil)
+		return salt
+	}
+	return pid // legacy: raw processID, cropped to 20 bytes by the primitives
+}
+
+// TestCSPProofValid is the baseline: for every proof type, on both sides of the
+// fork, a proof salted the way the verifier expects must verify and return the
+// declared weight.
+func TestCSPProofValid(t *testing.T) {
+	allTypes := []models.ProofCA_Type{
+		models.ProofCA_ECDSA,
+		models.ProofCA_ECDSA_PIDSALTED,
+		models.ProofCA_ECDSA_BLIND,
+		models.ProofCA_ECDSA_BLIND_PIDSALTED,
+	}
+	for _, proofType := range allTypes {
+		for _, chainID := range []string{chainActive, chainInactive} {
+			t.Run(proofType.String()+"/"+chainID, func(t *testing.T) {
+				signer, err := testcsp.NewSigner()
+				qt.Assert(t, err, qt.IsNil)
+				root, err := signer.CensusRoot(proofType)
+				qt.Assert(t, err, qt.IsNil)
+
+				pid := util.RandomBytes(32)
+				voter := newVoter(t)
+				weight := big.NewInt(42)
+				bundle := testcsp.Bundle(pid, voter.Address().Bytes(), weight)
+
+				proof, err := signer.SignProof(proofType, bundle, expectedSalt(t, chainID, pid, weight))
+				qt.Assert(t, err, qt.IsNil)
+
+				valid, gotWeight, err := verify(chainID, newProcess(pid, root), pid, proof, voter)
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, valid, qt.IsTrue)
+				qt.Assert(t, gotWeight.String(), qt.Equals, weight.String())
+			})
+		}
+	}
+}
+
+// TestCSPCrossElectionRejected is the regression test for the core of issue
+// #1424. The CSP authorizes election A; the voter presents a bundle for its
+// sibling election B. Before the fork both elections derive the same salted key,
+// so the proof verifies on B — in the blind flow, where the CSP cannot read the
+// message it signs, that is a forgery. After the fork it is rejected.
+func TestCSPCrossElectionRejected(t *testing.T) {
+	for _, proofType := range saltedTypes {
+		t.Run(proofType.String(), func(t *testing.T) {
+			signer, err := testcsp.NewSigner()
+			qt.Assert(t, err, qt.IsNil)
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+
+			pidA, pidB := siblingPIDs(t)
+			voter := newVoter(t)
+			weight := big.NewInt(42)
+			// the bundle names election B, but the CSP salted for election A
+			bundle := testcsp.Bundle(pidB, voter.Address().Bytes(), weight)
+
+			t.Run("legacy accepts it (the vulnerability)", func(t *testing.T) {
+				proof, err := signer.SignProof(proofType, bundle, expectedSalt(t, chainInactive, pidA, weight))
+				qt.Assert(t, err, qt.IsNil)
+				valid, _, err := verify(chainInactive, newProcess(pidB, root), pidB, proof, voter)
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, valid, qt.IsTrue)
+			})
+
+			t.Run("fork rejects it", func(t *testing.T) {
+				proof, err := signer.SignProof(proofType, bundle, expectedSalt(t, chainActive, pidA, weight))
+				qt.Assert(t, err, qt.IsNil)
+				valid, _, err := verify(chainActive, newProcess(pidB, root), pidB, proof, voter)
+				qt.Assert(t, err, qt.IsNotNil)
+				qt.Assert(t, valid, qt.IsFalse)
+			})
+		})
+	}
+}
+
+// TestCSPAdaptiveWeightForgeryRejected is the regression test for the adaptive
+// forgery that an additive derivation (salt = keccak256(pid)[:20] + w) allowed.
+// The attacker holds a blind signature the CSP made for election A weight 1, and
+// picks the weight that, under addition, would make election B derive the same
+// salt: w' = (saltA - keccak256(pidB)[:20]) mod 2^160. Against the hashed
+// derivation the salts do not coincide and the proof is rejected; if the
+// derivation were ever reverted to additive this test would fail, because the
+// forged proof would verify.
+//
+// Unlike TestCSPCrossElectionRejected, the attacker here chooses the weight
+// *after* seeing the salt — the only case that distinguishes a real binding from
+// a malleable one.
+func TestCSPAdaptiveWeightForgeryRejected(t *testing.T) {
+	for _, proofType := range saltedTypes {
+		t.Run(proofType.String(), func(t *testing.T) {
+			signer, err := testcsp.NewSigner()
+			qt.Assert(t, err, qt.IsNil)
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+
+			// unrelated elections: the attacker only needs them to share the CSP
+			// root, so random pids (not siblings) are the general case
+			pidA, pidB := util.RandomBytes(32), util.RandomBytes(32)
+
+			// the CSP authorizes the voter on election A for weight 1
+			saltA, err := saltedkey.Salt(pidA, big.NewInt(1).Bytes())
+			qt.Assert(t, err, qt.IsNil)
+
+			// solve for the weight that maps election B onto saltA under an
+			// additive derivation
+			mod := new(big.Int).Lsh(big.NewInt(1), saltedkey.MaxVoteWeightBits)
+			hB := new(big.Int).SetBytes(ethereum.HashRaw(pidB)[:saltedkey.SaltSize])
+			forged := new(big.Int).Mod(new(big.Int).Sub(new(big.Int).SetBytes(saltA), hB), mod)
+
+			voter := newVoter(t)
+			proof, err := signer.SignProof(proofType,
+				testcsp.Bundle(pidB, voter.Address().Bytes(), forged), saltA)
+			qt.Assert(t, err, qt.IsNil)
+
+			valid, _, err := verify(chainActive, newProcess(pidB, root), pidB, proof, voter)
+			qt.Assert(t, err, qt.IsNotNil)
+			qt.Assert(t, valid, qt.IsFalse)
+		})
+	}
+}
+
+// TestCSPWeightBinding covers the second half of the issue: the CSP authorizes
+// weight 5, the voter declares 1000. Before the fork the weight is outside the
+// salt, so the chain records whatever the voter asked for. After it, the voter
+// signs under a key the chain does not derive and the proof fails.
+func TestCSPWeightBinding(t *testing.T) {
+	const authorized, declared = 5, 1000
+	for _, proofType := range saltedTypes {
+		t.Run(proofType.String(), func(t *testing.T) {
+			signer, err := testcsp.NewSigner()
+			qt.Assert(t, err, qt.IsNil)
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+
+			pid := util.RandomBytes(32)
+			voter := newVoter(t)
+			bundle := testcsp.Bundle(pid, voter.Address().Bytes(), big.NewInt(declared))
+
+			t.Run("legacy accepts the inflated weight", func(t *testing.T) {
+				proof, err := signer.SignProof(proofType, bundle, expectedSalt(t, chainInactive, pid, nil))
+				qt.Assert(t, err, qt.IsNil)
+				valid, weight, err := verify(chainInactive, newProcess(pid, root), pid, proof, voter)
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, valid, qt.IsTrue)
+				qt.Assert(t, weight.Int64(), qt.Equals, int64(declared))
+			})
+
+			t.Run("fork rejects it", func(t *testing.T) {
+				// CSP salts for the weight it authorized, not the one declared
+				proof, err := signer.SignProof(proofType, bundle,
+					expectedSalt(t, chainActive, pid, big.NewInt(authorized)))
+				qt.Assert(t, err, qt.IsNil)
+				valid, _, err := verify(chainActive, newProcess(pid, root), pid, proof, voter)
+				qt.Assert(t, err, qt.IsNotNil)
+				qt.Assert(t, valid, qt.IsFalse)
+			})
+
+			t.Run("fork accepts the authorized weight", func(t *testing.T) {
+				honest := testcsp.Bundle(pid, voter.Address().Bytes(), big.NewInt(authorized))
+				proof, err := signer.SignProof(proofType, honest,
+					expectedSalt(t, chainActive, pid, big.NewInt(authorized)))
+				qt.Assert(t, err, qt.IsNil)
+				valid, weight, err := verify(chainActive, newProcess(pid, root), pid, proof, voter)
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, valid, qt.IsTrue)
+				qt.Assert(t, weight.Int64(), qt.Equals, int64(authorized))
+			})
+		})
+	}
+}
+
+// TestCSPWeightOverflowRejected covers the guard without which a voter
+// authorized for weight w submits w + 2^160, wraps to an identical salt, and has
+// the chain record the enormous value. The guard is fork-gated, so the legacy
+// path is unchanged.
+func TestCSPWeightOverflowRejected(t *testing.T) {
+	twoTo160 := new(big.Int).Lsh(big.NewInt(1), saltedkey.MaxVoteWeightBits)
+	huge := new(big.Int).Add(big.NewInt(5), twoTo160)
+
+	for _, proofType := range saltedTypes {
+		t.Run(proofType.String(), func(t *testing.T) {
+			signer, err := testcsp.NewSigner()
+			qt.Assert(t, err, qt.IsNil)
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+
+			pid := util.RandomBytes(32)
+			voter := newVoter(t)
+			bundle := testcsp.Bundle(pid, voter.Address().Bytes(), huge)
+			proof, err := signer.SignProof(proofType, bundle, pid)
+			qt.Assert(t, err, qt.IsNil)
+
+			t.Run("fork rejects the oversized weight", func(t *testing.T) {
+				valid, _, err := verify(chainActive, newProcess(pid, root), pid, proof, voter)
+				qt.Assert(t, err, qt.IsNotNil)
+				qt.Assert(t, valid, qt.IsFalse)
+			})
+
+			t.Run("legacy is unchanged", func(t *testing.T) {
+				valid, weight, err := verify(chainInactive, newProcess(pid, root), pid, proof, voter)
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, valid, qt.IsTrue)
+				qt.Assert(t, weight.String(), qt.Equals, huge.String())
+			})
+		})
+	}
+}
+
+// TestCSPSaltDerivationsAreMutuallyExclusive pins both sides of the gate: a
+// proof salted under one rule must not verify under the other.
+func TestCSPSaltDerivationsAreMutuallyExclusive(t *testing.T) {
+	for _, proofType := range saltedTypes {
+		t.Run(proofType.String(), func(t *testing.T) {
+			signer, err := testcsp.NewSigner()
+			qt.Assert(t, err, qt.IsNil)
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+
+			pid := util.RandomBytes(32)
+			voter := newVoter(t)
+			weight := big.NewInt(7)
+			bundle := testcsp.Bundle(pid, voter.Address().Bytes(), weight)
+
+			legacyProof, err := signer.SignProof(proofType, bundle, expectedSalt(t, chainInactive, pid, weight))
+			qt.Assert(t, err, qt.IsNil)
+			forkProof, err := signer.SignProof(proofType, bundle, expectedSalt(t, chainActive, pid, weight))
+			qt.Assert(t, err, qt.IsNil)
+
+			// a legacy proof is rejected once the fork is active
+			valid, _, err := verify(chainActive, newProcess(pid, root), pid, legacyProof, voter)
+			qt.Assert(t, err, qt.IsNotNil)
+			qt.Assert(t, valid, qt.IsFalse)
+
+			// and a fork proof is rejected before the fork
+			valid, _, err = verify(chainInactive, newProcess(pid, root), pid, forkProof, voter)
+			qt.Assert(t, err, qt.IsNotNil)
+			qt.Assert(t, valid, qt.IsFalse)
+		})
+	}
+}
+
+// TestCSPUnsaltedUnaffected checks the fork does not touch the unsalted proof
+// types: one and the same proof verifies on both sides.
+func TestCSPUnsaltedUnaffected(t *testing.T) {
+	for _, proofType := range []models.ProofCA_Type{models.ProofCA_ECDSA, models.ProofCA_ECDSA_BLIND} {
+		t.Run(proofType.String(), func(t *testing.T) {
+			signer, err := testcsp.NewSigner()
+			qt.Assert(t, err, qt.IsNil)
+			root, err := signer.CensusRoot(proofType)
+			qt.Assert(t, err, qt.IsNil)
+
+			pid := util.RandomBytes(32)
+			voter := newVoter(t)
+			// a weight that would be rejected by the salted path's guard, to show
+			// the guard really is confined to it
+			weight := new(big.Int).Lsh(big.NewInt(1), saltedkey.MaxVoteWeightBits)
+			bundle := testcsp.Bundle(pid, voter.Address().Bytes(), weight)
+			proof, err := signer.SignProof(proofType, bundle, nil)
+			qt.Assert(t, err, qt.IsNil)
+
+			for _, chainID := range []string{chainActive, chainInactive} {
+				valid, gotWeight, err := verify(chainID, newProcess(pid, root), pid, proof, voter)
+				qt.Assert(t, err, qt.IsNil, qt.Commentf("chainID %s", chainID))
+				qt.Assert(t, valid, qt.IsTrue)
+				qt.Assert(t, gotWeight.String(), qt.Equals, weight.String())
+			}
+		})
+	}
+}
+
+// TestCSPAbsentWeightDefaultsToOne preserves the legacy contract that an absent
+// voteWeight means a weight of 1, on both sides of the fork.
+func TestCSPAbsentWeightDefaultsToOne(t *testing.T) {
+	for _, proofType := range saltedTypes {
+		for _, chainID := range []string{chainActive, chainInactive} {
+			t.Run(proofType.String()+"/"+chainID, func(t *testing.T) {
+				signer, err := testcsp.NewSigner()
+				qt.Assert(t, err, qt.IsNil)
+				root, err := signer.CensusRoot(proofType)
+				qt.Assert(t, err, qt.IsNil)
+
+				pid := util.RandomBytes(32)
+				voter := newVoter(t)
+				bundle := testcsp.Bundle(pid, voter.Address().Bytes(), nil)
+
+				proof, err := signer.SignProof(proofType, bundle, expectedSalt(t, chainID, pid, nil))
+				qt.Assert(t, err, qt.IsNil)
+
+				valid, weight, err := verify(chainID, newProcess(pid, root), pid, proof, voter)
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, valid, qt.IsTrue)
+				qt.Assert(t, weight.Int64(), qt.Equals, int64(1))
+			})
+		}
+	}
+}

--- a/vochain/transaction/vote_tx.go
+++ b/vochain/transaction/vote_tx.go
@@ -173,7 +173,7 @@ func (t *TransactionHandler) VoteTxCheck(vtx *vochaintx.Tx, forCommit bool) (*vs
 		}
 		// verify the proof
 		valid := false
-		valid, vote.Weight, err = VerifyProof(process, voteEnvelope, vote.VoterID)
+		valid, vote.Weight, err = VerifyProof(t.state.ChainID(), process, voteEnvelope, vote.VoterID)
 		if err != nil {
 			return nil, fmt.Errorf("proof not valid: %w", err)
 		}
@@ -203,7 +203,7 @@ func (t *TransactionHandler) VoteTxCheck(vtx *vochaintx.Tx, forCommit bool) (*vs
 			"height", height)
 
 		// Verify the proof
-		valid, weight, err := VerifyProof(process, voteEnvelope, vote.VoterID)
+		valid, weight, err := VerifyProof(t.state.ChainID(), process, voteEnvelope, vote.VoterID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #1424. Targets `main`.

## Problem

The CSP salt was the raw processID, but the salting primitives consume only its first 20 bytes: `chainID[6] + orgAddr[:14]`. The nonce (bytes 28–31) never entered the salt, so **every election of the same organization on the same chain derived the same salted keypair**. In the blind flow the CSP signs a message it cannot read — a voter authorized for election A could get a bundle for sibling election B blind-signed, and it verified on B. Separately, `Bundle.VoteWeight` was read verbatim on-chain, with no way for the CSP to bind the weight it actually authorized.

## Fix

One derivation for both `ECDSA_PIDSALTED` and `ECDSA_BLIND_PIDSALTED` (`crypto/saltedkey.Salt`, the reference spec for the sibling repos):

```
w    = uint(bundle.voteWeight) big-endian, or 1 when absent
       rejected if w >= 2^160
salt = keccak256( processID || w-as-32-big-endian-bytes )[:20]
```

- All 32 processID bytes contribute → sibling elections derive distinct salts.
- The CSP-authorized weight is hashed in → declaring a weight the CSP did not authorize derives a different key and the proof fails, unbypassably, without linking weight to identity.
- The weight is rendered to a **fixed 32-byte width** so every byte encoding of an integer maps to one salt — the salt binds exactly the value the chain records.
- `SaltSize` stays 20, so the salting primitives and every deployed CSP are untouched; only the hash preimage changes.

### On the earlier additive derivation (thanks to the Argos review)

An earlier revision of this PR used `salt = keccak256(pid)[:20] + w mod 2^160`. That is **additively malleable** and was a critical break: the verifier re-derives the salt from the voter-chosen `w`, so a voter holding a blind signature valid for `saltA = keccak256(pidA)[:20] + 1` can present a bundle for election B declaring `w' = (saltA − keccak256(pidB)[:20]) mod 2^160`, making election B derive the identical salt — reusing the signature across elections and recording an arbitrary weight, with no crypto. Hashing both inputs removes the algebraic handle (hitting a target salt now needs a keccak preimage collision). Caught before any chain was scheduled and before the sibling repos mirrored it. Regression-tested by `TestCSPAdaptiveWeightForgeryRejected`, which fails against the additive rule and passes against the hashed one.

## Soft fork: **per-election**, not per-block-height

The gate lives in `vochain/genesis/forks.go` (`CSPSaltedProofV2Active`), keyed on `process.StartTime` per chainID rather than block height. The block-height gate the memo fork (#1419) uses **cannot** be applied to CSP proofs: a proof is verified at CheckTx and then **not** re-verified at DeliverTx when the vote is served from the vote cache (`VoteTxCheck`). A vote checked at `H-1` under the old rule and delivered at `H` under the new one would be accepted by the proposer and rejected by every node that never saw it in its mempool → **AppHash divergence / chain halt**.

Keying on immutable election data removes that class of bug: the predicate returns the same value at CheckTx and DeliverTx, on every node, regardless of height or mempool timing. Consequences:

- An election never changes rules mid-flight.
- Since votes with `currentTime < StartTime` are rejected, no vote governed by the new rule can be cast before the activation timestamp — the rollout window is **self-enforcing**.
- An external CSP evaluates the same predicate from the public `startDate` + `chainId`, with no chain polling.

`StartTime` is the anchor because it is always set, immutable after creation (`SetProcessDuration` moves the end, not the start), part of consensus state, and exposed off-chain. `StartBlock` (attacker-chosen for timestamp-based elections) and `ProcessBlockRegistry` (mutable on pause, deleted on end, outside the AppHash) were rejected.

### Activation runbook (full text in `forks.go`)

1. **Merge dormant.** All production chains ship at `forkNever` — merging changes nothing on-chain. Only `vocdoni/TEST/1` is active from genesis, for tests.
2. **Upgrade off-chain signers first.** Ship the mirrored derivation + the same `startDate >= T[chainId]` predicate in vocdoni/blind-csp, vocdoni/saas-backend (`csp/sign.go`, `csp/sign_blind.go`) and vocdoni/vocdoni-sdk (see vocdoni/vocdoni-sdk#435, vocdoni/integrator-sdk#18). Both sides must be deployable before either activates.
3. Pick `T` after the last node **and** CSP upgrade and the longest election lead time; set it for the ChainID in the table (one-line commit); release.
4. **Inverted failure mode vs. a height fork:** node divergence is impossible (the predicate is election-local), but a stale CSP after `T` issues proofs the chain rejects — voter-visible failures on one election, never a chain halt. Watch the signer, not the AppHash.
5. Abort before `T` by moving it later or to `forkNever`; after `T` it is committed consensus state.

## Tests

The salted and blind CSP paths previously had **zero** coverage. This PR adds:

- `test/testcommon/testcsp`: the signer counterpart of the verifier (all four `ProofCA` types, either derivation) — the repo had no CSP signer. Doubles as executable documentation for the sibling repos.
- `cspproof_test.go`: full matrix — every proof type × both sides of the fork; cross-election forgery and weight tampering demonstrated to succeed under the legacy derivation and rejected under the new one; **`TestCSPAdaptiveWeightForgeryRejected`** (the adaptive attack that solves for the weight after seeing the salt); overflow guard; canonical-weight; unsalted types byte-identical on both sides.
- `crypto/saltedkey`: determinism, nonce sensitivity (legacy collision pinned), fixed-width canonicalization, priv/pub round-trips, legacy truncation compatibility.
- Chain-level (`vochain/proof_test.go`): CheckTx→deliverTx→commit for both salted types on both chains, including the adaptive forgery, plus a no-cache delivery agreement test.
- e2e: new `cspelectionblindsalted` op (weighted blind pid-salted votes), wired into the testsuite; verified locally against voconed (5 votes × weight 10 → results `[[50 0]]`).

Drive-by: `TestBaseApplicationWithChainID` now propagates its chainID to the app and state as a real node does (it previously only reached cometbft), and `SaltECDSAPubKey` no longer mutates its input key.

## Note for reviewers

The issue text (#1424) specifies block-height activation, two derivations with a domain tag, and 8-byte BE weight concatenation. All three were superseded during design: per-election activation (halt-safety) and a single hashed derivation. The issue should be updated to match.

> Note on base branch: the soft-fork machinery (`vochain/genesis/forks.go`) also exists on `dev` from the memo fork (#1419). Since this PR targets `main`, it introduces `forks.go` standalone; whichever of the two lands second on a shared branch resolves a trivial add/add on that file (keep both fork tables under one `forkNever`).