### PR TITLE
ci: bump deprecated actions in swagger workflow

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
       - name: Checkout developer-portal repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: vocdoni/developer-portal
           ref: main
           path: developer-portal
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache: false
@@ -47,7 +47,7 @@ jobs:
               api/docs/oas3.yaml > developer-portal/swaggers/vocdoni-api.yaml
 
       - name: Publish Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: vocdoni-api.yaml
           path: developer-portal/swaggers/vocdoni-api.yaml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Create PR to developer-portal repo
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         if: ${{ github.event_name == 'push' }}
         with:
           path: developer-portal


### PR DESCRIPTION
GitHub deprecated Node 20 for actions and now force-runs old pins on Node 24 (see the warnings on recent runs of `Generate vocdoni-api.yaml`). This bumps the affected actions to their current majors, which target Node 24 natively: checkout v5, setup-go v6, upload-artifact v5, create-pull-request v7.

Note this does not fix the current failure of that job on `main`: the `create-pull-request` step fails with `could not read Username` because `VOCDONIBOT_PAT` appears to be expired or empty (last green run Jul 20). The secret needs to be rotated by an admin; this PR is the accompanying hygiene fix.