### PR TITLE
ci: don't request the pushing actor as portal PR reviewer

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -97,7 +97,6 @@ jobs:
             * GitHub Action Run: [${{ github.run_id }}](https://github.com/vocdoni/vocdoni-node/actions/runs/${{ github.run_id }})
           labels: |
             automated pr
-          reviewers: ${{ github.actor }}
           team-reviewers: SdkDocsReviewer
 
       - name: "Check PR: ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
Follow-up to the VOCDONIBOT_PAT rotation. The swagger job now authors the developer-portal PR with the rotated token's account; `reviewers: ${{ github.actor }}` then asks the PR author to review their own PR, which the API rejects (`Review cannot be requested from pull request author`, see run 30544676389 — note the spec PR itself was updated fine). The `SdkDocsReviewer` team request remains.