### PR TITLE
ci: author developer-portal docs PRs with a GitHub App

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -78,13 +78,23 @@ jobs:
             ${{ steps.diff.outputs.stdout }}
             ```
 
+      - name: Mint app token for developer-portal
+        id: app-token
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+          owner: vocdoni
+          repositories: developer-portal
+
       - name: Create PR to developer-portal repo
         id: cpr
         uses: peter-evans/create-pull-request@v7
         if: ${{ github.event_name == 'push' }}
         with:
           path: developer-portal
-          token: ${{ secrets.VOCDONIBOT_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Update vocdoni-api docs by commit ${{ env.SHA }}"
           committer: "Arabot-1 <arabot-1@users.noreply.github.com>"
           base: main


### PR DESCRIPTION
Replaces the `VOCDONIBOT_PAT` personal token with an installation token minted per run from the org-owned **vocdoni-docs-bot** GitHub App (ID in the `DOCS_BOT_APP_ID` repo variable, key in the `DOCS_BOT_PRIVATE_KEY` secret — both already in place, and the credential chain was verified by minting a token against the live installation covering `developer-portal`).

Consequences:
- No expiring credential: tokens are ephemeral (1h), the app key does not expire, and the app cannot leave the org.
- Portal PRs are authored by `vocdoni-docs-bot[bot]`, so `reviewers: ${{ github.actor }}` is valid again for every actor, including the former PAT owner. The line is kept.
- `VOCDONIBOT_PAT` becomes unused and can be deleted after merge; the personal PAT can be revoked.

Supersedes #1428, which worked around the author/reviewer collision by dropping the reviewer request.