### PR TITLE
ci: fail fast in testsuite when docker is unusable

### DIFF
--- a/dockerfiles/testsuite/start_test.sh
+++ b/dockerfiles/testsuite/start_test.sh
@@ -39,6 +39,7 @@ TEST_PREFIX="testsuite_test"
 RANDOMID="${RANDOM}${RANDOM}"
 
 log() { echo $(date --rfc-3339=s) "$@" ; }
+die() { log "### $* ###" ; exit 4 ; }
 
 ### if you want to add a new test:
 ### add "newtest" to tests_to_run array (as well as a comment at the head of the file)
@@ -169,12 +170,12 @@ test_statesync() {
 
 log "### Starting test suite ###"
 [ $BUILD -eq 1 ] && {
-	$COMPOSE_CMD build
-	$COMPOSE_CMD build test
+	$COMPOSE_CMD build || die "docker compose build failed"
+	$COMPOSE_CMD build test || die "docker compose build test failed"
 }
-$COMPOSE_CMD up -d seed # start the seed first so the nodes can properly bootstrap
+$COMPOSE_CMD up -d seed || die "docker compose up seed failed" # start the seed first so the nodes can properly bootstrap
 sleep 10
-$COMPOSE_CMD up -d miner0 miner1 miner2 miner3 gateway0
+$COMPOSE_CMD up -d miner0 miner1 miner2 miner3 gateway0 || die "docker compose up nodes failed"
 
 check_gw_is_up() {
   height=$($COMPOSE_CMD_RUN --rm test \


### PR DESCRIPTION
## Problem

`job_compose_test` went red on #1425 for a reason that had nothing to do with the code: the same commit `8dd52744` **passed at 07:19 and failed at 07:32**. The self-hosted runner had lost access to the docker socket.

```
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
```

That line sat 30 lines up the log. What the failure *looked* like was this:

```
### Waiting for test suite to be ready and reaches height=8 ###
height=
height=            (× 30, over 60 seconds)
### Timed out waiting! Abort, don't even try running tests ###
```

— which points at the node stack, not at docker.

## Cause

`dockerfiles/testsuite/start_test.sh` has no `set -e` and discards the exit status of every `docker compose` call. `build` fails, `up -d seed` fails, `up -d miner0 …` fails, all silently; the readiness loop then spins out its full 60 s and reports a timeout.

## Change

Check those four commands and abort on the first one that fails, naming it. New `die()` helper exits `4` — `30` (readiness timeout), `2` (panic), `3` (consensus failure) and `66` (data race) are already in use, and CI only cares about zero vs non-zero.

No `docker info` preflight: `$COMPOSE_CMD build` is already the first command to touch the daemon and prints the permission error itself, so a preflight would just duplicate it. Guarding `up -d` as well covers the `BUILD=0` path.

The readiness loop is deliberately left alone — a timeout *after* a healthy start is a real, differently-caused failure and keeps its own exit code `30`.

## Verification

Against an unreachable daemon, before and after:

```console
$ DOCKER_HOST=unix:///nonexistent NOTTY=1 ./start_test.sh
# before: exit 30, 31 `height=` lines, "Timed out waiting!"
# after:  exit 4,   0 `height=` lines, "### docker compose build failed ###"
```

## Note

This does **not** fix the runner. `job_compose_test` will keep failing for every PR until docker socket access is restored on the self-hosted host (the `github` user needs to be back in the `docker` group). This only makes the next occurrence say so on the first line instead of the thirty-first.