### PR TITLE
fix(indexer): preserve account name/avatar across account updates

### DIFF
--- a/vochain/indexer/db/account.sql.go
+++ b/vochain/indexer/db/account.sql.go
@@ -24,9 +24,12 @@ func (q *Queries) CountAccounts(ctx context.Context) (int64, error) {
 }
 
 const createAccount = `-- name: CreateAccount :execresult
-REPLACE INTO accounts (
+INSERT INTO accounts (
     account, balance, nonce
 ) VALUES (?, ?, ?)
+ON CONFLICT(account) DO UPDATE
+SET balance = excluded.balance,
+    nonce   = excluded.nonce
 `
 
 type CreateAccountParams struct {
@@ -35,6 +38,9 @@ type CreateAccountParams struct {
 	Nonce   int64
 }
 
+// Preserves name/avatar (resolved separately by SetAccountMetadata): a plain
+// REPLACE INTO is DELETE + INSERT, so every account update would otherwise wipe
+// them back to their defaults.
 func (q *Queries) CreateAccount(ctx context.Context, arg CreateAccountParams) (sql.Result, error) {
 	return q.exec(ctx, q.createAccountStmt, createAccount, arg.Account, arg.Balance, arg.Nonce)
 }

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -22,6 +22,7 @@ import (
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/dvote/vochain"
+	indexerdb "go.vocdoni.io/dvote/vochain/indexer/db"
 	"go.vocdoni.io/dvote/vochain/indexer/indexertypes"
 	"go.vocdoni.io/dvote/vochain/results"
 	"go.vocdoni.io/dvote/vochain/state"
@@ -1242,6 +1243,37 @@ func TestVoteMemoSurvivesReindex(t *testing.T) {
 	env, err = idx.GetEnvelope(vote.Nullifier)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, env.Memo, qt.DeepEquals, memo)
+}
+
+// TestAccountMetadataSurvivesReindex guards the same REPLACE INTO hazard as
+// TestVoteMemoSurvivesReindex, but for accounts.name/avatar: those columns are
+// resolved separately by SetAccountMetadata, so OnSetAccount (called on every
+// balance/nonce change) must not reset them to their defaults.
+func TestAccountMetadataSurvivesReindex(t *testing.T) {
+	app := vochain.TestBaseApplication(t)
+	idx := newTestIndexer(t, app)
+	account := util.RandomBytes(20)
+
+	idx.OnSetAccount(account, &state.Account{Account: models.Account{Balance: 100, Nonce: 0}})
+	app.AdvanceTestBlock()
+
+	qt.Assert(t, idx.SetAccountMetadata(account, "Acme", "ipfs://avatar"), qt.IsNil)
+
+	// A subsequent account update (e.g. a balance change from a later tx) must
+	// not wipe the metadata resolved above.
+	idx.OnSetAccount(account, &state.Account{Account: models.Account{Balance: 50, Nonce: 1}})
+	app.AdvanceTestBlock()
+
+	rows, err := idx.readOnlyQuery.SearchAccounts(context.TODO(), indexerdb.SearchAccountsParams{
+		Limit:           10,
+		AccountIDSubstr: hex.EncodeToString(account),
+	})
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, rows, qt.HasLen, 1)
+	qt.Assert(t, rows[0].Name, qt.Equals, "Acme")
+	qt.Assert(t, rows[0].Avatar, qt.Equals, "ipfs://avatar")
+	qt.Assert(t, rows[0].Balance, qt.Equals, int64(50))
+	qt.Assert(t, rows[0].Nonce, qt.Equals, int64(1))
 }
 
 func TestOverwriteVotes(t *testing.T) {

--- a/vochain/indexer/queries/account.sql
+++ b/vochain/indexer/queries/account.sql
@@ -1,7 +1,13 @@
 -- name: CreateAccount :execresult
-REPLACE INTO accounts (
+-- Preserves name/avatar (resolved separately by SetAccountMetadata): a plain
+-- REPLACE INTO is DELETE + INSERT, so every account update would otherwise wipe
+-- them back to their defaults.
+INSERT INTO accounts (
     account, balance, nonce
-) VALUES (?, ?, ?);
+) VALUES (?, ?, ?)
+ON CONFLICT(account) DO UPDATE
+SET balance = excluded.balance,
+    nonce   = excluded.nonce;
 
 -- name: SearchAccounts :many
 WITH results AS (


### PR DESCRIPTION
## Problem

From the #1434 review (argos): `CreateAccount` is `REPLACE INTO accounts (account, balance, nonce)`. In SQLite, REPLACE is DELETE + INSERT, so every column not in the list reverts to its `NOT NULL DEFAULT ''`. `OnSetAccount` runs on every account state change — including the nonce bump from any transaction the organization signs — so the `name`/`avatar` columns added by migration 0017 were wiped on each subsequent update.

Concrete scenario: an organization's name and avatar get resolved and cached, then the org creates its next election — the nonce bump resets both to empty, the `?name=` filter stops matching it, and `ListAccountsMissingName` re-lists it on the next boot, re-triggering the IPFS fetch. For any actively transacting org the cache was effectively never populated.

This is the same hazard #1419 already fixed for `CreateVote` (the memo column); the accounts writer was missed.

## Fix

`INSERT INTO accounts ... ON CONFLICT(account) DO UPDATE SET balance, nonce` — leaves `name`/`avatar` (owned by `SetAccountMetadata`) untouched.

Adds `TestAccountMetadataSurvivesReindex`: metadata set → `OnSetAccount` → name/avatar/balance/nonce all correct. Verified it **fails on the current `REPLACE INTO`** and passes with the upsert.

(p4u: this is the standalone diff you asked argos for in #1434 — recovered from its dropped commit, re-verified, and retested.)