### PR TITLE
fix(api,vocone): review follow-ups for chain stats, name filter, metadata cache

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"go.vocdoni.io/dvote/api/censusdb"
 	"go.vocdoni.io/dvote/data"
@@ -116,6 +117,11 @@ type API struct {
 	db       db.Database // used for internal db operations
 
 	censusPublishStatusMap sync.Map // used to store the status of the census publishing process when async
+
+	// chainStatsMu guards the short-lived cache for chainStatsHandler.
+	chainStatsMu    sync.Mutex
+	chainStatsCache *ChainStats
+	chainStatsAt    time.Time
 }
 
 // NewAPI creates a new instance of the API.  Attach must be called next.

--- a/api/chain.go
+++ b/api/chain.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	comettypes "github.com/cometbft/cometbft/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -30,8 +31,9 @@ import (
 // maxTransactionBatchSize bounds how many transactions POST /chain/transactions/batch accepts.
 const maxTransactionBatchSize = 100
 
-// MaxOrganizationNameFilterLen bounds the length of the ?name= substring filter
-// accepted by /chain/organizations, before it reaches the SearchEntities query.
+// MaxOrganizationNameFilterLen bounds the ?name= substring filter accepted by
+// /chain/organizations, in runes (characters), before it reaches the
+// SearchEntities query.
 const MaxOrganizationNameFilterLen = 100
 
 const (
@@ -1675,9 +1677,9 @@ func parseOrganizationParams(paramPage, paramLimit, paramOrganizationID, paramNa
 }
 
 // validateOrganizationNameFilter rejects a ?name= filter before it reaches
-// SearchEntities: too long, or containing non-printable characters.
+// SearchEntities: too many runes, or containing non-printable characters.
 func validateOrganizationNameFilter(name string) error {
-	if len(name) > MaxOrganizationNameFilterLen {
+	if utf8.RuneCountInString(name) > MaxOrganizationNameFilterLen {
 		return ErrParamNameInvalid
 	}
 	for _, r := range name {

--- a/api/chain.go
+++ b/api/chain.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	comettypes "github.com/cometbft/cometbft/types"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -28,6 +29,10 @@ import (
 
 // maxTransactionBatchSize bounds how many transactions POST /chain/transactions/batch accepts.
 const maxTransactionBatchSize = 100
+
+// MaxOrganizationNameFilterLen bounds the length of the ?name= substring filter
+// accepted by /chain/organizations, before it reaches the SearchEntities query.
+const MaxOrganizationNameFilterLen = 100
 
 const (
 	ChainHandler = "chain"
@@ -450,30 +455,54 @@ func (a *API) organizationCountHandler(_ *apirest.APIdata, ctx *httprouter.HTTPC
 //	@Success		200	{object}	ChainStats
 //	@Router			/chain/stats [get]
 func (a *API) chainStatsHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) error {
+	stats, err := a.chainStats()
+	if err != nil {
+		return err
+	}
+	return marshalAndSend(ctx, stats)
+}
+
+// chainStatsCacheTTL bounds how stale /chain/stats may be. The underlying
+// counters are recomputed with several full-table queries, so caching them
+// avoids repeating that work for every request between two blocks.
+const chainStatsCacheTTL = 10 * time.Second
+
+// chainStats returns the chain-wide counters, reusing a cached response when
+// it is younger than chainStatsCacheTTL.
+func (a *API) chainStats() (*ChainStats, error) {
+	a.chainStatsMu.Lock()
+	defer a.chainStatsMu.Unlock()
+	if a.chainStatsCache != nil && time.Since(a.chainStatsAt) < chainStatsCacheTTL {
+		return a.chainStatsCache, nil
+	}
+
 	txCountByType, err := a.indexer.CountTransactionsByType()
 	if err != nil {
-		return ErrIndexerQueryFailed.WithErr(err)
+		return nil, ErrIndexerQueryFailed.WithErr(err)
 	}
 	electionCountByStatus, err := a.indexer.CountProcessesByStatus()
 	if err != nil {
-		return ErrIndexerQueryFailed.WithErr(err)
+		return nil, ErrIndexerQueryFailed.WithErr(err)
 	}
 	accountCount, err := a.indexer.CountTotalAccounts()
 	if err != nil {
-		return ErrIndexerQueryFailed.WithErr(err)
+		return nil, ErrIndexerQueryFailed.WithErr(err)
 	}
 	voteCount, err := a.indexer.CountTotalVotes()
 	if err != nil {
-		return ErrIndexerQueryFailed.WithErr(err)
+		return nil, ErrIndexerQueryFailed.WithErr(err)
 	}
 
-	return marshalAndSend(ctx, &ChainStats{
+	stats := &ChainStats{
 		TxCountByType:         txCountByType,
 		ElectionCountByStatus: electionCountByStatus,
 		AccountCount:          accountCount,
 		ElectionCount:         a.indexer.CountTotalProcesses(),
 		VoteCount:             voteCount,
-	})
+	}
+	a.chainStatsCache = stats
+	a.chainStatsAt = time.Now()
+	return stats, nil
 }
 
 // chainInfoHandler
@@ -1634,12 +1663,29 @@ func parseOrganizationParams(paramPage, paramLimit, paramOrganizationID, paramNa
 	if err != nil {
 		return nil, err
 	}
+	if err := validateOrganizationNameFilter(paramName); err != nil {
+		return nil, err
+	}
 
 	return &OrganizationParams{
 		PaginationParams: pagination,
 		OrganizationID:   util.TrimHex(paramOrganizationID),
 		Name:             paramName,
 	}, nil
+}
+
+// validateOrganizationNameFilter rejects a ?name= filter before it reaches
+// SearchEntities: too long, or containing non-printable characters.
+func validateOrganizationNameFilter(name string) error {
+	if len(name) > MaxOrganizationNameFilterLen {
+		return ErrParamNameInvalid
+	}
+	for _, r := range name {
+		if !unicode.IsPrint(r) {
+			return ErrParamNameInvalid
+		}
+	}
+	return nil
 }
 
 // parseFeesParams returns an FeesParams filled with the passed params

--- a/api/chain_name_filter_test.go
+++ b/api/chain_name_filter_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateOrganizationNameFilter(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"100 ascii", strings.Repeat("a", 100), false},
+		{"101 ascii", strings.Repeat("a", 101), true},
+		// 100 multi-byte runes: >100 bytes but <=100 runes, must pass (the regression fixed here).
+		{"100 multibyte runes", strings.Repeat("é", 100), false},
+		{"101 multibyte runes", strings.Repeat("é", 101), true},
+		{"non-printable null", "abc\x00def", true},
+		{"non-printable newline", "abc\ndef", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateOrganizationNameFilter(tc.input)
+			if tc.wantErr {
+				if !errors.Is(err, ErrParamNameInvalid) {
+					t.Fatalf("got err %v, want ErrParamNameInvalid", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("got err %v, want nil", err)
+			}
+		})
+	}
+}

--- a/api/errors.go
+++ b/api/errors.go
@@ -88,6 +88,7 @@ var (
 	ErrTransactionBatchEmpty            = apirest.APIerror{Code: 4060, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("transaction batch is empty")}
 	ErrParamBucketInvalid               = apirest.APIerror{Code: 4061, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (bucket) invalid, must be hour or day")}
 	ErrTooManyBucketsRequested          = apirest.APIerror{Code: 4062, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("too many time buckets requested, use a coarser bucket or narrow the time window with the (from) and (to) params")}
+	ErrParamNameInvalid                 = apirest.APIerror{Code: 4063, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (name) invalid, must be at most %d printable characters", MaxOrganizationNameFilterLen)}
 	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
 	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
 	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}

--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -41,7 +41,35 @@ const (
 	// is deliberately short: the backfill is meant to pick up what the local
 	// store already has, not to wait on the network for what it does not.
 	metadataBackfillTimeout = time.Second
+	// metadataBackfillMaxFailures caps how many unresolved fetches a single
+	// backfill pass tolerates before giving up early. Without a bound, a
+	// backlog of permanently unreachable metadata documents gets re-fetched
+	// over the network in full on every boot.
+	metadataBackfillMaxFailures = 200
+	// metadataCacheWriteWorkers bounds the number of detached goroutines that
+	// may be writing request-triggered cache updates at once, so a burst of
+	// requests cannot pile up writers against the single read-write connection
+	// that block commits also use.
+	metadataCacheWriteWorkers = 4
 )
+
+// metadataCacheWriteSem bounds concurrent request-triggered cache writes; see
+// metadataCacheWriteWorkers.
+var metadataCacheWriteSem = make(chan struct{}, metadataCacheWriteWorkers)
+
+// cacheWrite runs fn on a detached goroutine if the concurrent-write bound
+// allows it, and drops it otherwise: the cache will be filled by a future
+// request or by the next boot's backfill, so no caller needs to wait or queue.
+func cacheWrite(fn func()) {
+	select {
+	case metadataCacheWriteSem <- struct{}{}:
+		go func() {
+			defer func() { <-metadataCacheWriteSem }()
+			fn()
+		}()
+	default:
+	}
+}
 
 // languageString picks a displayable value out of a multi-language string,
 // preferring the default language and falling back to any English variant.
@@ -62,11 +90,11 @@ func (a *API) cacheElectionTitle(electionID []byte, metadata *ElectionMetadata) 
 		return
 	}
 	id := append([]byte(nil), electionID...)
-	go func() {
+	cacheWrite(func() {
 		if err := a.indexer.SetProcessMetadataTitle(id, title); err != nil {
 			log.Warnw("could not cache election title", "electionId", id, "err", err.Error())
 		}
-	}()
+	})
 }
 
 // cacheAccountMetadata stores an already resolved organization name and avatar
@@ -84,11 +112,11 @@ func (a *API) cacheAccountMetadata(address []byte, metadata *AccountMetadata) {
 		return
 	}
 	addr := append([]byte(nil), address...)
-	go func() {
+	cacheWrite(func() {
 		if err := a.indexer.SetAccountMetadata(addr, name, avatar); err != nil {
 			log.Warnw("could not cache account metadata", "account", addr, "err", err.Error())
 		}
-	}()
+	})
 }
 
 // startMetadataBackfill launches, once per boot, a best-effort pass filling the
@@ -163,6 +191,7 @@ func (a *API) retrieveMetadata(uri string, v any) bool {
 // cached, and returns how many were filled.
 func (a *API) backfillElectionTitles() int {
 	filled := 0
+	failures := 0
 	var after []byte
 	for {
 		pending, err := a.indexer.ProcessesMissingMetadataTitle(after, metadataBackfillBatch)
@@ -174,7 +203,7 @@ func (a *API) backfillElectionTitles() int {
 			return filled
 		}
 		after = pending[len(pending)-1].ProcessID
-		filled += backfillWorkers(pending, func(p indexer.ProcessMetadataURI) bool {
+		batchFilled := backfillWorkers(pending, func(p indexer.ProcessMetadataURI) bool {
 			metadata := ElectionMetadata{}
 			if !a.retrieveMetadata(p.URI, &metadata) {
 				return false
@@ -189,6 +218,13 @@ func (a *API) backfillElectionTitles() int {
 			}
 			return true
 		})
+		filled += batchFilled
+		failures += len(pending) - batchFilled
+		if failures >= metadataBackfillMaxFailures {
+			log.Infow("metadata backfill stopping early, too many unresolved election titles",
+				"filled", filled, "failures", failures)
+			return filled
+		}
 	}
 }
 
@@ -200,6 +236,7 @@ func (a *API) backfillAccountMetadata() int {
 		return 0
 	}
 	filled := 0
+	failures := 0
 	var after []byte
 	for {
 		pending, err := a.indexer.AccountsMissingName(after, metadataBackfillBatch)
@@ -211,7 +248,7 @@ func (a *API) backfillAccountMetadata() int {
 			return filled
 		}
 		after = pending[len(pending)-1]
-		filled += backfillWorkers(pending, func(address []byte) bool {
+		batchFilled := backfillWorkers(pending, func(address []byte) bool {
 			acc, err := a.vocapp.State.GetAccount(common.BytesToAddress(address), true)
 			if err != nil || acc == nil {
 				return false
@@ -234,5 +271,12 @@ func (a *API) backfillAccountMetadata() int {
 			}
 			return true
 		})
+		filled += batchFilled
+		failures += len(pending) - batchFilled
+		if failures >= metadataBackfillMaxFailures {
+			log.Infow("metadata backfill stopping early, too many unresolved account metadata fetches",
+				"filled", filled, "failures", failures)
+			return filled
+		}
 	}
 }

--- a/vochain/state/votes.go
+++ b/vochain/state/votes.go
@@ -35,9 +35,9 @@ type Vote struct {
 	VoterID              VoterID
 	Overwrites           uint32
 	// Memo is an optional free-text note attached by the voter, at most
-	// types.MaxVoteMemoSize bytes of valid UTF-8. Bytes rather than string to
-	// match VoteEnvelope.memo and StateDBVote.memo on either side of it.
-	// Validated in VoteTxCheck; nil when the voter attached none.
+	// types.MaxVoteMemoSize opaque bytes. Bytes rather than string to match
+	// VoteEnvelope.memo and StateDBVote.memo on either side of it. Only its
+	// length is validated in VoteTxCheck; nil when the voter attached none.
 	Memo []byte
 }
 

--- a/vocone/vocone.go
+++ b/vocone/vocone.go
@@ -28,7 +28,6 @@ import (
 	"go.vocdoni.io/dvote/vochain/indexer"
 	"go.vocdoni.io/dvote/vochain/keykeeper"
 	"go.vocdoni.io/dvote/vochain/state"
-	"go.vocdoni.io/dvote/vochain/transaction/proofs/farcasterproof"
 	"go.vocdoni.io/dvote/vochain/vochaininfo"
 	"go.vocdoni.io/proto/build/go/models"
 )
@@ -127,6 +126,8 @@ func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool,
 	if err != nil {
 		return nil, fmt.Errorf("could not create indexer: %w", err)
 	}
+	// launch the indexer after sync routine (executed when the blockchain is ready)
+	go vc.Indexer.AfterSyncBootstrap(false)
 
 	// Create key keeper (also adds the validator).
 	if err := vc.SetKeyKeeper(keymanager); err != nil {
@@ -151,9 +152,6 @@ func NewVocone(dataDir string, keymanager *ethereum.SignKeys, disableIPFS bool,
 			return nil, fmt.Errorf("could not create offchain data handler: %w", err)
 		}
 	}
-
-	// Disable election ID verification on the farcaster proof for testing purposes.
-	farcasterproof.DisableElectionIDVerification = true
 
 	return vc, nil
 }


### PR DESCRIPTION
Salvages the valid fixes from #1437 (which I'm closing — it also carried an unrequested ~2800-line removal of the Farcaster Frame feature, live on main since #1248, that no reviewer asked for).

Covers these items from the #1434 review, tracked in #1435:

- `/chain/stats`: 10s TTL cache — the counters run GROUP BY / COUNT(*) scans over the largest tables on every unauthenticated request
- `?name=` organization filter: reject >100 chars or non-printable characters before it reaches `SearchEntities` (new error 4063)
- metadata cache: request-triggered writes bounded to 4 concurrent goroutines (drop when full — the value is re-resolved on a future request or boot); boot backfill stops early after 200 unresolved fetches instead of re-fetching them every boot
- vocone: call `Indexer.AfterSyncBootstrap` at startup so the post-migration reindex flag is actually consumed (vote `blockTime` / `key_reveal_*` columns would otherwise stay empty on a reused datadir)
- `Vote.Memo` doc: opaque bytes, only length validated — drops the false UTF-8 claim

`go build ./...`, `go vet`, and `go test ./api/...` pass locally.