### PR TITLE
feat(api): sort organizations by election count, name or creation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -95,6 +95,8 @@ const (
 	ParamStartDateBefore = "startDateBefore"
 	ParamEndDateAfter    = "endDateAfter"
 	ParamEndDateBefore   = "endDateBefore"
+	ParamSortBy          = "sortBy"
+	ParamOrder           = "order"
 )
 
 var (

--- a/api/api_types.go
+++ b/api/api_types.go
@@ -35,11 +35,13 @@ type ElectionParams struct {
 	EndDateBefore   *time.Time `json:"endDateBefore,omitempty"`
 }
 
-// OrganizationParams allows the client to filter organizations
+// OrganizationParams allows the client to filter and sort organizations
 type OrganizationParams struct {
 	PaginationParams
 	OrganizationID string `json:"organizationId,omitempty"`
 	Name           string `json:"name,omitempty"`
+	SortBy         string `json:"sortBy,omitempty"`
+	Order          string `json:"order,omitempty"`
 }
 
 // AccountParams allows the client to filter accounts

--- a/api/chain.go
+++ b/api/chain.go
@@ -289,6 +289,8 @@ func (a *API) enableChainHandlers() error {
 //	@Param					limit			query		number	false	"Items per page"
 //	@Param					organizationId	query		string	false	"Filter by partial organizationId"
 //	@Param					name			query		string	false	"Filter by organization name, case-insensitive substring match (ASCII case folding only)"
+//	@Param					sortBy			query		string	false	"Sort by createdAt (when the organization first appeared, default), electionCount or name"	Enums(createdAt, electionCount, name)
+//	@Param					order			query		string	false	"Sort direction. Defaults to desc for createdAt and electionCount, asc for name"			Enums(asc, desc)
 //	@Success				200				{object}	OrganizationsList
 //	@Router					/chain/organizations [get]
 func (a *API) organizationListHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) error {
@@ -297,6 +299,8 @@ func (a *API) organizationListHandler(_ *apirest.APIdata, ctx *httprouter.HTTPCo
 		ctx.QueryParam(ParamLimit),
 		ctx.QueryParam(ParamOrganizationId),
 		ctx.QueryParam(ParamName),
+		ctx.QueryParam(ParamSortBy),
+		ctx.QueryParam(ParamOrder),
 	)
 	if err != nil {
 		return err
@@ -325,6 +329,8 @@ func (a *API) organizationListHandler(_ *apirest.APIdata, ctx *httprouter.HTTPCo
 func (a *API) organizationListByPageHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	params, err := parseOrganizationParams(
 		ctx.URLParam(ParamPage),
+		"",
+		"",
 		"",
 		"",
 		"",
@@ -388,15 +394,26 @@ func (a *API) organizationListByFilterAndPageHandler(msg *apirest.APIdata, ctx *
 	return marshalAndSend(ctx, list)
 }
 
-// organizationList produces a filtered, paginated OrganizationsList.
+// organizationList produces a filtered, sorted, paginated OrganizationsList.
+//
+// The ordering is validated here rather than in parseOrganizationParams so that
+// the deprecated POST filter endpoint, which unmarshals its OrganizationParams
+// straight from the request body, is covered as well.
 //
 // Errors returned are always of type APIerror.
 func (a *API) organizationList(params *OrganizationParams) (*OrganizationsList, error) {
+	sortBy, order, err := parseOrganizationSort(params.SortBy, params.Order)
+	if err != nil {
+		return nil, err
+	}
+
 	orgs, total, err := a.indexer.EntityList(
 		params.Limit,
 		params.Page*params.Limit,
 		params.OrganizationID,
 		params.Name,
+		sortBy,
+		order,
 	)
 	if err != nil {
 		return nil, ErrIndexerQueryFailed.WithErr(err)
@@ -1628,8 +1645,14 @@ func (a *API) chainIndexerExportHandler(_ *apirest.APIdata, ctx *httprouter.HTTP
 	return ctx.Send(data, apirest.HTTPstatusOK)
 }
 
-// parseOrganizationParams returns an OrganizationParams filled with the passed params
-func parseOrganizationParams(paramPage, paramLimit, paramOrganizationID, paramName string) (*OrganizationParams, error) {
+// parseOrganizationParams returns an OrganizationParams filled with the passed params.
+//
+// paramSortBy and paramOrder are carried through as given; organizationList
+// validates and defaults them, so that the endpoints taking an OrganizationParams
+// from a JSON body are covered by the same check.
+func parseOrganizationParams(paramPage, paramLimit, paramOrganizationID, paramName,
+	paramSortBy, paramOrder string,
+) (*OrganizationParams, error) {
 	pagination, err := parsePaginationParams(paramPage, paramLimit)
 	if err != nil {
 		return nil, err
@@ -1639,6 +1662,8 @@ func parseOrganizationParams(paramPage, paramLimit, paramOrganizationID, paramNa
 		PaginationParams: pagination,
 		OrganizationID:   util.TrimHex(paramOrganizationID),
 		Name:             paramName,
+		SortBy:           paramSortBy,
+		Order:            paramOrder,
 	}, nil
 }
 

--- a/api/chain_organizations_test.go
+++ b/api/chain_organizations_test.go
@@ -131,4 +131,40 @@ func TestOrganizationListSorting(t *testing.T) {
 	legacy := &OrganizationsList{}
 	c.Assert(json.Unmarshal(resp, legacy), qt.IsNil)
 	c.Assert(legacy.Organizations, qt.HasLen, 3)
+
+	// The deprecated POST filter endpoint takes its OrganizationParams straight
+	// from the request body, so it reaches the ordering without going through
+	// parseOrganizationParams. It must sort, and reject, just the same.
+	postList := func(body *OrganizationParams) []string {
+		resp, code := cl.Request("POST", body, "organizations", "filter", "page", "0")
+		c.Assert(code, qt.Equals, apirest.HTTPstatusOK, qt.Commentf("body %+v: %s", body, resp))
+		result := &OrganizationsList{}
+		c.Assert(json.Unmarshal(resp, result), qt.IsNil)
+		byID := map[string]string{}
+		for name, eid := range orgs {
+			byID[hex.EncodeToString(eid)] = name
+		}
+		names := []string{}
+		for _, org := range result.Organizations {
+			names = append(names, byID[org.OrganizationID.String()])
+		}
+		return names
+	}
+	c.Assert(postList(&OrganizationParams{SortBy: "electionCount", Order: "desc"}),
+		qt.DeepEquals, []string{"abacus", "zenith", "quorum"})
+	c.Assert(postList(&OrganizationParams{}), qt.DeepEquals, []string{"zenith", "abacus", "quorum"})
+
+	for _, tc := range []struct {
+		body    *OrganizationParams
+		wantErr apirest.APIerror
+	}{
+		{&OrganizationParams{SortBy: "votes"}, ErrParamSortByInvalid},
+		{&OrganizationParams{Order: "sideways"}, ErrParamOrderInvalid},
+	} {
+		resp, code := cl.Request("POST", tc.body, "organizations", "filter", "page", "0")
+		c.Assert(code, qt.Equals, tc.wantErr.HTTPstatus, qt.Commentf("body %+v: %s", tc.body, resp))
+		apiErr := &apirest.APIerror{}
+		c.Assert(json.Unmarshal(resp, apiErr), qt.IsNil)
+		c.Assert(apiErr.Code, qt.Equals, tc.wantErr.Code, qt.Commentf("body %+v: %s", tc.body, resp))
+	}
 }

--- a/api/chain_organizations_test.go
+++ b/api/chain_organizations_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/url"
+	"path"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
+	"go.vocdoni.io/dvote/api/censusdb"
+	"go.vocdoni.io/dvote/data/ipfs"
+	"go.vocdoni.io/dvote/db"
+	"go.vocdoni.io/dvote/db/metadb"
+	"go.vocdoni.io/dvote/httprouter"
+	"go.vocdoni.io/dvote/httprouter/apirest"
+	"go.vocdoni.io/dvote/test/testcommon/testutil"
+	"go.vocdoni.io/dvote/util"
+	"go.vocdoni.io/dvote/vochain"
+	"go.vocdoni.io/dvote/vochain/indexer"
+	"go.vocdoni.io/dvote/vochain/state"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+// TestOrganizationListSorting exercises the sortBy/order params of
+// GET /chain/organizations end to end, over a small indexed fixture.
+func TestOrganizationListSorting(t *testing.T) {
+	c := qt.New(t)
+
+	router := httprouter.HTTProuter{}
+	router.Init("127.0.0.1", 0)
+	addr, err := url.Parse("http://" + path.Join(router.Address().String(), "chain"))
+	c.Assert(err, qt.IsNil)
+
+	api, err := NewAPI(&router, "/", t.TempDir(), db.TypePebble)
+	c.Assert(err, qt.IsNil)
+	kv, err := metadb.New(db.TypePebble, t.TempDir())
+	c.Assert(err, qt.IsNil)
+	app := vochain.TestBaseApplication(t)
+	idx, err := indexer.New(app, indexer.Options{DataDir: t.TempDir()})
+	c.Assert(err, qt.IsNil)
+	api.Attach(app, nil, idx, ipfs.MockIPFS(t), censusdb.NewCensusDB(kv))
+	c.Assert(api.EnableHandlers(ChainHandler), qt.IsNil)
+
+	// Three organizations with a distinct number of elections each, created
+	// oldest to newest. A process is indexed with the timestamp of the block
+	// before the one committing it, hence two blocks per organization.
+	orgs := map[string][]byte{
+		"quorum": util.RandomBytes(20),
+		"abacus": util.RandomBytes(20),
+		"zenith": util.RandomBytes(20),
+	}
+	electionCounts := map[string]int{"quorum": 1, "abacus": 3, "zenith": 2}
+	for _, name := range []string{"quorum", "abacus", "zenith"} {
+		eid := orgs[name]
+		for i := 0; i < electionCounts[name]; i++ {
+			c.Assert(app.State.AddProcess(&models.Process{
+				ProcessId:     util.RandomBytes(32),
+				EntityId:      eid,
+				EnvelopeType:  &models.EnvelopeType{},
+				Status:        models.ProcessStatus_READY,
+				Mode:          &models.ProcessMode{AutoStart: true},
+				BlockCount:    100,
+				MaxCensusSize: 10,
+				VoteOptions:   &models.ProcessVoteOptions{MaxCount: 1, MaxValue: 1},
+			}), qt.IsNil)
+		}
+		idx.OnSetAccount(eid, &state.Account{})
+		app.AdvanceTestBlock()
+		app.AdvanceTestBlock()
+		c.Assert(idx.SetAccountMetadata(eid, name, ""), qt.IsNil)
+	}
+
+	token := uuid.New()
+	cl := testutil.NewTestHTTPclient(t, addr, &token)
+
+	list := func(query string) []string {
+		resp, code := cl.RequestWithQuery("GET", nil, query, "organizations")
+		c.Assert(code, qt.Equals, apirest.HTTPstatusOK, qt.Commentf("query %q: %s", query, resp))
+		result := &OrganizationsList{}
+		c.Assert(json.Unmarshal(resp, result), qt.IsNil)
+		byID := map[string]string{}
+		for name, eid := range orgs {
+			byID[hex.EncodeToString(eid)] = name
+		}
+		names := []string{}
+		for _, org := range result.Organizations {
+			names = append(names, byID[org.OrganizationID.String()])
+		}
+		return names
+	}
+
+	// Ranking by election count, which is what a "top organizations" view needs:
+	// one request, no client-side sweep of every page.
+	c.Assert(list("sortBy=electionCount&order=desc"), qt.DeepEquals, []string{"abacus", "zenith", "quorum"})
+	c.Assert(list("sortBy=electionCount&order=asc"), qt.DeepEquals, []string{"quorum", "zenith", "abacus"})
+	// order defaults to the natural direction of each sortBy.
+	c.Assert(list("sortBy=electionCount"), qt.DeepEquals, []string{"abacus", "zenith", "quorum"})
+	c.Assert(list("sortBy=name"), qt.DeepEquals, []string{"abacus", "quorum", "zenith"})
+	c.Assert(list("sortBy=name&order=desc"), qt.DeepEquals, []string{"zenith", "quorum", "abacus"})
+	c.Assert(list("sortBy=createdAt"), qt.DeepEquals, []string{"zenith", "abacus", "quorum"})
+	c.Assert(list("sortBy=createdAt&order=asc"), qt.DeepEquals, []string{"quorum", "abacus", "zenith"})
+	// No sortBy at all keeps the ordering the endpoint had before it took one.
+	c.Assert(list(""), qt.DeepEquals, []string{"zenith", "abacus", "quorum"})
+
+	// Sorting composes with paging and with the existing filters.
+	c.Assert(list("sortBy=electionCount&order=desc&limit=1"), qt.DeepEquals, []string{"abacus"})
+	c.Assert(list("sortBy=electionCount&order=desc&limit=1&page=1"), qt.DeepEquals, []string{"zenith"})
+	c.Assert(list("sortBy=electionCount&order=desc&limit=1&page=2"), qt.DeepEquals, []string{"quorum"})
+	c.Assert(list("sortBy=name&order=asc&name=quo"), qt.DeepEquals, []string{"quorum"})
+
+	// Unsupported values are a 400, not silently ignored.
+	for query, wantErr := range map[string]apirest.APIerror{
+		"sortBy=electioncount":              ErrParamSortByInvalid,
+		"sortBy=votes":                      ErrParamSortByInvalid,
+		"order=sideways":                    ErrParamOrderInvalid,
+		"sortBy=electionCount&order=DESC":   ErrParamOrderInvalid,
+		"sortBy=electionCount&order=lowest": ErrParamOrderInvalid,
+	} {
+		resp, code := cl.RequestWithQuery("GET", nil, query, "organizations")
+		c.Assert(code, qt.Equals, wantErr.HTTPstatus, qt.Commentf("query %q: %s", query, resp))
+		apiErr := &apirest.APIerror{}
+		c.Assert(json.Unmarshal(resp, apiErr), qt.IsNil)
+		c.Assert(apiErr.Code, qt.Equals, wantErr.Code, qt.Commentf("query %q: %s", query, resp))
+	}
+
+	// The deprecated by-page endpoint keeps working, with the default ordering.
+	resp, code := cl.Request("GET", nil, "organizations", "page", "0")
+	c.Assert(code, qt.Equals, apirest.HTTPstatusOK)
+	legacy := &OrganizationsList{}
+	c.Assert(json.Unmarshal(resp, legacy), qt.IsNil)
+	c.Assert(legacy.Organizations, qt.HasLen, 3)
+}

--- a/api/docs/descriptions/organizationListHandler.md
+++ b/api/docs/descriptions/organizationListHandler.md
@@ -5,3 +5,22 @@ The `/chain/organizations` endpoints are related only to the Organization accoun
 
 - Return list of organizations ids.
 - If no page is defined, will assume page 0.
+
+### Sorting
+
+`sortBy` picks the ordering and `order` its direction. Both are optional, and an
+unsupported value is rejected with a 400 rather than ignored.
+
+| `sortBy` | orders by | default `order` |
+| --- | --- | --- |
+| `createdAt` (default) | when the organization first appeared in the index, i.e. the creation time of its oldest indexed election | `desc`, newest organizations first |
+| `electionCount` | how many elections the organization has | `desc`, busiest organizations first |
+| `name` | the organization name resolved from its account metadata, case-insensitively (ASCII case folding only). Organizations whose account resolves no name always sort last, in either direction | `asc`, alphabetical |
+
+The ordering is total: organizations that tie are ordered by their id, so paging
+through a sorted list never repeats nor skips an organization. Sorting composes
+with the `organizationId` and `name` filters and with `page`/`limit`, so a
+ranking such as the top five organizations by election count is a single
+`?sortBy=electionCount&order=desc&limit=5` request.
+
+Omitting `sortBy` keeps the ordering this endpoint had before it took one.

--- a/api/docs/descriptions/organizationListHandler.md
+++ b/api/docs/descriptions/organizationListHandler.md
@@ -23,4 +23,8 @@ with the `organizationId` and `name` filters and with `page`/`limit`, so a
 ranking such as the top five organizations by election count is a single
 `?sortBy=electionCount&order=desc&limit=5` request.
 
-Omitting `sortBy` keeps the ordering this endpoint had before it took one.
+Omitting `sortBy` orders by `createdAt` descending, as before. Creation times
+have a one second granularity, so organizations whose first election landed in
+the same block share one: their relative order is now their organization id and
+may differ from previous releases, where it was neither documented nor
+deterministic.

--- a/api/errors.go
+++ b/api/errors.go
@@ -88,6 +88,8 @@ var (
 	ErrTransactionBatchEmpty            = apirest.APIerror{Code: 4060, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("transaction batch is empty")}
 	ErrParamBucketInvalid               = apirest.APIerror{Code: 4061, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (bucket) invalid, must be hour or day")}
 	ErrTooManyBucketsRequested          = apirest.APIerror{Code: 4062, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("too many time buckets requested, use a coarser bucket or narrow the time window with the (from) and (to) params")}
+	ErrParamSortByInvalid               = apirest.APIerror{Code: 4063, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (sortBy) invalid")}
+	ErrParamOrderInvalid                = apirest.APIerror{Code: 4064, HTTPstatus: apirest.HTTPstatusBadRequest, Err: fmt.Errorf("parameter (order) invalid, must be asc or desc")}
 	ErrVochainEmptyReply                = apirest.APIerror{Code: 5000, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain returned an empty reply")}
 	ErrVochainSendTxFailed              = apirest.APIerror{Code: 5001, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain SendTx failed")}
 	ErrVochainGetTxFailed               = apirest.APIerror{Code: 5002, HTTPstatus: apirest.HTTPstatusInternalErr, Err: fmt.Errorf("vochain GetTx failed")}

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -325,6 +325,23 @@ func parseBucket(s string) (string, error) {
 	}
 }
 
+// parseOrganizationSort validates an organization list ordering, given as the
+// sortBy and order query params, and fills in the defaults for the empty
+// strings: ordering by createdAt, and the natural direction of the resulting
+// ordering (descending for createdAt and electionCount, ascending for name).
+//
+// If either string doesn't map to a value, returns an APIerror.
+func parseOrganizationSort(sortBy, order string) (string, string, error) {
+	normalizedSortBy, normalizedOrder, err := indexer.NormalizeEntitySort(sortBy, order)
+	if err != nil {
+		if errors.Is(err, indexer.ErrInvalidSortOrder) {
+			return "", "", ErrParamOrderInvalid.With(order)
+		}
+		return "", "", ErrParamSortByInvalid.With(sortBy)
+	}
+	return normalizedSortBy, normalizedOrder, nil
+}
+
 // bucketDuration returns the time span covered by a single bucket of the given
 // granularity, which must be one returned by parseBucket.
 func bucketDuration(bucket string) time.Duration {

--- a/vochain/indexer/db/processes.sql.go
+++ b/vochain/indexer/db/processes.sql.go
@@ -310,15 +310,35 @@ WITH results AS (
         ON a.account = p.entity_id
     WHERE (?3 = '' OR (INSTR(LOWER(HEX(p.entity_id)), ?3) > 0))
     AND (?4 = '' OR (INSTR(LOWER(COALESCE(a.name, '')), LOWER(?4)) > 0))
+), grouped AS (
+    SELECT entity_id,
+        account_name,
+        account_avatar,
+        COUNT(id) AS process_count,
+        COUNT(entity_id) OVER() AS total_count,
+        -- organizations whose account resolves no name sort last when sorting
+        -- by name, in either direction
+        CASE WHEN ?5 = 'name' AND account_name = '' THEN 1 END AS sort_name_empty,
+        CASE WHEN ?6 = 'asc' THEN (CASE
+            WHEN ?5 = 'electionCount' THEN COUNT(id)
+            WHEN ?5 = 'name' THEN LOWER(account_name)
+            WHEN ?5 = 'createdAt' THEN MIN(creation_time)
+        END) END AS sort_key_asc,
+        CASE WHEN ?6 = 'desc' THEN (CASE
+            WHEN ?5 = 'electionCount' THEN COUNT(id)
+            WHEN ?5 = 'name' THEN LOWER(account_name)
+            WHEN ?5 = 'createdAt' THEN MIN(creation_time)
+        END) END AS sort_key_desc
+    FROM results
+    GROUP BY entity_id
 )
 SELECT entity_id,
 	account_name,
 	account_avatar,
-	COUNT(id) AS process_count,
-	COUNT(entity_id) OVER() AS total_count
-FROM results
-GROUP BY entity_id
-ORDER BY creation_time DESC, id ASC
+	process_count,
+	total_count
+FROM grouped
+ORDER BY sort_name_empty ASC, sort_key_asc ASC, sort_key_desc DESC, entity_id ASC
 LIMIT ?2
 OFFSET ?1
 `
@@ -328,6 +348,8 @@ type SearchEntitiesParams struct {
 	Limit          int64
 	EntityIDSubstr interface{}
 	NameSubstr     interface{}
+	SortBy         interface{}
+	SortOrder      interface{}
 }
 
 type SearchEntitiesRow struct {
@@ -343,12 +365,34 @@ type SearchEntitiesRow struct {
 // so a client listing organizations doesn't need one account request per row.
 // The name filter is a case-insensitive substring match; LOWER only folds ASCII
 // in sqlite, so names differing by non-ASCII case or by diacritics do not match.
+//
+// sort_by selects the ordering ('createdAt', 'electionCount' or 'name') and
+// sort_order its direction ('asc' or 'desc'). Both are expected to be one of
+// those exact values; the caller validates them. sqlite cannot parameterize an
+// ORDER BY term and sqlc does not even substitute arguments inside one, so the
+// sort key is computed as a column of the grouped subquery and the outer ORDER
+// BY only picks between the ascending and the descending one, exactly one of
+// which is non-NULL. A term that is NULL on every row compares equal on every
+// row, so it is a no-op.
+//
+// 'createdAt' is MIN(creation_time), the creation time of the *first* election
+// indexed for an organization, i.e. when the organization first appeared in the
+// index. That is what the previous hardcoded `ORDER BY creation_time DESC, id
+// ASC` resolved to in practice: creation_time and id were bare columns of a
+// grouped query, so sqlite took them from an arbitrary row of each group, and
+// with the scan driven by index_processes_entity_id that row was the group's
+// first, i.e. its oldest process.
+//
+// entity_id is always the last tiebreak, so the ordering is total and paging
+// with LIMIT/OFFSET can neither repeat nor skip a row.
 func (q *Queries) SearchEntities(ctx context.Context, arg SearchEntitiesParams) ([]SearchEntitiesRow, error) {
 	rows, err := q.query(ctx, q.searchEntitiesStmt, searchEntities,
 		arg.Offset,
 		arg.Limit,
 		arg.EntityIDSubstr,
 		arg.NameSubstr,
+		arg.SortBy,
+		arg.SortOrder,
 	)
 	if err != nil {
 		return nil, err

--- a/vochain/indexer/indexer_test.go
+++ b/vochain/indexer/indexer_test.go
@@ -164,7 +164,7 @@ func testEntityList(t *testing.T, entityCount int) {
 	entitiesByID := make(map[string]bool)
 	last := 0
 	for len(entitiesByID) <= entityCount {
-		list, _, err := idx.EntityList(10, last, "", "")
+		list, _, err := idx.EntityList(10, last, "", "", "", "")
 		qt.Assert(t, err, qt.IsNil)
 		if len(list) < 1 {
 			t.Log("list is empty")
@@ -186,6 +186,173 @@ func testEntityList(t *testing.T, entityCount int) {
 	if len(entitiesByID) < entityCount {
 		t.Fatalf("expected %d entities, got %d", entityCount, len(entitiesByID))
 	}
+
+	// Paging an ordering where almost every entity ties (all but one have a
+	// single election) must still visit each entity exactly once, which is only
+	// true because entity_id is the last tiebreak.
+	byElectionCount := make(map[string]bool)
+	for offset := 0; ; offset += 10 {
+		list, total, err := idx.EntityList(10, offset, "", "", EntitySortByElectionCount, SortOrderDesc)
+		qt.Assert(t, err, qt.IsNil)
+		if len(list) == 0 {
+			break
+		}
+		qt.Assert(t, total, qt.Equals, uint64(entityCount))
+		for _, e := range list {
+			if byElectionCount[string(e.EntityID)] {
+				t.Fatalf("found duplicated entity: %x", e.EntityID)
+			}
+			byElectionCount[string(e.EntityID)] = true
+		}
+	}
+	qt.Assert(t, byElectionCount, qt.HasLen, entityCount)
+	// the only entity with two elections must come first
+	first, _, err := idx.EntityList(1, 0, "", "", EntitySortByElectionCount, SortOrderDesc)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, first, qt.HasLen, 1)
+	qt.Assert(t, hex.EncodeToString(first[0].EntityID), qt.Equals, hex.EncodeToString(twoProcessesEntity))
+	qt.Assert(t, first[0].ProcessCount, qt.Equals, int64(2))
+}
+
+func TestEntityListSorting(t *testing.T) {
+	app := vochain.TestBaseApplication(t)
+	idx := newTestIndexer(t, app)
+
+	// Fixed entity ids, so the entity_id tiebreak is predictable: eA < eB < eC < eD.
+	eA := bytes.Repeat([]byte{0xaa}, 20)
+	eB := bytes.Repeat([]byte{0xbb}, 20)
+	eC := bytes.Repeat([]byte{0xcc}, 20)
+	eD := bytes.Repeat([]byte{0xdd}, 20)
+
+	addElection := func(eid []byte) {
+		err := app.State.AddProcess(&models.Process{
+			ProcessId:     util.RandomBytes(32),
+			EntityId:      eid,
+			EnvelopeType:  &models.EnvelopeType{},
+			Status:        models.ProcessStatus_READY,
+			Mode:          &models.ProcessMode{AutoStart: true},
+			BlockCount:    100,
+			MaxCensusSize: 10,
+			VoteOptions:   &models.ProcessVoteOptions{MaxCount: 1, MaxValue: 1},
+		})
+		qt.Assert(t, err, qt.IsNil)
+		idx.OnSetAccount(eid, &state.Account{})
+	}
+
+	// Each block is one second later than the previous one, and a process is
+	// indexed with the timestamp of the block before the one committing it, so
+	// two blocks per entity give every entity a distinct creation time: eA is
+	// the oldest, eD the newest.
+	advance := func() {
+		app.AdvanceTestBlock()
+		app.AdvanceTestBlock()
+	}
+	for _, eid := range [][]byte{eA, eB, eC, eD} {
+		addElection(eid)
+		advance()
+	}
+	// Later elections for eB and eC, in a block newer than every entity's first
+	// one. They change each entity's *last* election but not its first, so an
+	// ordering by MAX(creation_time) rather than MIN would come out different.
+	addElection(eB)
+	addElection(eB)
+	addElection(eC)
+	advance()
+
+	// Names chosen so that a case-sensitive (binary) collation would order them
+	// "Bravo" < "alpha" < "charlie"; eC deliberately resolves no name.
+	qt.Assert(t, idx.SetAccountMetadata(eA, "charlie", ""), qt.IsNil)
+	qt.Assert(t, idx.SetAccountMetadata(eB, "alpha", ""), qt.IsNil)
+	qt.Assert(t, idx.SetAccountMetadata(eD, "Bravo", ""), qt.IsNil)
+
+	names := map[string]string{
+		string(eA): "eA(charlie, 1 election, oldest)",
+		string(eB): "eB(alpha, 3 elections)",
+		string(eC): "eC(unnamed, 2 elections)",
+		string(eD): "eD(Bravo, 1 election, newest)",
+	}
+	describe := func(list []indexertypes.Entity) []string {
+		out := []string{}
+		for _, e := range list {
+			out = append(out, names[string(e.EntityID)])
+		}
+		return out
+	}
+	want := func(eids ...[]byte) []string {
+		out := []string{}
+		for _, eid := range eids {
+			out = append(out, names[string(eid)])
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		sortBy, order string
+		want          []string
+	}{
+		// createdAt is the creation time of the entity's *first* election
+		{EntitySortByCreatedAt, SortOrderDesc, want(eD, eC, eB, eA)},
+		{EntitySortByCreatedAt, SortOrderAsc, want(eA, eB, eC, eD)},
+		// eA and eD both have one election, so they fall back to entity_id ASC
+		{EntitySortByElectionCount, SortOrderDesc, want(eB, eC, eA, eD)},
+		{EntitySortByElectionCount, SortOrderAsc, want(eA, eD, eC, eB)},
+		// the unnamed eC sorts last in both directions
+		{EntitySortByName, SortOrderAsc, want(eB, eD, eA, eC)},
+		{EntitySortByName, SortOrderDesc, want(eA, eD, eB, eC)},
+	} {
+		comment := qt.Commentf("sortBy=%s order=%s", tc.sortBy, tc.order)
+		list, total, err := idx.EntityList(10, 0, "", "", tc.sortBy, tc.order)
+		qt.Assert(t, err, qt.IsNil, comment)
+		qt.Assert(t, total, qt.Equals, uint64(4), comment)
+		qt.Assert(t, describe(list), qt.DeepEquals, tc.want, comment)
+
+		// Paging must not repeat nor skip: every page of size 1 yields exactly
+		// the corresponding element of the unpaged list.
+		paged := []string{}
+		for offset := 0; ; offset++ {
+			page, _, err := idx.EntityList(1, offset, "", "", tc.sortBy, tc.order)
+			qt.Assert(t, err, qt.IsNil, comment)
+			if len(page) == 0 {
+				break
+			}
+			paged = append(paged, describe(page)...)
+		}
+		qt.Assert(t, paged, qt.DeepEquals, tc.want, comment)
+
+		// And so must overlapping page sizes: pages 0 and 1 of size 2 share no
+		// row and together are the whole list.
+		firstPage, _, err := idx.EntityList(2, 0, "", "", tc.sortBy, tc.order)
+		qt.Assert(t, err, qt.IsNil, comment)
+		secondPage, _, err := idx.EntityList(2, 2, "", "", tc.sortBy, tc.order)
+		qt.Assert(t, err, qt.IsNil, comment)
+		qt.Assert(t, append(describe(firstPage), describe(secondPage)...), qt.DeepEquals, tc.want, comment)
+	}
+
+	// The zero values keep the ordering EntityList had before it took a sortBy.
+	defaults, _, err := idx.EntityList(10, 0, "", "", "", "")
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, describe(defaults), qt.DeepEquals, want(eD, eC, eB, eA))
+	// An empty order picks the natural direction of the sortBy.
+	naturalName, _, err := idx.EntityList(10, 0, "", "", EntitySortByName, "")
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, describe(naturalName), qt.DeepEquals, want(eB, eD, eA, eC))
+	naturalCount, _, err := idx.EntityList(10, 0, "", "", EntitySortByElectionCount, "")
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, describe(naturalCount), qt.DeepEquals, want(eB, eC, eA, eD))
+
+	// Sorting composes with the filters.
+	filtered, total, err := idx.EntityList(10, 0, "", "a", EntitySortByName, SortOrderAsc)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, total, qt.Equals, uint64(3)) // eC has no name to match
+	qt.Assert(t, describe(filtered), qt.DeepEquals, want(eB, eD, eA))
+
+	// Unsupported values are rejected rather than silently ignored.
+	_, _, err = idx.EntityList(10, 0, "", "", "electioncount", "")
+	qt.Assert(t, err, qt.ErrorIs, ErrInvalidEntitySortBy)
+	_, _, err = idx.EntityList(10, 0, "", "", "", "sideways")
+	qt.Assert(t, err, qt.ErrorIs, ErrInvalidSortOrder)
+	_, _, err = idx.EntityList(10, 0, "", "", EntitySortByName, "DESC")
+	qt.Assert(t, err, qt.ErrorIs, ErrInvalidSortOrder)
 }
 
 func TestEntitySearch(t *testing.T) {
@@ -259,23 +426,23 @@ func TestEntitySearch(t *testing.T) {
 	}
 	app.AdvanceTestBlock()
 	// Exact entity search
-	list, _, err := idx.EntityList(10, 0, "4011d50537fa164b6fef261141797bbe4014526e", "")
+	list, _, err := idx.EntityList(10, 0, "4011d50537fa164b6fef261141797bbe4014526e", "", "", "")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, list, qt.HasLen, 1)
 	// Search for nonexistent entity
-	list, _, err = idx.EntityList(10, 0, "4011d50537fa164b6fef261141797bbe4014526f", "")
+	list, _, err = idx.EntityList(10, 0, "4011d50537fa164b6fef261141797bbe4014526f", "", "", "")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, list, qt.HasLen, 0)
 	// Search containing part of all manually-defined entities
-	list, _, err = idx.EntityList(10, 0, "011d50537fa164b6fef261141797bbe4014526e", "")
+	list, _, err = idx.EntityList(10, 0, "011d50537fa164b6fef261141797bbe4014526e", "", "", "")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, list, qt.HasLen, len(entityIds))
 	// Partial entity search as mixed case hex
-	list, _, err = idx.EntityList(10, 0, "50537FA164B6Fef261141797BbE401452", "")
+	list, _, err = idx.EntityList(10, 0, "50537FA164B6Fef261141797BbE401452", "", "", "")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, list, qt.HasLen, len(entityIds))
 	// Partial entity search as uppercase hex
-	list, _, err = idx.EntityList(10, 0, "50537FA164B6FEF261141797BBE401452", "")
+	list, _, err = idx.EntityList(10, 0, "50537FA164B6FEF261141797BBE401452", "", "", "")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, list, qt.HasLen, len(entityIds))
 }
@@ -360,7 +527,7 @@ func testProcessList(t *testing.T, procsCount int) {
 
 	qt.Assert(t, idx.CountTotalProcesses(), qt.Equals, uint64(10+procsCount))
 	countEntityProcs := func(eid []byte) int64 {
-		list, _, err := idx.EntityList(1, 0, fmt.Sprintf("%x", eid), "")
+		list, _, err := idx.EntityList(1, 0, fmt.Sprintf("%x", eid), "", "", "")
 		qt.Assert(t, err, qt.IsNil)
 		if len(list) == 0 {
 			return -1
@@ -1907,7 +2074,7 @@ func TestEntityMetadata(t *testing.T) {
 	app.AdvanceTestBlock()
 
 	// with no metadata resolved yet, the rows carry no name
-	list, total, err := idx.EntityList(10, 0, "", "")
+	list, total, err := idx.EntityList(10, 0, "", "", "", "")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, total, qt.Equals, uint64(2))
 	for _, e := range list {
@@ -1917,7 +2084,7 @@ func TestEntityMetadata(t *testing.T) {
 
 	// resolving the metadata of one of them embeds it in its list row
 	qt.Assert(t, idx.SetAccountMetadata(entities[0], "Bank of Åland", "ipfs://avatar"), qt.IsNil)
-	list, _, err = idx.EntityList(10, 0, hex.EncodeToString(entities[0]), "")
+	list, _, err = idx.EntityList(10, 0, hex.EncodeToString(entities[0]), "", "", "")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, list, qt.HasLen, 1)
 	qt.Assert(t, list[0].Name, qt.Equals, "Bank of Åland")
@@ -1925,13 +2092,13 @@ func TestEntityMetadata(t *testing.T) {
 
 	// the name filter matches a substring, ignoring ASCII case
 	for _, query := range []string{"Bank", "bank of", "BANK OF ÅLAND"} {
-		list, total, err = idx.EntityList(10, 0, "", query)
+		list, total, err = idx.EntityList(10, 0, "", query, "", "")
 		qt.Assert(t, err, qt.IsNil, qt.Commentf("query %q", query))
 		qt.Assert(t, total, qt.Equals, uint64(1), qt.Commentf("query %q", query))
 		qt.Assert(t, hex.EncodeToString(list[0].EntityID), qt.Equals, hex.EncodeToString(entities[0]))
 	}
 	// and it excludes the organizations with no name resolved
-	_, total, err = idx.EntityList(10, 0, "", "nonesuch")
+	_, total, err = idx.EntityList(10, 0, "", "nonesuch", "", "")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, total, qt.Equals, uint64(0))
 

--- a/vochain/indexer/process.go
+++ b/vochain/indexer/process.go
@@ -136,21 +136,90 @@ func (idx *Indexer) CountProcessesByStatus() (map[string]uint64, error) {
 	return counts, nil
 }
 
+// Orderings supported by EntityList.
+const (
+	// EntitySortByCreatedAt orders by the creation time of the first election
+	// indexed for the entity, i.e. by when the entity first appeared in the
+	// index. It is the default, and matches the ordering EntityList had before
+	// it took a sortBy.
+	EntitySortByCreatedAt = "createdAt"
+	// EntitySortByElectionCount orders by how many elections the entity has.
+	EntitySortByElectionCount = "electionCount"
+	// EntitySortByName orders by the entity name resolved from its account
+	// metadata, case-insensitively (ASCII case folding only). Entities whose
+	// account resolves no name sort last, in either direction.
+	EntitySortByName = "name"
+)
+
+// Sort directions supported by EntityList.
+const (
+	SortOrderAsc  = "asc"
+	SortOrderDesc = "desc"
+)
+
+// entitySortDefaultOrder maps each supported sortBy to its natural direction,
+// used when the caller does not ask for one.
+var entitySortDefaultOrder = map[string]string{
+	EntitySortByCreatedAt:     SortOrderDesc, // most recently created first
+	EntitySortByElectionCount: SortOrderDesc, // busiest organizations first
+	EntitySortByName:          SortOrderAsc,  // alphabetical
+}
+
+var (
+	// ErrInvalidEntitySortBy is returned when an unsupported entity ordering is requested.
+	ErrInvalidEntitySortBy = fmt.Errorf("invalid entity sortBy")
+	// ErrInvalidSortOrder is returned when an unsupported sort direction is requested.
+	ErrInvalidSortOrder = fmt.Errorf("invalid sort order")
+)
+
+// NormalizeEntitySort validates a sortBy/order pair for EntityList and fills in
+// the defaults for the zero values: EntitySortByCreatedAt for sortBy, and the
+// natural direction of the resulting sortBy for order.
+func NormalizeEntitySort(sortBy, order string) (string, string, error) {
+	if sortBy == "" {
+		sortBy = EntitySortByCreatedAt
+	}
+	defaultOrder, ok := entitySortDefaultOrder[sortBy]
+	if !ok {
+		return "", "", fmt.Errorf("%w: %q", ErrInvalidEntitySortBy, sortBy)
+	}
+	switch order {
+	case "":
+		order = defaultOrder
+	case SortOrderAsc, SortOrderDesc:
+	default:
+		return "", "", fmt.Errorf("%w: %q", ErrInvalidSortOrder, order)
+	}
+	return sortBy, order, nil
+}
+
 // EntityList returns the list of entities indexed by the indexer.
 // entityID and name are optional, if declared as zero-value they are ignored.
 // entityID is searched against the entityID field as lowercase hex, name as a
 // case-insensitive substring of the entity name resolved from its account
 // metadata (ASCII case folding only, see the SearchEntities query).
-func (idx *Indexer) EntityList(limit, offset int, entityID, name string) ([]indexertypes.Entity, uint64, error) {
+//
+// sortBy is one of the EntitySortBy* values and order one of the SortOrder*
+// ones; both are optional and, when zero-valued, default to EntitySortByCreatedAt
+// and to the natural direction of the chosen sortBy, as NormalizeEntitySort does.
+// The ordering is always total, entityID being the last tiebreak, so paging
+// through it neither repeats nor skips entities.
+func (idx *Indexer) EntityList(limit, offset int, entityID, name, sortBy, order string) ([]indexertypes.Entity, uint64, error) {
 	if offset < 0 {
 		return nil, 0, fmt.Errorf("invalid value: offset cannot be %d", offset)
 	}
 	if limit <= 0 {
 		return nil, 0, fmt.Errorf("invalid value: limit cannot be %d", limit)
 	}
+	sortBy, order, err := NormalizeEntitySort(sortBy, order)
+	if err != nil {
+		return nil, 0, err
+	}
 	results, err := idx.readOnlyQuery.SearchEntities(context.TODO(), indexerdb.SearchEntitiesParams{
 		EntityIDSubstr: strings.ToLower(entityID), // we search in lowercase
 		NameSubstr:     name,
+		SortBy:         sortBy,
+		SortOrder:      order,
 		Offset:         int64(offset),
 		Limit:          int64(limit),
 	})
@@ -178,7 +247,7 @@ func (idx *Indexer) EntityExists(entityID string) bool {
 	if len(entityID) != 40 {
 		return false
 	}
-	_, count, err := idx.EntityList(1, 0, entityID, "")
+	_, count, err := idx.EntityList(1, 0, entityID, "", "", "")
 	if err != nil {
 		log.Errorw(err, "indexer query failed")
 	}

--- a/vochain/indexer/queries/processes.sql
+++ b/vochain/indexer/queries/processes.sql
@@ -174,6 +174,26 @@ SELECT COUNT(DISTINCT entity_id) FROM processes;
 -- so a client listing organizations doesn't need one account request per row.
 -- The name filter is a case-insensitive substring match; LOWER only folds ASCII
 -- in sqlite, so names differing by non-ASCII case or by diacritics do not match.
+--
+-- sort_by selects the ordering ('createdAt', 'electionCount' or 'name') and
+-- sort_order its direction ('asc' or 'desc'). Both are expected to be one of
+-- those exact values; the caller validates them. sqlite cannot parameterize an
+-- ORDER BY term and sqlc does not even substitute arguments inside one, so the
+-- sort key is computed as a column of the grouped subquery and the outer ORDER
+-- BY only picks between the ascending and the descending one, exactly one of
+-- which is non-NULL. A term that is NULL on every row compares equal on every
+-- row, so it is a no-op.
+--
+-- 'createdAt' is MIN(creation_time), the creation time of the *first* election
+-- indexed for an organization, i.e. when the organization first appeared in the
+-- index. That is what the previous hardcoded `ORDER BY creation_time DESC, id
+-- ASC` resolved to in practice: creation_time and id were bare columns of a
+-- grouped query, so sqlite took them from an arbitrary row of each group, and
+-- with the scan driven by index_processes_entity_id that row was the group's
+-- first, i.e. its oldest process.
+--
+-- entity_id is always the last tiebreak, so the ordering is total and paging
+-- with LIMIT/OFFSET can neither repeat nor skip a row.
 WITH results AS (
     SELECT p.*,
         COALESCE(a.name, '') AS account_name,
@@ -183,15 +203,35 @@ WITH results AS (
         ON a.account = p.entity_id
     WHERE (sqlc.arg(entity_id_substr) = '' OR (INSTR(LOWER(HEX(p.entity_id)), sqlc.arg(entity_id_substr)) > 0))
     AND (sqlc.arg(name_substr) = '' OR (INSTR(LOWER(COALESCE(a.name, '')), LOWER(sqlc.arg(name_substr))) > 0))
+), grouped AS (
+    SELECT entity_id,
+        account_name,
+        account_avatar,
+        COUNT(id) AS process_count,
+        COUNT(entity_id) OVER() AS total_count,
+        -- organizations whose account resolves no name sort last when sorting
+        -- by name, in either direction
+        CASE WHEN sqlc.arg(sort_by) = 'name' AND account_name = '' THEN 1 END AS sort_name_empty,
+        CASE WHEN sqlc.arg(sort_order) = 'asc' THEN (CASE
+            WHEN sqlc.arg(sort_by) = 'electionCount' THEN COUNT(id)
+            WHEN sqlc.arg(sort_by) = 'name' THEN LOWER(account_name)
+            WHEN sqlc.arg(sort_by) = 'createdAt' THEN MIN(creation_time)
+        END) END AS sort_key_asc,
+        CASE WHEN sqlc.arg(sort_order) = 'desc' THEN (CASE
+            WHEN sqlc.arg(sort_by) = 'electionCount' THEN COUNT(id)
+            WHEN sqlc.arg(sort_by) = 'name' THEN LOWER(account_name)
+            WHEN sqlc.arg(sort_by) = 'createdAt' THEN MIN(creation_time)
+        END) END AS sort_key_desc
+    FROM results
+    GROUP BY entity_id
 )
 SELECT entity_id,
 	account_name,
 	account_avatar,
-	COUNT(id) AS process_count,
-	COUNT(entity_id) OVER() AS total_count
-FROM results
-GROUP BY entity_id
-ORDER BY creation_time DESC, id ASC
+	process_count,
+	total_count
+FROM grouped
+ORDER BY sort_name_empty ASC, sort_key_asc ASC, sort_key_desc DESC, entity_id ASC
 LIMIT sqlc.arg(limit)
 OFFSET sqlc.arg(offset);
 


### PR DESCRIPTION
Claude here, controlled by elboletaire.

`GET /chain/organizations` can now sort server-side, so a client wanting a ranking no longer has to sweep every page and sort locally.

The motivating consumer is vocdoni/explorer-ng#16, which needs a "top organizations by election count" view. Because the API cannot sort, it fetches every page (`limit` is capped at 100, so 275 orgs today = 3 requests), sorts client-side, and declares the ranking partial past a hard cap of 1200 orgs. With this change that becomes a single `?sortBy=electionCount&order=desc&limit=5`.

## API

| param | values | default |
| --- | --- | --- |
| `sortBy` | `createdAt` · `electionCount` · `name` | `createdAt` |
| `order` | `asc` · `desc` | `desc` for `createdAt` and `electionCount`, `asc` for `name` |

- `createdAt` is `MIN(creation_time)`: the creation time of the organization's oldest indexed election, i.e. when the organization first appeared in the index.
- `name` folds ASCII case only, same as the existing `name` filter. Organizations whose account resolves no name always sort last, in either direction.
- Unsupported values are a 400 (`4063` sortBy, `4064` order), not silently ignored.
- Sorting composes with the `organizationId`/`name` filters and with `page`/`limit`. The deprecated `/chain/organizations/page/{page}` and `/chain/organizations/filter/page/{page}` endpoints keep working with the default ordering.

`entity_id` is always the last tiebreak, so the ordering is total and paging a sorted list never repeats nor skips an organization. That property is what the explorer relies on, and it is tested explicitly (page N and N+1 share no row and together are the whole list).

```
### GET /chain/organizations?sortBy=electionCount&order=desc&limit=5 -> 200
{"organizations":[
 {"organizationID":"8822fe…1e78","electionCount":30,"name":"Zeta Collective",…},
 {"organizationID":"5e3e7c…1ec1","electionCount":12,"name":"Beta Coop",…},
 {"organizationID":"a966ad…ccae","electionCount":9,"name":"Eta Assembly",…},
 {"organizationID":"4063db…bdbb","electionCount":7,"name":"Delta Guild",…},
 {"organizationID":"7581f1…7104","electionCount":4,"name":"Alpha DAO",…}],
 "pagination":{"totalItems":7,…}}

### GET /chain/organizations?sortBy=votes -> 400
{"error":"parameter (sortBy) invalid: votes","code":4063}
```

## Implementation notes

**sqlc does not substitute `sqlc.arg()` inside an `ORDER BY`.** The idiomatic `ORDER BY CASE WHEN sqlc.arg(sort_by) = … END` generates SQL with that literal text still in it and no matching struct fields — it fails at runtime, not at compile time. So `SearchEntities` computes the sort key as a column of a grouped subquery, where arguments *are* substituted, and the outer `ORDER BY` only picks between an ascending and a descending key, exactly one of which is non-NULL. A term that is NULL on every row compares equal on every row, so it is a no-op.

`SearchEntitiesRow` is unchanged (the sort keys are not projected), the `total_count` window still counts distinct entities, and the query plan keeps the same shape it had before (`SCAN p USING INDEX index_processes_entity_id` → `USE TEMP B-TREE FOR ORDER BY`).

**The previous default ordering was not what it looked like.** `ORDER BY creation_time DESC, id ASC` read bare columns of a `GROUP BY` query, which sqlite takes from an arbitrary row of each group — I measured it landing on different rows under different plans. Checked against production: across consecutive organizations on `api.vocdoni.io`, each organization's *oldest* election date is strictly descending while its newest is not monotonic, so in practice it ordered by the oldest election. `createdAt` now says that explicitly with `MIN(creation_time)`, which is deterministic instead of plan-dependent, and an A/B of the old query verbatim against the new default on the same indexer database (60 organizations, 44 of them with several elections) returns identical order.

## Verification

- `go generate ./vochain/indexer/...`, generated diff confined to `SearchEntities`
- `go build ./...`, `go vet`, `staticcheck ./api/... ./vochain/indexer/...`, `gofumpt -l .` — all clean
- `go test ./vochain/indexer/... ./api/...` — `ok vochain/indexer 0.826s`, `ok api 0.308s`
- `swag init` with the CI's flags succeeds; both params land in the spec with `enum` lists
- New coverage: `TestEntityListSorting` (every sortBy/order pair, defaults, paging stability, rejected values) and `TestOrganizationListSorting` (the same over HTTP, plus the 400s and the deprecated endpoint)

## Risks

- **Same-block organizations reorder.** When two organizations' first elections share a `creation_time`, the old tiebreak was an arbitrary process id and it is now `entity_id`. That is the determinism fix, but it is an observable reordering for those organizations. Low impact at 275 organizations; more visible on a chain that creates organizations in bulk.
- **Cost is O(all matching processes) regardless of `limit`**, unchanged from before: every ordering materialises all groups through a temp b-tree. `?limit=5` is cheap in bytes, not in work. Fine at today's size; a six-figure index would want a summary table rather than a better `ORDER BY`.
- Not checked: behaviour against a real synced mainnet indexer database, and whether any consumer depends on the old same-block tiebreak.
